### PR TITLE
fix: updated return ad added code on block

### DIFF
--- a/Plugin/Frontend/CheckoutBillingAddress.php
+++ b/Plugin/Frontend/CheckoutBillingAddress.php
@@ -24,7 +24,7 @@ class CheckoutBillingAddress extends AbstractPlugin
         $useForShipping = false
     ) {
         if (empty($this->helper->getConfigValue('loqate_settings/settings/api_key'))) {
-            $proceed($cartId, $address, $useForShipping);
+            return $proceed($cartId, $address, $useForShipping);
         }
 
         if ($billingAddress = $address->getData()) {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Loqate\ApiIntegration\Logger\Logger">
+        <arguments>
+            <argument name="name" xsi:type="string">loqate</argument>
+            <argument name="handlers" xsi:type="array">
+                <item name="system" xsi:type="object">Loqate\ApiIntegration\Logger\Handler</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Quote\Model\BillingAddressManagement">
         <plugin name="LoqateCheckoutBillingAddress" type="Loqate\ApiIntegration\Plugin\Frontend\CheckoutBillingAddress" sortOrder="1" />
     </type>


### PR DESCRIPTION
[Jira](https://gbg.atlassian.net/browse/LOQ-13038)

Fixed:

`CheckoutBillingAddress.php`:

`$proceed(...)` was called without `return` when the API key is empty. This meant execution fell through to the rest of the method and called `$proceed` a second time at the bottom. In Magento 2.4.6-p13, calling `assign()` twice on `BillingAddressManagement` causes it to fail with "Unable to save billing address". The fix is simply `return $proceed(...)`.

`di.xml`:

`Loqate\ApiIntegration\Logger\Logger` extends` \Monolog\Logge`r, whose constructor requires a `string $name` argument (mandatory in Monolog 3.x). Magento's object manager had no configuration telling it what value to pass, resulting in "Missing required argument $name of Loqate\ApiIntegration\Logger\Logger" at runtime. The fix adds a <type> block in `di.xml` that provides `name = "loqate"` and wires the `Handler` into the handlers array, the standard pattern for custom Magento loggers.