### PR TITLE
Loq 4527   fixing display of description and adding highlights

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "gbg-loqate/loqate-integration",
   "description": "Performs address capture and data validation (email, phone number and address) using Loqate API.",
   "type": "magento2-module",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "require": {
     "lqt/api-connector": "*"
   },

--- a/view/base/web/capture.css
+++ b/view/base/web/capture.css
@@ -1,40 +1,52 @@
 .loqate-autocomplete-container {
-    position: relative;
+  position: relative;
 }
 
 .loqate-autocomplete-items {
-    position: absolute;
-    border: 1px solid #d4d4d4;
-    z-index: 99;
-    left: 0;
-    right: 0;
-    margin-top: 2px;
-    max-height: 300px;
-    overflow-y: auto;
+  position: absolute;
+  border: 1px solid #d4d4d4;
+  z-index: 99;
+  left: 0;
+  right: 0;
+  margin-top: 2px;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .loqate-autocomplete-items:empty {
-    border: none;
+  border: none;
 }
 
 .loqate-autocomplete-items div {
-    padding: 10px;
-    cursor: pointer;
-    background-color: #fff;
-    border-bottom: 1px solid #d4d4d4;
+  padding: 10px;
+  cursor: pointer;
+  background-color: #fff;
+  border-bottom: 1px solid #d4d4d4;
 }
 
 .loqate-autocomplete-items div:hover {
-    background-color: #f0f0f0;
+  background-color: #f0f0f0;
 }
 
 .loqate-autocomplete-items div.loqate-error-item.message.error {
-    padding: 10px;
-    cursor: default;
-    margin: 0;
-    pointer-events:none
+  padding: 10px;
+  cursor: default;
+  margin: 0;
+  pointer-events: none;
 }
 
-.message.message-error>div {
-    white-space: pre-line;
+.message.message-error > div {
+  white-space: pre-line;
+}
+
+.loqate-address-item {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+}
+
+@media screen and (min-width: 768px) {
+  .loqate-address-item {
+    grid-template-columns: auto 1fr;
+  }
 }

--- a/view/base/web/capture.js
+++ b/view/base/web/capture.js
@@ -204,17 +204,55 @@ requirejs(["jquery", "mage/url", "domReady"], function ($, urlBuilder) {
     if (Array.isArray(response)) {
       response.forEach(function (item) {
         let addressItem = $(
-          "<div class='loqate-address-item' data-id='" +
-            item.Id +
-            "' data-type='" +
-            item.Type +
-            "'>" +
-            item.Text +
-            (item.Description ? item.Description : "") +
-            "</div>"
+          `<div class='loqate-address-item' data-id='${item.Id}' data-type='${
+            item.Type
+          }'>
+<span>${buildHighlights(item)}</span><span>${
+            item.Description ? item.Description : ""
+          }</span>
+</div>`
         );
         $(addressItem).appendTo($(addressList));
       });
+    }
+  }
+
+  function buildHighlights(findResponseItem, prefix, suffix) {
+    prefix = prefix || "<strong>";
+    suffix = suffix || "</strong>";
+
+    var highlights;
+
+    //initial values are all the same
+    highlightedText =
+      findResponseItem.title =
+      findResponseItem.tag =
+        findResponseItem.Text;
+
+    try {
+      //no highlight indexes
+      if (!findResponseItem.Highlight) return highlightedText;
+
+      highlights = findResponseItem.Highlight.split(",");
+
+      for (var i = highlights.length - 1; i >= 0; i--) {
+        var indexes = highlights[i].split("-");
+        highlightedText =
+          highlightedText.substring(0, parseInt(indexes[0])) +
+          prefix +
+          highlightedText.substring(
+            parseInt(indexes[0]),
+            parseInt(indexes[1])
+          ) +
+          suffix +
+          highlightedText.substring(
+            parseInt(indexes[1]),
+            highlightedText.length
+          );
+      }
+      return highlightedText;
+    } catch (e) {
+      return findResponseItem.Text;
     }
   }
 


### PR DESCRIPTION
- Fixes an issue with the display of find results when typing an address. Previously the title and description would appear together, they are now correctly separated.
- Updates the layout to better support smaller viewports.
- Adds highlighting to the find result title.
