### PR TITLE
fix(LOQ-13123): Reverted di.xml changes and tweaks to Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,8 +21,6 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     lsb-release \
     default-mysql-client \
-    nodejs \
-    npm \
     ca-certificates \
     nginx \
     jq \
@@ -45,7 +43,6 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 # Install Node.js (LTS) and npm
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g npm@latest && \
     npm install -g grunt-cli && \
     npm install -g yarn
 

--- a/README.md
+++ b/README.md
@@ -66,3 +66,30 @@ This repository includes a [devcontainer](.devcontainer/) for rapid Magento 2 ex
 
 - `php -r '$e=include "app/etc/env.php"; $d=$e["db"]["connection"]["default"]; printf("mysql -h%s -u%s -p%s %s\n",$d["host"],$d["username"],$d["password"],$d["dbname"]);'` Will extract the command to access mysql within the devcontainer, currently that command is `mysql -hdb -umagento -pmagento magento`
 - `bin/magento config:show` will list all of the config currently set in the instance, this can be set with `bin/magento config:set <PATH> <VALUE>`
+
+
+## Deployment
+
+Releasing a new version requires two separate deployments: one to the **Adobe Marketplace** and one via **Composer**. Before proceeding with either, update the version number in both [`composer.json`](composer.json) and [`etc/module.xml`](etc/module.xml) to reflect the new release, then commit and push the change.
+
+### Adobe Marketplace
+
+1. Create a zip archive of the module directory. Ensure that `.devcontainer/devcontainer.env` is excluded, as it contains sensitive credentials. The following command will produce a clean archive:
+   ```bash
+   zip -r loqate-integration.zip . -x "*.git*" -x ".devcontainer/devcontainer.env" -x ".devcontainer/zscaler.crt"
+   ```
+2. Log in to your Adobe account at [account.magento.com](https://account.magento.com/customer/account/login).
+3. Navigate to the [extension versions page](https://commercedeveloper.adobe.com/extensions/versions/gbg-loqate-loqate-integration) on the Adobe Commerce Developer Portal.
+4. Upload the zip archive.
+5. Adobe will automatically process and scan the submission. This can take up to **3 days**.
+   - If the scan **fails**, review the provided feedback, address the reported issues, and resubmit.
+   - If the scan **passes**, the extension will be published to the marketplace within the hour.
+
+### Composer
+
+1. Create a new Git tag in GitHub matching the release version number (e.g. `2.0.4`) and push it:
+   ```bash
+   git tag 2.0.4
+   git push origin 2.0.4
+   ```
+2. Composer will automatically detect the new tag and make the release available.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "gbg-loqate/loqate-integration",
   "description": "Performs address capture and data validation (email, phone number and address) using Loqate API.",
   "type": "magento2-module",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "require": {
     "lqt/api-connector": "*"
   },

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -53,10 +53,10 @@
     </type>
 
     <type name="Magento\Customer\Api\Data\AddressInterface">
-        <plugin name="LoqateChangeAddressDefaultCountry" type="Loqate\ApiIntegration\Plugin\ChangeAddressDefaultCountry" sortOrder="1"/>
+        <plugin name="LoqateChangeAddressDefaultCountry" type="Loqate\ApiIntegration\Plugin\ChangeAddressDefaultCountry" sortOrder="1" />
     </type>
 
     <type name="Magento\Checkout\Block\Checkout\LayoutProcessor">
-        <plugin name="LoqateChangeCheckoutDefaultCountry" type="Loqate\ApiIntegration\Plugin\ChangeCheckoutDefaultCountry" sortOrder="1"/>
+        <plugin name="LoqateChangeCheckoutDefaultCountry" type="Loqate\ApiIntegration\Plugin\ChangeCheckoutDefaultCountry" sortOrder="1" />
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,7 +1,62 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Loqate\ApiIntegration\Logger\Handler">
+        <arguments>
+            <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+        </arguments>
+    </type>
+    <type name="Loqate\ApiIntegration\Logger\Logger">
+        <arguments>
+            <argument name="name" xsi:type="string">Loqate</argument>
+            <argument name="handlers" xsi:type="array">
+                <item name="system" xsi:type="object">Loqate\ApiIntegration\Logger\Handler</item>
+            </argument>
+        </arguments>
+    </type>
+
+<!--    plugins-->
+    <type name="Magento\Customer\Controller\Address\FormPost">
+        <plugin name="LoqateCustomerAccountAddress" type="Loqate\ApiIntegration\Plugin\Frontend\CustomerAccountAddress" sortOrder="1" />
+    </type>
+    <type name="Magento\Customer\Controller\Account\CreatePost">
+        <plugin name="LoqateCustomerAccountCreate" type="Loqate\ApiIntegration\Plugin\Frontend\CustomerAccountCreate" sortOrder="1" />
+    </type>
+    <type name="Magento\Customer\Controller\Account\EditPost">
+        <plugin name="LoqateCustomerAccountEdit" type="Loqate\ApiIntegration\Plugin\Frontend\CustomerAccountEdit" sortOrder="1" />
+    </type>
+    <type name="Magento\Checkout\Model\ShippingInformationManagement">
+        <plugin name="LoqateCheckoutShippingInformation" type="Loqate\ApiIntegration\Plugin\Frontend\CheckoutShippingInformation" sortOrder="1" />
+    </type>
     <type name="Magento\Quote\Model\BillingAddressManagement">
         <plugin name="LoqateCheckoutBillingAddress" type="Loqate\ApiIntegration\Plugin\Frontend\CheckoutBillingAddress" sortOrder="1" />
+    </type>
+    <type name="Magento\Customer\Controller\Adminhtml\Address\Validate">
+        <plugin name="LoqateAdminValidateAddress" type="Loqate\ApiIntegration\Plugin\Admin\ValidateAddress" sortOrder="1" />
+    </type>
+    <type name="Magento\Sales\Controller\Adminhtml\Order\Create\Save">
+        <plugin name="LoqateAdminSaveOrder" type="Loqate\ApiIntegration\Plugin\Admin\OrderSave" sortOrder="1" />
+    </type>
+    <type name="Magento\Customer\Controller\Adminhtml\Index\Validate">
+        <plugin name="LoqateAdminValidateCustomer" type="Loqate\ApiIntegration\Plugin\Admin\ValidateCustomer" sortOrder="1" />
+    </type>
+    <type name="Magento\CustomerImportExport\Model\Import\Address">
+        <plugin name="LoqateAdminValidateImportAddress" type="Loqate\ApiIntegration\Plugin\Admin\ValidateImportAddress" sortOrder="1" />
+    </type>
+    <type name="Magento\Customer\Model\AccountManagement">
+        <plugin name="LoqateStoreGuestEmail" type="Loqate\ApiIntegration\Plugin\Frontend\AccountManagement" sortOrder="1" />
+    </type>
+    <type name="Magento\Checkout\Model\PaymentInformationManagement">
+        <plugin name="LoqatePlaceOrder" type="Loqate\ApiIntegration\Plugin\Frontend\PlaceOrder" sortOrder="1" />
+    </type>
+    <type name="Magento\Checkout\Model\GuestPaymentInformationManagement">
+        <plugin name="LoqatePlaceOrderGuest" type="Loqate\ApiIntegration\Plugin\Frontend\PlaceOrderGuest" sortOrder="1" />
+    </type>
+
+    <type name="Magento\Customer\Api\Data\AddressInterface">
+        <plugin name="LoqateChangeAddressDefaultCountry" type="Loqate\ApiIntegration\Plugin\ChangeAddressDefaultCountry" sortOrder="1"/>
+    </type>
+
+    <type name="Magento\Checkout\Block\Checkout\LayoutProcessor">
+        <plugin name="LoqateChangeCheckoutDefaultCountry" type="Loqate\ApiIntegration\Plugin\ChangeCheckoutDefaultCountry" sortOrder="1"/>
     </type>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -14,7 +14,7 @@
         </arguments>
     </type>
 
-<!--    plugins-->
+    <!-- plugins -->
     <type name="Magento\Customer\Controller\Address\FormPost">
         <plugin name="LoqateCustomerAccountAddress" type="Loqate\ApiIntegration\Plugin\Frontend\CustomerAccountAddress" sortOrder="1" />
     </type>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Loqate_ApiIntegration" setup_version="2.0.3">
+    <module name="Loqate_ApiIntegration" setup_version="2.0.4">
     </module>
 </config>


### PR DESCRIPTION
## Changes
- Reverted di.xml changes
- Tweaks to the Dockerfile to fix build issues
    - This may have just been a me thing but the installs of these were failing and seem unecessary as we're already installing node after the fact. The node install we do also comes with a version of npm that is sufficient. Happy to remove this change though.

## Testing
Tested this locally, built fine and Capture is now showing on checkout again.

<img width="836" height="1038" alt="image" src="https://github.com/user-attachments/assets/924a32c8-bc89-4659-be03-0067b85fa174" />
