### PR TITLE
LOQ-11376 - Fix Province not updating when element is select

### DIFF
--- a/view/base/web/capture.js
+++ b/view/base/web/capture.js
@@ -7884,6 +7884,13 @@ requirejs(["jquery", "mage/url", "domReady"], function ($, urlBuilder) {
   function dispatchChange(element) {
     const event = new Event("change", { bubbles: true, cancelable: true });
     element.dispatchEvent(event);
+
+    if (window.jQuery && typeof window.jQuery === "function") {
+      const $el = window.jQuery(element);
+      if ($el.valid) {
+        $el.valid();
+      }
+    }
   }
 
   function mapRegionSelectValue(selectElement, details) {
@@ -7919,15 +7926,10 @@ requirejs(["jquery", "mage/url", "domReady"], function ($, urlBuilder) {
         for (let valueIndex = 0; valueIndex < optionValues.length; valueIndex++) {
           const optionValue = normalizeRegionValue(optionValues[valueIndex]);
           if (optionValue && optionValue === candidate) {
-            const valueChanged = selectElement.value !== option.value;
             selectElement.value = option.value;
             selectElement.selectedIndex = optionIndex;
             selectElement.setAttribute("value", option.value);
             dispatchChange(selectElement);
-            if (!valueChanged) {
-              // force validation to re-check even if the underlying value matched
-              dispatchChange(selectElement);
-            }
             return true;
           }
         }
@@ -7941,7 +7943,7 @@ requirejs(["jquery", "mage/url", "domReady"], function ($, urlBuilder) {
     selectElement,
     details,
     attempt = 0,
-    maxAttempts = 5
+    maxAttempts = 4
   ) {
     if (mapRegionSelectValue(selectElement, details)) {
       return;
@@ -7951,7 +7953,7 @@ requirejs(["jquery", "mage/url", "domReady"], function ($, urlBuilder) {
       return;
     }
 
-    const delay = 150 * Math.pow(2, attempt);
+    const delay = 75 * Math.pow(2, attempt);
     window.setTimeout(function () {
       mapRegionSelectValueWithRetry(selectElement, details, attempt + 1, maxAttempts);
     }, delay);

--- a/view/base/web/capture.js
+++ b/view/base/web/capture.js
@@ -7951,7 +7951,7 @@ requirejs(["jquery", "mage/url", "domReady"], function ($, urlBuilder) {
       return;
     }
 
-    const delay = 150 * Math.pow(2, attempt);
+    const delay = 75 * Math.pow(2, attempt);
     window.setTimeout(function () {
       mapRegionSelectValueWithRetry(selectElement, details, attempt + 1, maxAttempts);
     }, delay);


### PR DESCRIPTION
Fix for region select population for retrieved addresses

- Added logic to detect when the mapped ProvinceName field is a <select> and match province data against the select’s options.

- When a match is found, the correct option is selected via value and selectedIndex, and a bubbling change event is dispatched to re-trigger Magento’s client-side validation.

- Added mapRegionSelectValueWithRetry to retry mapping the region value a few times with backoff, covering the case where Magento repopulates the region dropdown after the country changes and overwrites the initial selection.

- Hooked this retry logic into the Loqate populate event for any mapped ProvinceName select fields.