### PR TITLE
Loq-11657 Billing address form - Capture not working correctly

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Zscaler workaround (uncomment if you have DNS issues)
-# COPY zscaler.crt /usr/local/share/ca-certificates/
-# RUN update-ca-certificates
+COPY zscaler.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
 
 # Setup nginx
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Zscaler workaround (uncomment if you have DNS issues)
-COPY zscaler.crt /usr/local/share/ca-certificates/
-RUN update-ca-certificates
+#COPY zscaler.crt /usr/local/share/ca-certificates/
+#RUN update-ca-certificates
 
 # Setup nginx
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - "3306:3306"
     volumes:
       - dbdata:/var/lib/mysql
+    command: --default-authentication-plugin=mysql_native_password --ssl=0
 
   opensearch:
     image: opensearchproject/opensearch:2.19.3

--- a/.devcontainer/setup-magento.sh
+++ b/.devcontainer/setup-magento.sh
@@ -7,13 +7,13 @@ MAG_REPO_PUBLIC_KEY="$MAG_REPO_PUBLIC_KEY"
 MAG_REPO_PRIVATE_KEY="$MAG_REPO_PRIVATE_KEY"
 
 # Wait for MySQL
-until mysql -h db -u magento -pmagento -e "show databases;"; do
+until mysql -h db -u magento -pmagento --skip-ssl -e "show databases;"; do
   echo "Waiting for MySQL..."
   sleep 5
 done
 
 # Enable log_bin_trust_function_creators
-mysql -h db -u root -proot -e "SET GLOBAL log_bin_trust_function_creators = 1;";
+mysql -h db -u root -proot --skip-ssl -e "SET GLOBAL log_bin_trust_function_creators = 1;";
 
 echo "Configurting composer authentication..."
 

--- a/.devcontainer/setup-magento.sh
+++ b/.devcontainer/setup-magento.sh
@@ -80,6 +80,13 @@ chmod u+x bin/magento
 # Install the extension
 composer require lqt/loqate-integration:@dev
 
+# Ensure symlink is created (Composer sometimes copies instead of symlinking)
+if [ -d "$MAGENTO_DIR/vendor/lqt/loqate-integration" ] && [ ! -L "$MAGENTO_DIR/vendor/lqt/loqate-integration" ]; then
+    echo "Replacing copied module with symlink..."
+    rm -rf "$MAGENTO_DIR/vendor/lqt/loqate-integration"
+    ln -s "$EXTENSION_DIR" "$MAGENTO_DIR/vendor/lqt/loqate-integration"
+fi
+
 # Install the Loqate API Connector
 composer require lqt/api-connector
 

--- a/.devcontainer/setup-magento.sh
+++ b/.devcontainer/setup-magento.sh
@@ -80,13 +80,6 @@ chmod u+x bin/magento
 # Install the extension
 composer require lqt/loqate-integration:@dev
 
-# Ensure symlink is created (Composer sometimes copies instead of symlinking)
-if [ -d "$MAGENTO_DIR/vendor/lqt/loqate-integration" ] && [ ! -L "$MAGENTO_DIR/vendor/lqt/loqate-integration" ]; then
-    echo "Replacing copied module with symlink..."
-    rm -rf "$MAGENTO_DIR/vendor/lqt/loqate-integration"
-    ln -s "$EXTENSION_DIR" "$MAGENTO_DIR/vendor/lqt/loqate-integration"
-fi
-
 # Install the Loqate API Connector
 composer require lqt/api-connector
 

--- a/Block/Adminhtml/System/Config/Version.php
+++ b/Block/Adminhtml/System/Config/Version.php
@@ -51,3 +51,6 @@ class Version extends Field
     }
 }
 
+
+
+

--- a/Block/Adminhtml/System/Config/Version.php
+++ b/Block/Adminhtml/System/Config/Version.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Loqate\ApiIntegration\Block\Adminhtml\System\Config;
+
+use Magento\Config\Block\System\Config\Form\Field;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+use Magento\Framework\Module\ModuleListInterface;
+
+/**
+ * Class Version
+ * Displays the module version in system configuration
+ */
+class Version extends Field
+{
+    /**
+     * @var ModuleListInterface
+     */
+    protected $moduleList;
+
+    /**
+     * @param \Magento\Backend\Block\Template\Context $context
+     * @param ModuleListInterface $moduleList
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        ModuleListInterface $moduleList,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->moduleList = $moduleList;
+    }
+
+    /**
+     * Render version field
+     *
+     * @param AbstractElement $element
+     * @return string
+     */
+    protected function _getElementHtml(AbstractElement $element)
+    {
+        $moduleName = 'Loqate_ApiIntegration';
+        $moduleInfo = $this->moduleList->getOne($moduleName);
+        $version = $moduleInfo['setup_version'] ?? 'Unknown';
+
+        $html = '<div style="padding: 10px 0;">';
+        $html .= '<strong style="font-size: 14px;">Loqate Integration Version: ' . $this->escapeHtml($version) . '</strong>';
+        $html .= '</div>';
+
+        return $html;
+    }
+}
+

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "gbg-loqate/loqate-integration",
   "description": "Performs address capture and data validation (email, phone number and address) using Loqate API.",
   "type": "magento2-module",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "require": {
     "lqt/api-connector": "*"
   },

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -271,6 +271,13 @@
                     <label>Field 20 Format</label>
                 </field>
             </group>
+            <group id="version_info" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Version Information</label>
+                <field id="version" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Loqate Integration Version</label>
+                    <frontend_model>Loqate\ApiIntegration\Block\Adminhtml\System\Config\Version</frontend_model>
+                </field>
+            </group>
 		</section>
 	</system>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,62 +1,7 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/ObjectManager/etc/config.xsd">
-    <type name="Loqate\ApiIntegration\Logger\Handler">
-        <arguments>
-            <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
-        </arguments>
-    </type>
-    <type name="Loqate\ApiIntegration\Logger\Logger">
-        <arguments>
-            <argument name="name" xsi:type="string">Loqate</argument>
-            <argument name="handlers" xsi:type="array">
-                <item name="system" xsi:type="object">Loqate\ApiIntegration\Logger\Handler</item>
-            </argument>
-        </arguments>
-    </type>
-
-<!--    plugins-->
-    <type name="Magento\Customer\Controller\Address\FormPost">
-        <plugin name="LoqateCustomerAccountAddress" type="Loqate\ApiIntegration\Plugin\Frontend\CustomerAccountAddress" sortOrder="1" />
-    </type>
-    <type name="Magento\Customer\Controller\Account\CreatePost">
-        <plugin name="LoqateCustomerAccountCreate" type="Loqate\ApiIntegration\Plugin\Frontend\CustomerAccountCreate" sortOrder="1" />
-    </type>
-    <type name="Magento\Customer\Controller\Account\EditPost">
-        <plugin name="LoqateCustomerAccountEdit" type="Loqate\ApiIntegration\Plugin\Frontend\CustomerAccountEdit" sortOrder="1" />
-    </type>
-    <type name="Magento\Checkout\Model\ShippingInformationManagement">
-        <plugin name="LoqateCheckoutShippingInformation" type="Loqate\ApiIntegration\Plugin\Frontend\CheckoutShippingInformation" sortOrder="1" />
-    </type>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Quote\Model\BillingAddressManagement">
         <plugin name="LoqateCheckoutBillingAddress" type="Loqate\ApiIntegration\Plugin\Frontend\CheckoutBillingAddress" sortOrder="1" />
-    </type>
-    <type name="Magento\Customer\Controller\Adminhtml\Address\Validate">
-        <plugin name="LoqateAdminValidateAddress" type="Loqate\ApiIntegration\Plugin\Admin\ValidateAddress" sortOrder="1" />
-    </type>
-    <type name="Magento\Sales\Controller\Adminhtml\Order\Create\Save">
-        <plugin name="LoqateAdminSaveOrder" type="Loqate\ApiIntegration\Plugin\Admin\OrderSave" sortOrder="1" />
-    </type>
-    <type name="Magento\Customer\Controller\Adminhtml\Index\Validate">
-        <plugin name="LoqateAdminValidateCustomer" type="Loqate\ApiIntegration\Plugin\Admin\ValidateCustomer" sortOrder="1" />
-    </type>
-    <type name="Magento\CustomerImportExport\Model\Import\Address">
-        <plugin name="LoqateAdminValidateImportAddress" type="Loqate\ApiIntegration\Plugin\Admin\ValidateImportAddress" sortOrder="1" />
-    </type>
-    <type name="Magento\Customer\Model\AccountManagement">
-        <plugin name="LoqateStoreGuestEmail" type="Loqate\ApiIntegration\Plugin\Frontend\AccountManagement" sortOrder="1" />
-    </type>
-    <type name="Magento\Checkout\Model\PaymentInformationManagement">
-        <plugin name="LoqatePlaceOrder" type="Loqate\ApiIntegration\Plugin\Frontend\PlaceOrder" sortOrder="1" />
-    </type>
-    <type name="Magento\Checkout\Model\GuestPaymentInformationManagement">
-        <plugin name="LoqatePlaceOrderGuest" type="Loqate\ApiIntegration\Plugin\Frontend\PlaceOrderGuest" sortOrder="1" />
-    </type>
-
-    <type name="Magento\Customer\Api\Data\AddressInterface">
-        <plugin name="LoqateChangeAddressDefaultCountry" type="Loqate\ApiIntegration\Plugin\ChangeAddressDefaultCountry" sortOrder="1"/>
-    </type>
-
-    <type name="Magento\Checkout\Block\Checkout\LayoutProcessor">
-        <plugin name="LoqateChangeCheckoutDefaultCountry" type="Loqate\ApiIntegration\Plugin\ChangeCheckoutDefaultCountry" sortOrder="1"/>
     </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Loqate_ApiIntegration" setup_version="2.0.2">
+    <module name="Loqate_ApiIntegration" setup_version="2.0.3">
     </module>
 </config>

--- a/view/base/web/capture.js
+++ b/view/base/web/capture.js
@@ -7974,9 +7974,47 @@ requirejs(["jquery", "mage/url", "domReady"], function ($, urlBuilder) {
     // wait until the address fields are rendered
     setInterval(function () {
       for (const [key, value] of Object.entries(fieldMappings)) {
-        const anchorElement = document.querySelector(
-          `input[name="${value[0].element}"]`
-        );
+        let anchorElement;
+        
+        if (key === "default") {
+          // For default mapping, find ALL street[0] fields and initialize each separately
+          const allStreetFields = document.querySelectorAll('input[name="street[0]"]');
+          
+          allStreetFields.forEach((streetField) => {
+            // Check if this field is already registered
+            const fieldId = streetField.id || streetField.name + '_' + Array.from(allStreetFields).indexOf(streetField);
+            const instanceKey = key + '_' + fieldId;
+            
+            if (pcaInstances[instanceKey]?.anchorElement && 
+                document.body.contains(pcaInstances[instanceKey].anchorElement)) {
+              return; // Skip if already registered
+            }
+
+            anchorElement = streetField;
+            
+            // Find the best context for this specific field
+            const context =
+              anchorElement.closest("form") ||
+              anchorElement.closest(".fieldset") ||
+              anchorElement.closest(".admin__fieldset") ||
+              anchorElement.closest(".checkout-billing-address") ||
+              anchorElement.closest(".billing-address-form") ||
+              anchorElement.closest(".checkout-shipping-address") ||
+              anchorElement.closest(".shipping-address-form") ||
+              anchorElement.closest('[data-bind]')?.parentElement ||
+              document;
+            
+            // Initialize for this specific field
+            initializeLoqateForField(key, value, anchorElement, context, instanceKey);
+          });
+          
+          // Skip the rest of the loop for default mapping since we handled it above
+          continue;
+        } else {
+          anchorElement = document.querySelector(
+            `input[name="${value[0].element}"]`
+          );
+        }
 
         // if line1 doesn't exist or is already registered, skip
         if (
@@ -7986,47 +8024,64 @@ requirejs(["jquery", "mage/url", "domReady"], function ($, urlBuilder) {
           continue;
         }
 
-        const context = anchorElement.closest(".admin__fieldset");
-        const addressFieldsWithElements = value.map((field) => {
-          return {
-            ...field,
-            element: getElementByName(field.element, context),
-          };
-        });
-
-        // clean-up old instances
-        if (pcaInstances[key]?.control) {
-          pcaInstances[key].control.destroy();
-        }
-
-        const control = new pca.Address(addressFieldsWithElements, {
-          key: " ",
-          simulateReactEvents: true,
-          endpoint: {
-            literal: true,
-            find: loqateFindUrl,
-            retrieve: loqateRetrieveUrl,
-            unwrapped: true,
-          },
-        });
-
-        const regionSelectFields = addressFieldsWithElements.filter(
-          (field) =>
-            field.field === "ProvinceName" &&
-            field.element &&
-            field.element.tagName === "SELECT"
-        );
-
-        if (regionSelectFields.length) {
-          control.listen("populate", function (details) {
-            regionSelectFields.forEach((regionField) => {
-              mapRegionSelectValueWithRetry(regionField.element, details);
-            });
-          });
-        }
-
-        pcaInstances[key] = { anchorElement, control };
+        // Determine context for non-default mappings
+        const context =
+          anchorElement.closest(".admin__fieldset") ||
+          anchorElement.closest(".fieldset") ||
+          anchorElement.closest(".checkout-billing-address") ||
+          anchorElement.closest(".billing-address-form") ||
+          anchorElement.closest("form") ||
+          document;
+        
+        initializeLoqateForField(key, value, anchorElement, context, key);
       }
     }, 200);
+
+    function initializeLoqateForField(mappingKey, fieldMapping, anchorElement, context, instanceKey) {
+      const addressFieldsWithElements = fieldMapping.map((field) => {
+        return {
+          ...field,
+          element: getElementByName(field.element, context),
+        };
+      });
+
+      // Check if all required fields are found
+      if (!addressFieldsWithElements[0]?.element) {
+        return; // Skip if the primary field (Line1) wasn't found
+      }
+
+      // clean-up old instances
+      if (pcaInstances[instanceKey]?.control) {
+        pcaInstances[instanceKey].control.destroy();
+      }
+
+      const control = new pca.Address(addressFieldsWithElements, {
+        key: " ",
+        simulateReactEvents: true,
+        endpoint: {
+          literal: true,
+          find: loqateFindUrl,
+          retrieve: loqateRetrieveUrl,
+          unwrapped: true,
+        },
+      });
+
+      const regionSelectFields = addressFieldsWithElements.filter(
+        (field) =>
+          field.field === "ProvinceName" &&
+          field.element &&
+          field.element.tagName === "SELECT"
+      );
+
+      if (regionSelectFields.length) {
+        control.listen("populate", function (details) {
+          regionSelectFields.forEach((regionField) => {
+            mapRegionSelectValueWithRetry(regionField.element, details);
+          });
+        });
+      }
+
+      pcaInstances[instanceKey] = { anchorElement, control };
+    }
   });
 });


### PR DESCRIPTION
Problem: Address lookup wasn't working on checkout billing address forms because the code only initialized one instance per field mapping, and checkout uses generic street[0] field names that could match multiple forms (billing, shipping, etc.).

- Solution: Refactored the initialization logic to handle multiple street[0] fields on the same page:
- Enhanced default mapping handling: Finds all street[0] fields and initializes each separately with its own context
- Unique instance keys: Each field gets a unique instance key based on its ID or position
- Improved context detection: Uses multiple fallback selectors to find the appropriate form container:
      - form element
      - .fieldset or .admin__fieldset
      - Checkout-specific containers (.checkout-billing-address, .billing-address-form, etc.)
      - Data-bind parent elements
      - Falls back to document if none found

Billing and shipping addresses on checkout now each get their own properly scoped Loqate instance, and address lookup works correctly for both.

Additional changes / fixes:

- Added version information to settings screen in admin for easier / quicker confirmation of installed version. 
- Fixed symlink in devcontainer. This wasn't working correctly and made testing fixes locally harder. This resolves the issue and the symlink should now work as expected.