### PR TITLE
test: add unit tests for config sources, AbstractPlugin and country plugins

### DIFF
--- a/Test/Unit/Model/Config/Source/SourceModelsTest.php
+++ b/Test/Unit/Model/Config/Source/SourceModelsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loqate\ApiIntegration\Test\Unit\Model\Config\Source;
+
+use Loqate\ApiIntegration\Model\Config\Source\AVCContextIdentificationMatchLevel;
+use Loqate\ApiIntegration\Model\Config\Source\AVCLexiconIdentificationMatchLevel;
+use Loqate\ApiIntegration\Model\Config\Source\AVCParsingStatus;
+use Loqate\ApiIntegration\Model\Config\Source\AVCPostcodeStatus;
+use Loqate\ApiIntegration\Model\Config\Source\AVCPostProcessedMatchLevel;
+use Loqate\ApiIntegration\Model\Config\Source\AVCPreProcessedMatchLevel;
+use Loqate\ApiIntegration\Model\Config\Source\AVCVerificationStatus;
+use Loqate\ApiIntegration\Model\Config\Source\AddressQualityIndex;
+use Magento\Framework\Data\OptionSourceInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the admin config option-source models.
+ *
+ * These back the AVC threshold dropdowns in Stores > Configuration > Loqate,
+ * so the exact option values must stay aligned with what Helper\Validator and
+ * Helper\AVC expect to compare against.
+ */
+class SourceModelsTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: OptionSourceInterface, 1: list<string>}>
+     */
+    public static function optionValuesProvider(): array
+    {
+        return [
+            'verification status' => [new AVCVerificationStatus(), ['V', 'P', 'A', 'R', 'U']],
+            'parsing status'      => [new AVCParsingStatus(), ['I', 'U']],
+            'address quality'     => [new AddressQualityIndex(), ['A', 'B', 'C', 'D', 'E']],
+            'postcode status'     => [new AVCPostcodeStatus(), ['P8', 'P7', 'P6', 'P5', 'P4', 'P3', 'P2', 'P1', 'P0']],
+            'post-processed'      => [new AVCPostProcessedMatchLevel(), ['5', '4', '3', '2', '1', '0']],
+            'pre-processed'       => [new AVCPreProcessedMatchLevel(), ['5', '4', '3', '2', '1', '0']],
+            'lexicon level'       => [new AVCLexiconIdentificationMatchLevel(), ['5', '4', '3', '2', '1', '0']],
+            'context level'       => [new AVCContextIdentificationMatchLevel(), ['5', '4', '3', '2', '1', '0']],
+        ];
+    }
+
+    /**
+     * @param list<string> $expectedValues
+     */
+    #[DataProvider('optionValuesProvider')]
+    public function testToOptionArrayExposesExpectedValuesInOrder(
+        OptionSourceInterface $source,
+        array $expectedValues
+    ): void {
+        $options = $source->toOptionArray();
+
+        $actualValues = array_map(
+            static fn ($option) => (string)$option['value'],
+            $options
+        );
+
+        $this->assertSame($expectedValues, $actualValues);
+    }
+
+    /**
+     * @param list<string> $expectedValues
+     */
+    #[DataProvider('optionValuesProvider')]
+    public function testToOptionArrayEntriesAreWellFormed(
+        OptionSourceInterface $source,
+        array $expectedValues
+    ): void {
+        $options = $source->toOptionArray();
+
+        $this->assertCount(count($expectedValues), $options);
+
+        foreach ($options as $option) {
+            $this->assertArrayHasKey('value', $option);
+            $this->assertArrayHasKey('label', $option);
+            $this->assertNotSame('', (string)$option['label'], 'Every option must have a non-empty label.');
+        }
+    }
+
+    /**
+     * @param list<string> $expectedValues
+     */
+    #[DataProvider('optionValuesProvider')]
+    public function testToArrayIsKeyedByValue(
+        OptionSourceInterface $source,
+        array $expectedValues
+    ): void {
+        if (!method_exists($source, 'toArray')) {
+            $this->markTestSkipped('Source does not expose toArray().');
+        }
+
+        $keys = array_map(
+            static fn ($entry) => (string)array_key_first($entry),
+            $source->toArray()
+        );
+
+        $this->assertSame($expectedValues, $keys);
+    }
+}

--- a/Test/Unit/Plugin/AbstractPluginTest.php
+++ b/Test/Unit/Plugin/AbstractPluginTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loqate\ApiIntegration\Test\Unit\Plugin;
+
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Plugin\AbstractPlugin;
+use Magento\Customer\Model\Session;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\UrlInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Concrete subclass exposing AbstractPlugin's protected helpers for testing.
+ */
+class ConcreteAbstractPlugin extends AbstractPlugin
+{
+    public function callShouldVerify($field, $value): bool
+    {
+        return $this->shouldVerify($field, $value);
+    }
+
+    public function callValidateEmail($email)
+    {
+        return $this->validateEmail($email);
+    }
+
+    public function callValidatePhone($phone, $country = null)
+    {
+        return $this->validatePhone($phone, $country);
+    }
+}
+
+/**
+ * Tests for the shared validation logic in AbstractPlugin, which every frontend
+ * and admin validation plugin extends.
+ */
+class AbstractPluginTest extends TestCase
+{
+    /** @var Validator&MockObject */
+    private $validator;
+
+    /** @var Data&MockObject */
+    private $helper;
+
+    /** @var Session */
+    private $session;
+
+    /** @var ConcreteAbstractPlugin */
+    private $plugin;
+
+    protected function setUp(): void
+    {
+        $this->validator = $this->createMock(Validator::class);
+        $this->helper = $this->createMock(Data::class);
+
+        // Stateful in-memory session double so the de-dupe logic can be exercised.
+        $this->session = new class extends Session {
+            /** @var array<string, mixed> */
+            private array $store = [];
+
+            public function getData($key = '', $clear = false)
+            {
+                return $this->store[$key] ?? null;
+            }
+
+            public function setData($key, $value = null)
+            {
+                $this->store[$key] = $value;
+                return $this;
+            }
+        };
+
+        $this->plugin = new ConcreteAbstractPlugin(
+            $this->createMock(Context::class),
+            $this->createMock(UrlInterface::class),
+            $this->session,
+            $this->validator,
+            $this->helper,
+            $this->createMock(JsonFactory::class)
+        );
+    }
+
+    public function testShouldVerifyTracksValuesPerField(): void
+    {
+        $this->assertTrue($this->plugin->callShouldVerify('loqate_email', 'a@b.com'), 'first time must verify');
+        $this->assertFalse($this->plugin->callShouldVerify('loqate_email', 'a@b.com'), 'repeat must skip');
+        $this->assertTrue($this->plugin->callShouldVerify('loqate_email', 'c@d.com'), 'new value must verify');
+        $this->assertTrue($this->plugin->callShouldVerify('loqate_phone', 'a@b.com'), 'different field is independent');
+    }
+
+    public function testValidateEmailSkipsRepeatSubmissionWhenSubmitNotPrevented(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(false); // prevent_submit off
+        $this->validator->expects($this->once())
+            ->method('verifyEmail')
+            ->willReturn(['valid' => true]);
+
+        $this->assertFalse($this->plugin->callValidateEmail('a@b.com'));
+        // Second submission of the same email must not hit the API again.
+        $this->assertFalse($this->plugin->callValidateEmail('a@b.com'));
+    }
+
+    public function testValidateEmailReturnsUnexpectedErrorPhraseOnVerifyError(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(false);
+        $this->validator->method('verifyEmail')->willReturn(['error' => true, 'message' => 'boom']);
+
+        $result = $this->plugin->callValidateEmail('x@y.com');
+
+        $this->assertStringContainsString('unexpected error', (string)$result);
+        $this->assertStringContainsString('email', (string)$result);
+    }
+
+    public function testValidateEmailReturnsResubmitMessageWhenResponseEmpty(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(false);
+        $this->validator->method('verifyEmail')->willReturn([]);
+
+        $result = $this->plugin->callValidateEmail('x@y.com');
+
+        $this->assertStringContainsString('Submit again', (string)$result);
+    }
+
+    public function testValidateEmailReturnsFalseWhenNoApiKey(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(false);
+        $this->validator->method('verifyEmail')->willReturn(['noKeyFound' => true]);
+
+        $this->assertFalse($this->plugin->callValidateEmail('x@y.com'));
+    }
+
+    public function testValidatePhoneReturnsUnexpectedErrorPhraseOnVerifyError(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(false);
+        $this->validator->method('verifyPhoneNumber')->willReturn(['error' => true, 'message' => 'boom']);
+
+        $result = $this->plugin->callValidatePhone('+441234567890', 'GB');
+
+        $this->assertStringContainsString('unexpected error', (string)$result);
+        $this->assertStringContainsString('phone number', (string)$result);
+    }
+}

--- a/Test/Unit/Plugin/ChangeAddressDefaultCountryTest.php
+++ b/Test/Unit/Plugin/ChangeAddressDefaultCountryTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loqate\ApiIntegration\Test\Unit\Plugin;
+
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\Extra;
+use Loqate\ApiIntegration\Plugin\ChangeAddressDefaultCountry;
+use Magento\Customer\Api\Data\AddressInterface;
+use Magento\Customer\Model\Session;
+use Magento\Directory\Model\CountryFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the customer-address default-country plugin, which pre-fills the
+ * country from the visitor's IP (via Loqate) when no country is set yet.
+ */
+class ChangeAddressDefaultCountryTest extends TestCase
+{
+    private const CONFIG_PATH = 'loqate_settings/ipcountry_settings/enable_customer_account';
+
+    /** @var CountryFactory&MockObject */
+    private $countryFactory;
+
+    /** @var Extra&MockObject */
+    private $extra;
+
+    /** @var Data&MockObject */
+    private $helper;
+
+    /** @var Session&MockObject */
+    private $session;
+
+    /** @var ChangeAddressDefaultCountry */
+    private $plugin;
+
+    protected function setUp(): void
+    {
+        $this->countryFactory = $this->createMock(CountryFactory::class);
+        $this->extra = $this->createMock(Extra::class);
+        $this->helper = $this->createMock(Data::class);
+        $this->session = $this->createMock(Session::class);
+
+        $this->plugin = new ChangeAddressDefaultCountry(
+            $this->countryFactory,
+            $this->extra,
+            $this->helper,
+            $this->session
+        );
+    }
+
+    /**
+     * A country model double that resolves a code to a Magento country id.
+     */
+    private function countryModel(?int $id, string $countryId = 'GB'): object
+    {
+        return new class($id, $countryId) {
+            public function __construct(private ?int $id, private string $countryId)
+            {
+            }
+
+            public function loadByCode($code): self
+            {
+                return $this;
+            }
+
+            public function getId(): ?int
+            {
+                return $this->id;
+            }
+
+            public function getCountryId(): string
+            {
+                return $this->countryId;
+            }
+        };
+    }
+
+    public function testReturnsResultUnchangedWhenDisabled(): void
+    {
+        $this->helper->method('getConfigValue')->with(self::CONFIG_PATH)->willReturn(false);
+        $this->extra->expects($this->never())->method('ipToCountry');
+        $this->countryFactory->expects($this->never())->method('create');
+
+        $subject = $this->createMock(AddressInterface::class);
+
+        $this->assertSame('US', $this->plugin->afterGetCountryId($subject, 'US'));
+    }
+
+    public function testResolvesCountryFromIpWhenResultEmpty(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(true);
+        $this->session->method('getData')->with('loqate_ipcountry')->willReturn(null);
+        $this->extra->method('ipToCountry')->willReturn(['Iso2' => 'gb']);
+        $this->countryFactory->method('create')->willReturn($this->countryModel(826, 'GB'));
+
+        $subject = $this->createMock(AddressInterface::class);
+
+        $this->assertSame('GB', $this->plugin->afterGetCountryId($subject, ''));
+    }
+
+    public function testKeepsExistingResultWhenNotEmpty(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(true);
+        $this->session->method('getData')->willReturn(['Iso2' => 'GB']);
+        $this->countryFactory->expects($this->never())->method('create');
+
+        $subject = $this->createMock(AddressInterface::class);
+
+        $this->assertSame('FR', $this->plugin->afterGetCountryId($subject, 'FR'));
+    }
+
+    public function testUsesCachedIpCountryFromSession(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(true);
+        $this->session->method('getData')->with('loqate_ipcountry')->willReturn(['Iso2' => 'GB']);
+        // Cached value present -> the IP lookup must not be called again.
+        $this->extra->expects($this->never())->method('ipToCountry');
+        $this->countryFactory->method('create')->willReturn($this->countryModel(826, 'GB'));
+
+        $subject = $this->createMock(AddressInterface::class);
+
+        $this->assertSame('GB', $this->plugin->afterGetCountryId($subject, ''));
+    }
+
+    public function testKeepsResultWhenCountryCannotBeResolved(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(true);
+        $this->session->method('getData')->willReturn(['Iso2' => 'ZZ']);
+        // Unknown country -> getId() returns null, original (empty) result is kept.
+        $this->countryFactory->method('create')->willReturn($this->countryModel(null));
+
+        $subject = $this->createMock(AddressInterface::class);
+
+        $this->assertSame('', $this->plugin->afterGetCountryId($subject, ''));
+    }
+}

--- a/Test/Unit/Plugin/ChangeCheckoutDefaultCountryTest.php
+++ b/Test/Unit/Plugin/ChangeCheckoutDefaultCountryTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loqate\ApiIntegration\Test\Unit\Plugin;
+
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\Extra;
+use Loqate\ApiIntegration\Plugin\ChangeCheckoutDefaultCountry;
+use Magento\Checkout\Block\Checkout\LayoutProcessorInterface;
+use Magento\Customer\Model\Session;
+use Magento\Directory\Model\CountryFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the checkout default-country plugin, which injects the IP-derived
+ * country into the checkout jsLayout when enabled.
+ */
+class ChangeCheckoutDefaultCountryTest extends TestCase
+{
+    private const CONFIG_PATH = 'loqate_settings/ipcountry_settings/enable_checkout';
+
+    /** @var CountryFactory&MockObject */
+    private $countryFactory;
+
+    /** @var Extra&MockObject */
+    private $extra;
+
+    /** @var Data&MockObject */
+    private $helper;
+
+    /** @var Session&MockObject */
+    private $session;
+
+    /** @var ChangeCheckoutDefaultCountry */
+    private $plugin;
+
+    protected function setUp(): void
+    {
+        $this->countryFactory = $this->createMock(CountryFactory::class);
+        $this->extra = $this->createMock(Extra::class);
+        $this->helper = $this->createMock(Data::class);
+        $this->session = $this->createMock(Session::class);
+
+        $this->plugin = new ChangeCheckoutDefaultCountry(
+            $this->countryFactory,
+            $this->extra,
+            $this->helper,
+            $this->session
+        );
+    }
+
+    private function countryModel(?int $id): object
+    {
+        return new class($id) {
+            public function __construct(private ?int $id)
+            {
+            }
+
+            public function loadByCode($code): self
+            {
+                return $this;
+            }
+
+            public function getId(): ?int
+            {
+                return $this->id;
+            }
+        };
+    }
+
+    /**
+     * Builds a minimal jsLayout containing the shipping country_id node the
+     * plugin targets.
+     */
+    private function layoutWithShippingCountry(string $value = ''): array
+    {
+        return [
+            'components' => ['checkout' => ['children' => ['steps' => ['children' => [
+                'shipping-step' => ['children' => ['shippingAddress' => ['children' => [
+                    'shipping-address-fieldset' => ['children' => [
+                        'country_id' => ['value' => $value],
+                    ]],
+                ]]]],
+            ]]]]],
+        ];
+    }
+
+    private function shippingCountryValue(array $jsLayout): mixed
+    {
+        return $jsLayout['components']['checkout']['children']['steps']['children']
+            ['shipping-step']['children']['shippingAddress']['children']
+            ['shipping-address-fieldset']['children']['country_id']['value'];
+    }
+
+    public function testReturnsLayoutUnchangedWhenDisabled(): void
+    {
+        $this->helper->method('getConfigValue')->with(self::CONFIG_PATH)->willReturn(false);
+        $this->extra->expects($this->never())->method('ipToCountry');
+
+        $layout = $this->layoutWithShippingCountry('US');
+
+        $this->assertSame($layout, $this->plugin->afterProcess($this->subject(), $layout));
+    }
+
+    public function testInjectsResolvedCountryIntoShippingFieldset(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(true);
+        $this->session->method('getData')->with('loqate_ipcountry')->willReturn(null);
+        $this->extra->method('ipToCountry')->willReturn(['Iso2' => 'gb']);
+        $this->countryFactory->method('create')->willReturn($this->countryModel(826));
+
+        $result = $this->plugin->afterProcess($this->subject(), $this->layoutWithShippingCountry());
+
+        $this->assertSame('GB', $this->shippingCountryValue($result));
+    }
+
+    public function testLeavesLayoutUnchangedWhenCountryCannotBeResolved(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(true);
+        $this->session->method('getData')->willReturn(['Iso2' => 'ZZ']);
+        $this->countryFactory->method('create')->willReturn($this->countryModel(null));
+
+        $layout = $this->layoutWithShippingCountry('US');
+
+        $this->assertSame('US', $this->shippingCountryValue($this->plugin->afterProcess($this->subject(), $layout)));
+    }
+
+    public function testIgnoresMissingIso2(): void
+    {
+        $this->helper->method('getConfigValue')->willReturn(true);
+        $this->session->method('getData')->willReturn(null);
+        $this->extra->method('ipToCountry')->willReturn(['error' => true]); // no Iso2
+        $this->countryFactory->expects($this->never())->method('create');
+
+        $layout = $this->layoutWithShippingCountry('US');
+
+        $this->assertSame('US', $this->shippingCountryValue($this->plugin->afterProcess($this->subject(), $layout)));
+    }
+
+    private function subject(): LayoutProcessorInterface
+    {
+        return $this->createMock(LayoutProcessorInterface::class);
+    }
+}

--- a/Test/stubs/magento.php
+++ b/Test/stubs/magento.php
@@ -125,6 +125,15 @@ namespace Magento\Framework\Module {
     }
 }
 
+namespace Magento\Framework\Data {
+    if (!interface_exists(\Magento\Framework\Data\OptionSourceInterface::class, false)) {
+        interface OptionSourceInterface
+        {
+            public function toOptionArray();
+        }
+    }
+}
+
 namespace Magento\Framework\Serialize {
     if (!interface_exists(\Magento\Framework\Serialize\SerializerInterface::class, false)) {
         interface SerializerInterface
@@ -132,6 +141,97 @@ namespace Magento\Framework\Serialize {
             public function serialize($data);
 
             public function unserialize($string);
+        }
+    }
+}
+
+namespace Magento\Framework\App\Action {
+    if (!class_exists(\Magento\Framework\App\Action\Context::class, false)) {
+        class Context
+        {
+            public function getMessageManager()
+            {
+                return null;
+            }
+
+            public function getResultRedirectFactory()
+            {
+                return null;
+            }
+
+            public function getRedirect()
+            {
+                return null;
+            }
+        }
+    }
+}
+
+namespace Magento\Framework {
+    if (!interface_exists(\Magento\Framework\UrlInterface::class, false)) {
+        interface UrlInterface
+        {
+        }
+    }
+}
+
+namespace Magento\Framework\Controller\Result {
+    if (!class_exists(\Magento\Framework\Controller\Result\JsonFactory::class, false)) {
+        class JsonFactory
+        {
+            public function create(array $data = [])
+            {
+                return null;
+            }
+        }
+    }
+}
+
+namespace Magento\Directory\Model {
+    if (!class_exists(\Magento\Directory\Model\CountryFactory::class, false)) {
+        class CountryFactory
+        {
+            public function create(array $data = [])
+            {
+                return null;
+            }
+        }
+    }
+}
+
+namespace Magento\Customer\Api\Data {
+    if (!interface_exists(\Magento\Customer\Api\Data\AddressInterface::class, false)) {
+        interface AddressInterface
+        {
+        }
+    }
+}
+
+namespace Magento\Checkout\Block\Checkout {
+    if (!interface_exists(\Magento\Checkout\Block\Checkout\LayoutProcessorInterface::class, false)) {
+        interface LayoutProcessorInterface
+        {
+        }
+    }
+}
+
+namespace {
+    if (!function_exists('__')) {
+        /**
+         * Minimal stand-in for Magento's global translation function. Returns the
+         * text with Magento-style %1/%2 placeholders substituted, as a plain
+         * string (stringly compatible with the real Phrase via (string) casts).
+         */
+        function __($text, ...$arguments)
+        {
+            $text = (string)$text;
+            if ($arguments && isset($arguments[0]) && is_array($arguments[0])) {
+                $arguments = $arguments[0];
+            }
+            foreach (array_values($arguments) as $index => $value) {
+                $text = str_replace('%' . ($index + 1), (string)$value, $text);
+            }
+            return $text;
         }
     }
 }


### PR DESCRIPTION
## What

Builds on the PHPUnit infra (#30) to add unit coverage across the module's cleanly unit-testable surface.

Stacked on `feat/add-phpunit` — merge #30 first, then this retargets to `master`.

## Coverage added

| Area | Tests |
|------|-------|
| `Model/Config/Source/*` (all 8 AVC / quality option models) | option value lists & order, well-formed entries, `toArray` keying |
| `Plugin/AbstractPlugin` | `shouldVerify` per-field de-dupe; `validateEmail`/`validatePhone` branching — repeat-submission skip, verify-error phrase, no-key, empty-response message |
| `Plugin/ChangeAddressDefaultCountry` | disabled passthrough, IP→country resolution when empty, keep existing result, session cache reuse, unresolved-country no-op |
| `Plugin/ChangeCheckoutDefaultCountry` | disabled passthrough, country injection into shipping fieldset, unresolved/missing-Iso2 no-op |

## Stub layer

Extended `Test/stubs/magento.php` with the extra framework doubles these tests reference (`OptionSourceInterface`, `App\Action\Context`, `UrlInterface`, `JsonFactory`, `CountryFactory`, `AddressInterface`, `LayoutProcessorInterface`) plus a global `__()` translation stub. All guarded with `class_exists/interface_exists(..., false)` so the suite still runs unchanged inside Magento's `dev/tests/unit`.

## Not unit-tested (deliberately)

Classes that require a real Magento runtime are left for integration testing rather than over-mocking: the controllers (`Controller/**`), the orchestration frontend/admin plugins (`Plugin/Frontend/**`, `Plugin/Admin/**`, `Helper/Controller`), the `Version` admin block, and `Extra` (instantiates the Loqate API client internally). `Helper/Validator`'s captured-address logic is covered on the verification-fix branch (#29).

## Validation

PHPUnit's binary needs `ext-dom`/`ext-mbstring` (absent in the local sandbox; CI runners get them via `setup-php`). I drove every test method through a reflective runner locally: all assertion-only tests pass; the `expects()`-based mock-count checks require PHPUnit's full TextUI runtime, so their final verification runs here in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)