### PR TITLE
ci: align composer.json in release zip instead of pushing to master

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -66,7 +66,29 @@ jobs:
       # Step 4: Checkout the specific tag
       - name: Checkout tag
         run: git checkout ${{ steps.get_tag.outputs.tag }}
-      
+
+      # Step 4b: Align composer.json "version" with the tag
+      # ------------------------------------------------------------------------
+      # master is protected (changes must go through a PR), so we cannot commit a
+      # version bump back to the branch. Instead we rewrite composer.json's
+      # "version" field here — in the checked-out tag, right before packaging — to
+      # the tag's numeric version (no 'v' prefix). This change is NOT committed or
+      # pushed anywhere; it only affects the contents of the release zip, so the
+      # published artifact's composer.json always matches its git tag.
+      - name: Align composer.json version with tag
+        env:
+          VERSION: ${{ steps.get_tag.outputs.version }}
+        run: |
+          echo "Setting composer.json version to: $VERSION"
+
+          # Rewrite the "version" field atomically via a temp file so a failure
+          # never leaves a half-written composer.json.
+          jq --arg v "$VERSION" '.version = $v' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
+          echo "composer.json now reads:"
+          grep '"version"' composer.json
+
       # Step 5: Create zip file excluding specified files/directories
       # Excludes: .devcontainer/, .github/, .gitignore
       - name: Create release package

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -12,11 +12,15 @@
 #
 # Tag Format: v{major}.{minor}.{patch} (e.g., v2.0.4)
 #
-# Composer version sync:
-# - Before creating the real tag, this workflow bumps the "version" field in
-#   composer.json to match the computed tag (without the 'v' prefix) and commits
-#   that change to master. The tag is then created ON that bump commit, so the
-#   released artifact's composer.json always matches its git tag.
+# Notes:
+# - We do NOT commit anything back to master here. `master` is protected by a
+#   repository ruleset ("changes must be made through a pull request"), so a bot
+#   pushing a version-bump commit is rejected. Instead, composer.json's "version"
+#   field is aligned with the tag inside the release packaging step of
+#   auto-release.yml, which rewrites it in the checked-out tag right before
+#   zipping. The released artifact therefore always matches its git tag.
+# - Tagging/releasing only happens after the unit-test suite passes (see the
+#   `unit-tests` job below, which the `tag` job depends on).
 # ==============================================================================
 
 name: Auto Tag on Merge to Master
@@ -33,23 +37,12 @@ jobs:
   # Job 1: Unit tests — gate the release on a green test suite
   # ==========================================================================
   # On merge to master we re-run the module's PHPUnit unit suite (the same suite
-  # `ci.yml` runs on pull requests) BEFORE any version bump, tag, or release.
-  # The `tag` job below declares `needs: unit-tests`, so if these tests fail no
-  # tag is created and no release is published — broken code never gets tagged.
-  #
-  # This job carries the SAME loop guard as the `tag` job: the bump commit we
-  # push back to master must not re-trigger a wasted test run. (In practice
-  # pushes authored by the default GITHUB_TOKEN do not trigger new workflow
-  # runs, but we keep the guard as defence in depth.)
+  # `ci.yml` runs on pull requests) BEFORE any tag or release. The `tag` job
+  # below declares `needs: unit-tests`, so if these tests fail no tag is created
+  # and no release is published — broken code never gets tagged.
   unit-tests:
     name: Unit tests (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
-
-    if: >-
-      ${{
-        !contains(github.event.head_commit.message, 'chore(release):') &&
-        !contains(github.event.head_commit.message, '[skip ci]')
-      }}
 
     permissions:
       contents: read
@@ -92,7 +85,7 @@ jobs:
         run: vendor/bin/phpunit --colors=never
 
   # ==========================================================================
-  # Job 2: Tag, bump composer.json, and release
+  # Job 2: Tag and release
   # ==========================================================================
   tag:
     runs-on: ubuntu-latest
@@ -100,43 +93,17 @@ jobs:
     # Only tag/release once the unit suite is green (see job above).
     needs: unit-tests
 
-    # ------------------------------------------------------------------------
-    # INFINITE-LOOP GUARD (most important correctness concern)
-    # ------------------------------------------------------------------------
-    # This job pushes a "chore(release): ..." commit back to master, which would
-    # normally re-trigger this same `push: master` workflow and create a runaway
-    # loop of tags. We defend against that with this job-level guard:
-    #
-    #   - Skip the job entirely if the head commit message contains
-    #     "chore(release):" (the bump commit we create below), OR
-    #   - Skip if it contains "[skip ci]" (also present in our bump commit, and a
-    #     conventional opt-out token contributors may use).
-    #
-    # `github.event.head_commit.message` is the message of the commit that was
-    # just pushed (available on `push` events). `[skip ci]` alone does NOT stop
-    # GitHub Actions from running (that token is honoured by some other CI
-    # systems, not Actions), so this explicit `if:` is what actually breaks the
-    # loop. We check both tokens for defence in depth.
-    if: >-
-      ${{
-        !contains(github.event.head_commit.message, 'chore(release):') &&
-        !contains(github.event.head_commit.message, '[skip ci]')
-      }}
-
-    # Grant write permissions to create tags, releases, and push the bump commit
+    # Grant write permissions to create tags and releases
     permissions:
       contents: write
 
     steps:
       # Step 1: Checkout the repository with full git history
-      # fetch-depth: 0 ensures we get all commits and tags, not just the latest.
-      # We check out master explicitly because we will commit the version bump
-      # back to it before tagging.
+      # fetch-depth: 0 ensures we get all commits and tags, not just the latest
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history and tags for proper version detection
-          ref: master     # We push the bump commit back to this branch
 
       # Step 2: Force fetch all tags from remote
       # This ensures we have the latest tags even if checkout missed some
@@ -161,20 +128,13 @@ jobs:
             echo "current_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           fi
 
-      # Step 4: DRY RUN — compute the next version WITHOUT creating a tag
-      # ------------------------------------------------------------------------
-      # We run the tag action in dry-run mode first so we can learn what the next
-      # version would be, bump composer.json to that version, and commit it BEFORE
-      # the real tag is created. This guarantees the tag points at a commit whose
-      # composer.json already carries the correct version.
-      #
-      # Outputs of interest (only set when there is something to release):
-      #   new_tag      → e.g. "v2.0.11" (with tag_prefix)
-      #   new_version  → e.g. "2.0.11"  (without prefix) — used for composer.json
-      #   changelog    → conventional changelog since the previous tag
-      #   release_type → major | minor | patch (for logging)
-      - name: Compute next version (dry run)
-        id: dry_run
+      # Step 4: Analyze commits and create new version tag
+      # This action reads commits since the last tag and determines version bump
+      # based on conventional commit messages. It tags the current HEAD of master
+      # and pushes only the tag ref (no branch push), so the master branch ruleset
+      # is not involved.
+      - name: Bump version and push tag
+        id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -183,7 +143,6 @@ jobs:
           pre_release_branches: develop,beta  # Mark tags from these branches as pre-release
           tag_prefix: v                    # Maintain 'v' prefix (e.g., v2.0.4)
           fetch_all_tags: true             # Ensure all tags are fetched for accurate versioning
-          dry_run: true                    # IMPORTANT: do not create the tag yet
 
           # Conventional Commit Rules:
           # -------------------------
@@ -191,73 +150,13 @@ jobs:
           # fix: bug fix                    → PATCH bump (v2.0.4 → v2.0.5)
           # feat!: or BREAKING CHANGE:      → MAJOR bump (v2.0.4 → v3.0.0)
           # docs:, style:, refactor:, etc.  → NO bump (no tag created)
+          #
+          # Examples:
+          # - "feat: add address validation" → v2.0.4 becomes v2.1.0
+          # - "fix: correct postcode logic"  → v2.0.4 becomes v2.0.5
+          # - "feat!: redesign API"          → v2.0.4 becomes v3.0.0
 
-      # Step 5: Bump composer.json and commit it to master
-      # ------------------------------------------------------------------------
-      # Only runs when the dry run computed a new version (i.e. there is actually
-      # something to release). We update the "version" field in composer.json to
-      # the numeric version (no 'v' prefix) using jq, then commit + push to master
-      # as the github-actions bot.
-      #
-      # The commit message contains BOTH "chore(release):" and "[skip ci]" which
-      # are exactly the tokens the job-level `if:` guard above checks for, so this
-      # commit cannot re-trigger this workflow.
-      - name: Bump composer.json version and commit
-        id: bump
-        if: steps.dry_run.outputs.new_version != ''
-        env:
-          NEW_TAG: ${{ steps.dry_run.outputs.new_tag }}
-          NEW_VERSION: ${{ steps.dry_run.outputs.new_version }}
-        run: |
-          echo "Setting composer.json version to: $NEW_VERSION"
-
-          # Rewrite the "version" field. jq preserves the rest of the document;
-          # we write to a temp file and move it back so the update is atomic and
-          # we never leave a half-written composer.json on failure.
-          jq --arg v "$NEW_VERSION" '.version = $v' composer.json > composer.json.tmp
-          mv composer.json.tmp composer.json
-
-          echo "composer.json now reads:"
-          grep '"version"' composer.json
-
-          # Identify the commit as the github-actions bot
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add composer.json
-
-          # Only commit if something actually changed (e.g. the version may
-          # already match if a previous run committed but failed before tagging).
-          if git diff --cached --quiet; then
-            echo "composer.json already at $NEW_VERSION — nothing to commit."
-          else
-            git commit -m "chore(release): set composer.json version to ${NEW_TAG} [skip ci]"
-            git push origin master
-            echo "Pushed composer.json bump commit to master."
-          fi
-
-      # Step 6: Create the REAL tag on the (possibly new) HEAD of master
-      # ------------------------------------------------------------------------
-      # Now that the bump commit is the HEAD of master, we run the tag action for
-      # real. We pass `custom_tag` set to the version we computed in the dry run
-      # so the action tags EXACTLY that version. This is critical: a second
-      # commit-analysis run would now also see our new "chore(release): ..."
-      # commit and, with default_bump: patch, could otherwise compute a different
-      # (higher) version. `custom_tag` overrides all bump calculation.
-      #
-      # Note: `custom_tag` takes the version WITHOUT the prefix; the action
-      # re-applies `tag_prefix`, so `new_tag` here is still e.g. "v2.0.11".
-      - name: Create version tag
-        id: tag_version
-        if: steps.dry_run.outputs.new_version != ''
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag_prefix: v
-          fetch_all_tags: true
-          custom_tag: ${{ steps.dry_run.outputs.new_version }}  # Force the computed version
-
-      # Step 7: Display version information in workflow logs
+      # Step 5: Display version information in workflow logs
       # This helps with debugging and provides visibility into what changed
       - name: Display version information
         if: steps.tag_version.outputs.new_tag != ''
@@ -267,20 +166,18 @@ jobs:
           echo "========================================="
           echo "Previous tag: ${{ steps.get_latest_tag.outputs.current_tag }}"
           echo "New tag created: ${{ steps.tag_version.outputs.new_tag }}"
-          echo "Version bump type: ${{ steps.dry_run.outputs.release_type }}"
-          echo "composer.json version: ${{ steps.dry_run.outputs.new_version }}"
+          echo "Version bump type: ${{ steps.tag_version.outputs.release_type }}"
           echo "========================================="
 
-      # Step 8: Create a GitHub release with changelog
+      # Step 6: Create a GitHub release with changelog
       # This creates a release page on GitHub with auto-generated notes
-      # from conventional commits. We use the changelog computed during the dry
-      # run (which is generated from the conventional commits, independent of the
-      # custom_tag override).
+      # from conventional commits. The auto-release.yml workflow then attaches the
+      # packaged zip (with an aligned composer.json) to this same release.
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         if: steps.tag_version.outputs.new_tag != ''
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}          # Use the newly created tag
           name: Release ${{ steps.tag_version.outputs.new_tag }} # Release title
-          body: ${{ steps.dry_run.outputs.changelog }}           # Auto-generated changelog
+          body: ${{ steps.tag_version.outputs.changelog }}       # Auto-generated changelog
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The release pipeline merged in #32 fails on master:

```
remote: error: GH013: Repository rule violations found for refs/heads/master.
remote: - Changes must be made through a pull request.
 ! [remote rejected] master -> master (push declined due to repository rule violations)
```

`auto-tag.yml` bumped `composer.json` and did `git push origin master`. The `master` ruleset (all changes via PR) rejects a bot pushing straight to the branch, so the job dies before tagging — no tag, no release.

## Fix

Stop touching `master`. Align `composer.json` inside the **release packaging** step instead, where the version comes straight from the tag name:

- **`auto-release.yml`** — new step (after checking out the tag, before zipping) rewrites `composer.json`'s `version` to the tag's numeric value via `jq`. The change is **not committed or pushed** — it only affects the contents of the release `.zip`, so the published artifact always matches its git tag.
- **`auto-tag.yml`** — drop the dry-run / bump / `git push origin master` / loop-guard machinery (no longer needed). Keep the `unit-tests` gate: tagging/releasing still only happens after the PHPUnit suite (PHP 8.3 + 8.4) passes. Also fixes a stale reference (`outputs.part` → `outputs.release_type`).

## Why this is correct for a magento2-module

Composer/Packagist derive the package version from the **git tag** and ignore the `composer.json` `version` field for resolution. Aligning it in the packaged artifact is exactly the metadata consumers see when they install the zip — no branch push, no ruleset conflict, no infinite-loop risk.

## Validation

- Both workflow files parse as valid YAML; `tag` job still `needs: unit-tests`.
- `jq` bump verified on a scratch copy of the real `composer.json`: only the version line changes, output is valid JSON, real file untouched.

## Trade-off

The `version` field in the source tree on `master` stays as-is (currently `2.0.10`); only the released `.zip` is aligned. If you'd rather also keep the branch source in sync, the alternative is adding the GitHub Actions bot as a bypass actor on the `master` ruleset — but that weakens the "all changes via PR" guarantee and isn't needed for the release artifact to be correct.