### PR TITLE
ci: align composer.json version with release tag and gate release on unit tests

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,6 +11,12 @@
 # - Other types       → No version bump
 #
 # Tag Format: v{major}.{minor}.{patch} (e.g., v2.0.4)
+#
+# Composer version sync:
+# - Before creating the real tag, this workflow bumps the "version" field in
+#   composer.json to match the computed tag (without the 'v' prefix) and commits
+#   that change to master. The tag is then created ON that bump commit, so the
+#   released artifact's composer.json always matches its git tag.
 # ==============================================================================
 
 name: Auto Tag on Merge to Master
@@ -23,26 +29,120 @@ on:
       - master
 
 jobs:
+  # ==========================================================================
+  # Job 1: Unit tests — gate the release on a green test suite
+  # ==========================================================================
+  # On merge to master we re-run the module's PHPUnit unit suite (the same suite
+  # `ci.yml` runs on pull requests) BEFORE any version bump, tag, or release.
+  # The `tag` job below declares `needs: unit-tests`, so if these tests fail no
+  # tag is created and no release is published — broken code never gets tagged.
+  #
+  # This job carries the SAME loop guard as the `tag` job: the bump commit we
+  # push back to master must not re-trigger a wasted test run. (In practice
+  # pushes authored by the default GITHUB_TOKEN do not trigger new workflow
+  # runs, but we keep the guard as defence in depth.)
+  unit-tests:
+    name: Unit tests (PHP ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+
+    if: >-
+      ${{
+        !contains(github.event.head_commit.message, 'chore(release):') &&
+        !contains(github.event.head_commit.message, '[skip ci]')
+      }}
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.3', '8.4']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring, dom, libxml, tokenizer, xml, xmlwriter, simplexml, curl, intl
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer.json
+        run: composer validate --no-check-publish
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ matrix.php-version }}-${{ hashFiles('composer.json') }}
+          restore-keys: composer-${{ matrix.php-version }}-
+
+      - name: Install dependencies
+        run: composer update --no-interaction --no-progress --prefer-dist
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit --colors=never
+
+  # ==========================================================================
+  # Job 2: Tag, bump composer.json, and release
+  # ==========================================================================
   tag:
     runs-on: ubuntu-latest
-    
-    # Grant write permissions to create tags and releases
+
+    # Only tag/release once the unit suite is green (see job above).
+    needs: unit-tests
+
+    # ------------------------------------------------------------------------
+    # INFINITE-LOOP GUARD (most important correctness concern)
+    # ------------------------------------------------------------------------
+    # This job pushes a "chore(release): ..." commit back to master, which would
+    # normally re-trigger this same `push: master` workflow and create a runaway
+    # loop of tags. We defend against that with this job-level guard:
+    #
+    #   - Skip the job entirely if the head commit message contains
+    #     "chore(release):" (the bump commit we create below), OR
+    #   - Skip if it contains "[skip ci]" (also present in our bump commit, and a
+    #     conventional opt-out token contributors may use).
+    #
+    # `github.event.head_commit.message` is the message of the commit that was
+    # just pushed (available on `push` events). `[skip ci]` alone does NOT stop
+    # GitHub Actions from running (that token is honoured by some other CI
+    # systems, not Actions), so this explicit `if:` is what actually breaks the
+    # loop. We check both tokens for defence in depth.
+    if: >-
+      ${{
+        !contains(github.event.head_commit.message, 'chore(release):') &&
+        !contains(github.event.head_commit.message, '[skip ci]')
+      }}
+
+    # Grant write permissions to create tags, releases, and push the bump commit
     permissions:
       contents: write
-    
+
     steps:
       # Step 1: Checkout the repository with full git history
-      # fetch-depth: 0 ensures we get all commits and tags, not just the latest
+      # fetch-depth: 0 ensures we get all commits and tags, not just the latest.
+      # We check out master explicitly because we will commit the version bump
+      # back to it before tagging.
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history and tags for proper version detection
-          
+          ref: master     # We push the bump commit back to this branch
+
       # Step 2: Force fetch all tags from remote
       # This ensures we have the latest tags even if checkout missed some
       - name: Fetch all tags
         run: git fetch --force --tags
-      
+
       # Step 3: Identify the current latest tag
       # This step reads existing tags to determine the starting point for versioning
       # Example: If current tag is v2.0.4, this will be the base for the next version
@@ -51,7 +151,7 @@ jobs:
         run: |
           # Search for tags starting with 'v' and sort by version (highest first)
           LATEST_TAG=$(git tag -l "v*" --sort=-v:refname | head -n 1)
-          
+
           # If no tags exist, start from v0.0.0
           if [ -z "$LATEST_TAG" ]; then
             echo "No existing tags found. Will start from v0.0.0"
@@ -61,11 +161,20 @@ jobs:
             echo "current_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           fi
 
-      # Step 4: Analyze commits and create new version tag
-      # This action reads commits since the last tag and determines version bump
-      # based on conventional commit messages
-      - name: Bump version and push tag
-        id: tag_version
+      # Step 4: DRY RUN — compute the next version WITHOUT creating a tag
+      # ------------------------------------------------------------------------
+      # We run the tag action in dry-run mode first so we can learn what the next
+      # version would be, bump composer.json to that version, and commit it BEFORE
+      # the real tag is created. This guarantees the tag points at a commit whose
+      # composer.json already carries the correct version.
+      #
+      # Outputs of interest (only set when there is something to release):
+      #   new_tag      → e.g. "v2.0.11" (with tag_prefix)
+      #   new_version  → e.g. "2.0.11"  (without prefix) — used for composer.json
+      #   changelog    → conventional changelog since the previous tag
+      #   release_type → major | minor | patch (for logging)
+      - name: Compute next version (dry run)
+        id: dry_run
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,20 +183,81 @@ jobs:
           pre_release_branches: develop,beta  # Mark tags from these branches as pre-release
           tag_prefix: v                    # Maintain 'v' prefix (e.g., v2.0.4)
           fetch_all_tags: true             # Ensure all tags are fetched for accurate versioning
-          
+          dry_run: true                    # IMPORTANT: do not create the tag yet
+
           # Conventional Commit Rules:
           # -------------------------
           # feat: new feature               → MINOR bump (v2.0.4 → v2.1.0)
           # fix: bug fix                    → PATCH bump (v2.0.4 → v2.0.5)
           # feat!: or BREAKING CHANGE:      → MAJOR bump (v2.0.4 → v3.0.0)
           # docs:, style:, refactor:, etc.  → NO bump (no tag created)
-          #
-          # Examples:
-          # - "feat: add address validation" → v2.0.4 becomes v2.1.0
-          # - "fix: correct postcode logic"  → v2.0.4 becomes v2.0.5
-          # - "feat!: redesign API"          → v2.0.4 becomes v3.0.0
-      
-      # Step 5: Display version information in workflow logs
+
+      # Step 5: Bump composer.json and commit it to master
+      # ------------------------------------------------------------------------
+      # Only runs when the dry run computed a new version (i.e. there is actually
+      # something to release). We update the "version" field in composer.json to
+      # the numeric version (no 'v' prefix) using jq, then commit + push to master
+      # as the github-actions bot.
+      #
+      # The commit message contains BOTH "chore(release):" and "[skip ci]" which
+      # are exactly the tokens the job-level `if:` guard above checks for, so this
+      # commit cannot re-trigger this workflow.
+      - name: Bump composer.json version and commit
+        id: bump
+        if: steps.dry_run.outputs.new_version != ''
+        env:
+          NEW_TAG: ${{ steps.dry_run.outputs.new_tag }}
+          NEW_VERSION: ${{ steps.dry_run.outputs.new_version }}
+        run: |
+          echo "Setting composer.json version to: $NEW_VERSION"
+
+          # Rewrite the "version" field. jq preserves the rest of the document;
+          # we write to a temp file and move it back so the update is atomic and
+          # we never leave a half-written composer.json on failure.
+          jq --arg v "$NEW_VERSION" '.version = $v' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
+          echo "composer.json now reads:"
+          grep '"version"' composer.json
+
+          # Identify the commit as the github-actions bot
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add composer.json
+
+          # Only commit if something actually changed (e.g. the version may
+          # already match if a previous run committed but failed before tagging).
+          if git diff --cached --quiet; then
+            echo "composer.json already at $NEW_VERSION — nothing to commit."
+          else
+            git commit -m "chore(release): set composer.json version to ${NEW_TAG} [skip ci]"
+            git push origin master
+            echo "Pushed composer.json bump commit to master."
+          fi
+
+      # Step 6: Create the REAL tag on the (possibly new) HEAD of master
+      # ------------------------------------------------------------------------
+      # Now that the bump commit is the HEAD of master, we run the tag action for
+      # real. We pass `custom_tag` set to the version we computed in the dry run
+      # so the action tags EXACTLY that version. This is critical: a second
+      # commit-analysis run would now also see our new "chore(release): ..."
+      # commit and, with default_bump: patch, could otherwise compute a different
+      # (higher) version. `custom_tag` overrides all bump calculation.
+      #
+      # Note: `custom_tag` takes the version WITHOUT the prefix; the action
+      # re-applies `tag_prefix`, so `new_tag` here is still e.g. "v2.0.11".
+      - name: Create version tag
+        id: tag_version
+        if: steps.dry_run.outputs.new_version != ''
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: v
+          fetch_all_tags: true
+          custom_tag: ${{ steps.dry_run.outputs.new_version }}  # Force the computed version
+
+      # Step 7: Display version information in workflow logs
       # This helps with debugging and provides visibility into what changed
       - name: Display version information
         if: steps.tag_version.outputs.new_tag != ''
@@ -97,17 +267,20 @@ jobs:
           echo "========================================="
           echo "Previous tag: ${{ steps.get_latest_tag.outputs.current_tag }}"
           echo "New tag created: ${{ steps.tag_version.outputs.new_tag }}"
-          echo "Version bump type: ${{ steps.tag_version.outputs.part }}"
+          echo "Version bump type: ${{ steps.dry_run.outputs.release_type }}"
+          echo "composer.json version: ${{ steps.dry_run.outputs.new_version }}"
           echo "========================================="
 
-      # Step 6: Create a GitHub release with changelog
+      # Step 8: Create a GitHub release with changelog
       # This creates a release page on GitHub with auto-generated notes
-      # from conventional commits
+      # from conventional commits. We use the changelog computed during the dry
+      # run (which is generated from the conventional commits, independent of the
+      # custom_tag override).
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         if: steps.tag_version.outputs.new_tag != ''
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}          # Use the newly created tag
           name: Release ${{ steps.tag_version.outputs.new_tag }} # Release title
-          body: ${{ steps.tag_version.outputs.changelog }}       # Auto-generated changelog
+          body: ${{ steps.dry_run.outputs.changelog }}           # Auto-generated changelog
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Improves the release pipeline (`.github/workflows/auto-tag.yml`) so that on merge to master:

1. **`composer.json` version is kept aligned with the release tag.** The hardcoded `version` field previously drifted from the git tags. The workflow now:
   - dry-runs the tag action to compute the next semver **without** tagging,
   - bumps `composer.json`'s `version` to the numeric version via `jq` and commits it to master as `github-actions[bot]` (`chore(release): ... [skip ci]`),
   - creates the real tag on that bump commit using `custom_tag`, so the tag — and the zip `auto-release.yml` builds from it — always carries a matching `composer.json` version.

2. **The release is gated on a green unit suite.** A new `unit-tests` job re-runs the PHPUnit suite (PHP 8.3 + 8.4, mirroring `ci.yml`) on merge to master, and the `tag` job declares `needs: unit-tests`. Broken code on master no longer gets tagged or released.

## Flow

```
merge → master
  └─ unit-tests (8.3, 8.4)  ──pass──▶  dry-run → bump composer.json → tag → GitHub release
                            ──fail──▶  no bump, no tag, no release
```

## Correctness notes

- **Infinite-loop guard:** both jobs skip when the head commit message contains `chore(release):` or `[skip ci]`, so the bot's own bump push can't re-trigger a runaway tag loop. (`[skip ci]` alone is not honoured by GitHub Actions, hence the explicit `if:`.)
- **Version pinning:** the real tag uses `custom_tag` set to the dry-run version, so the extra `chore(release):` commit cannot inflate the computed bump.
- **Atomic bump:** `jq` writes to a temp file then moves it back; the commit only happens if `composer.json` actually changed.

## Out of scope

- `composer.json` is left at its current value (`2.0.10`); the pipeline manages it from here.
- `auto-release.yml` is unchanged — it already checks out the tag and zips it, so it picks up the corrected `composer.json` automatically.