### PR TITLE
ci: keep composer.json on master aligned with the release tag (no drift)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -2,7 +2,8 @@
 # Auto Tag on Merge to Master
 # ==============================================================================
 # This workflow automatically creates version tags based on conventional commits
-# when changes are merged to the master branch.
+# when changes are merged to the master branch, and keeps composer.json's
+# "version" field on master aligned with the tag.
 #
 # Version Bumping Rules (Semantic Versioning):
 # - feat: commits     → MINOR version bump (v2.0.4 → v2.1.0)
@@ -12,15 +13,27 @@
 #
 # Tag Format: v{major}.{minor}.{patch} (e.g., v2.0.4)
 #
-# Notes:
-# - We do NOT commit anything back to master here. `master` is protected by a
-#   repository ruleset ("changes must be made through a pull request"), so a bot
-#   pushing a version-bump commit is rejected. Instead, composer.json's "version"
-#   field is aligned with the tag inside the release packaging step of
-#   auto-release.yml, which rewrites it in the checked-out tag right before
-#   zipping. The released artifact therefore always matches its git tag.
-# - Tagging/releasing only happens after the unit-test suite passes (see the
-#   `unit-tests` job below, which the `tag` job depends on).
+# Composer version sync (on master):
+# - Before creating the real tag, this workflow bumps the "version" field in
+#   composer.json to match the computed tag (without the 'v' prefix) and COMMITS
+#   that change back to master. The tag is created ON that bump commit, so the
+#   composer.json on master ALWAYS points to the latest released version.
+#
+# Why a custom token (RELEASE_TOKEN):
+# - master is protected by the "Main Branch Protection" ruleset (changes must go
+#   through a pull request). Rulesets gate by WHO pushes, not by token scope, so
+#   the default GITHUB_TOKEN / github-actions[bot] cannot push the bump commit
+#   even with `contents: write` — it is not on the ruleset's bypass list.
+# - RELEASE_TOKEN is a fine-grained Personal Access Token (Contents: write on
+#   this repo) belonging to a user who IS on the bypass list (a repo/org admin).
+#   The push is attributed to that user, so the ruleset lets it through. No
+#   ruleset change is required because admins already bypass.
+#
+# IMPORTANT — infinite-loop guard:
+# - Unlike the default GITHUB_TOKEN, a push authored with RELEASE_TOKEN DOES
+#   trigger a new `push: master` run. The job-level `if:` guard below (skip when
+#   the head commit message contains "chore(release):" or "[skip ci]") is
+#   therefore the ONLY thing breaking the loop. It must stay.
 # ==============================================================================
 
 name: Auto Tag on Merge to Master
@@ -37,12 +50,21 @@ jobs:
   # Job 1: Unit tests — gate the release on a green test suite
   # ==========================================================================
   # On merge to master we re-run the module's PHPUnit unit suite (the same suite
-  # `ci.yml` runs on pull requests) BEFORE any tag or release. The `tag` job
-  # below declares `needs: unit-tests`, so if these tests fail no tag is created
-  # and no release is published — broken code never gets tagged.
+  # `ci.yml` runs on pull requests) BEFORE any version bump, tag, or release.
+  # The `tag` job below declares `needs: unit-tests`, so if these tests fail no
+  # tag is created and no release is published — broken code never gets tagged.
+  #
+  # This job carries the SAME loop guard as the `tag` job so the bump commit does
+  # not trigger a wasted test run.
   unit-tests:
     name: Unit tests (PHP ${{ matrix.php-version }})
     runs-on: ubuntu-latest
+
+    if: >-
+      ${{
+        !contains(github.event.head_commit.message, 'chore(release):') &&
+        !contains(github.event.head_commit.message, '[skip ci]')
+      }}
 
     permissions:
       contents: read
@@ -85,7 +107,7 @@ jobs:
         run: vendor/bin/phpunit --colors=never
 
   # ==========================================================================
-  # Job 2: Tag and release
+  # Job 2: Bump composer.json, tag, and release
   # ==========================================================================
   tag:
     runs-on: ubuntu-latest
@@ -93,17 +115,42 @@ jobs:
     # Only tag/release once the unit suite is green (see job above).
     needs: unit-tests
 
-    # Grant write permissions to create tags and releases
+    # ------------------------------------------------------------------------
+    # INFINITE-LOOP GUARD (most important correctness concern)
+    # ------------------------------------------------------------------------
+    # This job pushes a "chore(release): ..." commit back to master with
+    # RELEASE_TOKEN, which DOES re-trigger this `push: master` workflow. Without
+    # a guard that would loop forever. We skip the job when the head commit
+    # message contains "chore(release):" (our bump commit) or "[skip ci]".
+    #
+    # `[skip ci]` alone does NOT stop GitHub Actions (that token is honoured by
+    # some other CI systems, not Actions), so this explicit `if:` is what
+    # actually breaks the loop. We check both tokens for defence in depth.
+    if: >-
+      ${{
+        !contains(github.event.head_commit.message, 'chore(release):') &&
+        !contains(github.event.head_commit.message, '[skip ci]')
+      }}
+
+    # contents: write covers tag/release creation via GITHUB_TOKEN; the push to
+    # protected master is authenticated separately by RELEASE_TOKEN (see below).
     permissions:
       contents: write
 
     steps:
       # Step 1: Checkout the repository with full git history
-      # fetch-depth: 0 ensures we get all commits and tags, not just the latest
+      # ----------------------------------------------------------------------
+      # fetch-depth: 0 gives full history + tags. We check out master because we
+      # commit the bump back to it, and we authenticate with RELEASE_TOKEN so the
+      # later push can bypass the branch ruleset. actions/checkout persists this
+      # token in the local git config, so the `git push` in the bump step uses it
+      # automatically.
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history and tags for proper version detection
+          fetch-depth: 0                      # Full history + tags
+          ref: master                         # We push the bump back here
+          token: ${{ secrets.RELEASE_TOKEN }} # Bypass-capable identity (admin PAT)
 
       # Step 2: Force fetch all tags from remote
       # This ensures we have the latest tags even if checkout missed some
@@ -128,13 +175,19 @@ jobs:
             echo "current_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           fi
 
-      # Step 4: Analyze commits and create new version tag
-      # This action reads commits since the last tag and determines version bump
-      # based on conventional commit messages. It tags the current HEAD of master
-      # and pushes only the tag ref (no branch push), so the master branch ruleset
-      # is not involved.
-      - name: Bump version and push tag
-        id: tag_version
+      # Step 4: DRY RUN — compute the next version WITHOUT creating a tag
+      # ----------------------------------------------------------------------
+      # We compute the next version first so we can bump composer.json and commit
+      # it BEFORE the real tag is created — guaranteeing the tag points at a
+      # commit whose composer.json already carries the correct version.
+      #
+      # Outputs of interest (only set when there is something to release):
+      #   new_tag      → e.g. "v2.0.13" (with tag_prefix)
+      #   new_version  → e.g. "2.0.13"  (without prefix) — used for composer.json
+      #   changelog    → conventional changelog since the previous tag
+      #   release_type → major | minor | patch (for logging)
+      - name: Compute next version (dry run)
+        id: dry_run
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -143,21 +196,71 @@ jobs:
           pre_release_branches: develop,beta  # Mark tags from these branches as pre-release
           tag_prefix: v                    # Maintain 'v' prefix (e.g., v2.0.4)
           fetch_all_tags: true             # Ensure all tags are fetched for accurate versioning
+          dry_run: true                    # IMPORTANT: do not create the tag yet
 
-          # Conventional Commit Rules:
-          # -------------------------
-          # feat: new feature               → MINOR bump (v2.0.4 → v2.1.0)
-          # fix: bug fix                    → PATCH bump (v2.0.4 → v2.0.5)
-          # feat!: or BREAKING CHANGE:      → MAJOR bump (v2.0.4 → v3.0.0)
-          # docs:, style:, refactor:, etc.  → NO bump (no tag created)
-          #
-          # Examples:
-          # - "feat: add address validation" → v2.0.4 becomes v2.1.0
-          # - "fix: correct postcode logic"  → v2.0.4 becomes v2.0.5
-          # - "feat!: redesign API"          → v2.0.4 becomes v3.0.0
+      # Step 5: Bump composer.json and commit it to master
+      # ----------------------------------------------------------------------
+      # Only runs when the dry run computed a new version. We set the "version"
+      # field to the numeric version (no 'v' prefix) with jq, then commit + push
+      # to master using the RELEASE_TOKEN persisted by checkout.
+      #
+      # The commit message contains BOTH "chore(release):" and "[skip ci]" — the
+      # exact tokens the job-level `if:` guard checks for — so the run this push
+      # triggers will skip both jobs and not loop.
+      - name: Bump composer.json version and commit
+        id: bump
+        if: steps.dry_run.outputs.new_version != ''
+        env:
+          NEW_TAG: ${{ steps.dry_run.outputs.new_tag }}
+          NEW_VERSION: ${{ steps.dry_run.outputs.new_version }}
+        run: |
+          echo "Setting composer.json version to: $NEW_VERSION"
 
-      # Step 5: Display version information in workflow logs
-      # This helps with debugging and provides visibility into what changed
+          # Rewrite the "version" field atomically via a temp file so a failure
+          # never leaves a half-written composer.json.
+          jq --arg v "$NEW_VERSION" '.version = $v' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
+          echo "composer.json now reads:"
+          grep '"version"' composer.json
+
+          # Commit identity (cosmetic — the push is authenticated by RELEASE_TOKEN,
+          # which is what determines ruleset bypass).
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add composer.json
+
+          # Only commit if something actually changed.
+          if git diff --cached --quiet; then
+            echo "composer.json already at $NEW_VERSION — nothing to commit."
+          else
+            git commit -m "chore(release): set composer.json version to ${NEW_TAG} [skip ci]"
+            git push origin master
+            echo "Pushed composer.json bump commit to master."
+          fi
+
+      # Step 6: Create the REAL tag on the (now bumped) HEAD of master
+      # ----------------------------------------------------------------------
+      # We pass `custom_tag` set to the version computed in the dry run so the
+      # action tags EXACTLY that version. This is critical: a fresh commit
+      # analysis would now also see our new "chore(release): ..." commit and,
+      # with default_bump: patch, could compute a different (higher) version.
+      # `custom_tag` overrides all bump calculation.
+      #
+      # `custom_tag` takes the version WITHOUT the prefix; the action re-applies
+      # `tag_prefix`, so `new_tag` here is still e.g. "v2.0.13".
+      - name: Create version tag
+        id: tag_version
+        if: steps.dry_run.outputs.new_version != ''
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: v
+          fetch_all_tags: true
+          custom_tag: ${{ steps.dry_run.outputs.new_version }}  # Force the computed version
+
+      # Step 7: Display version information in workflow logs
       - name: Display version information
         if: steps.tag_version.outputs.new_tag != ''
         run: |
@@ -166,18 +269,18 @@ jobs:
           echo "========================================="
           echo "Previous tag: ${{ steps.get_latest_tag.outputs.current_tag }}"
           echo "New tag created: ${{ steps.tag_version.outputs.new_tag }}"
-          echo "Version bump type: ${{ steps.tag_version.outputs.release_type }}"
+          echo "Version bump type: ${{ steps.dry_run.outputs.release_type }}"
+          echo "composer.json version: ${{ steps.dry_run.outputs.new_version }}"
           echo "========================================="
 
-      # Step 6: Create a GitHub release with changelog
-      # This creates a release page on GitHub with auto-generated notes
-      # from conventional commits. The auto-release.yml workflow then attaches the
-      # packaged zip (with an aligned composer.json) to this same release.
+      # Step 8: Create a GitHub release with changelog
+      # The auto-release.yml workflow then attaches the packaged zip to this
+      # release. We use the changelog computed during the dry run.
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         if: steps.tag_version.outputs.new_tag != ''
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}          # Use the newly created tag
           name: Release ${{ steps.tag_version.outputs.new_tag }} # Release title
-          body: ${{ steps.tag_version.outputs.changelog }}       # Auto-generated changelog
+          body: ${{ steps.dry_run.outputs.changelog }}           # Auto-generated changelog
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

`composer.json` on `master` is stuck at `2.0.10` while the latest tag is `v2.0.12` — visible drift at https://github.com/loqate/loqate-magento/blob/master/composer.json. The released *zip* is already correct (PR #33), but the **source file on `master` never changes**.

## Fix

On merge to master, `auto-tag.yml` now commits the version bump onto `master` itself:

1. Dry-run the tag action → compute the next version (no tag yet).
2. Rewrite `composer.json`'s `version` with `jq`, commit it, **push to master**.
3. Tag that commit with `custom_tag` (so the extra commit can't inflate the version).
4. Create the release; `auto-release.yml` attaches the zip.

After this, `master/composer.json` always shows the latest released version — no drift.

## ⚠️ One-time setup: `RELEASE_TOKEN` secret

`master` is protected by the **"Main Branch Protection"** ruleset (`pull_request` rule). Rulesets gate by **who pushes, not token scope**, so the default `GITHUB_TOKEN` — even with `contents: write` — is rejected (`GH013`); `github-actions[bot]` isn't on the bypass list.

The bypass list already contains **Org admins** and the **Admin repo role**, so the lightest fix is a PAT owned by an admin (**no ruleset edit, no GitHub App**):

1. An admin creates a **fine-grained PAT**: repository `loqate-magento`, permission **Contents: Read and write**.
2. Add it as repo **secret** `RELEASE_TOKEN`.

The push is attributed to that admin user, who bypasses the rule. (If you'd prefer a non-personal credential, a GitHub App added to the bypass list works too — say the word and I'll switch the YAML to `actions/create-github-app-token`.)

> If `RELEASE_TOKEN` is missing/unauthorized, only the push step fails — the merge itself is unaffected, and no bad tag is produced.

## Loop safety

A `RELEASE_TOKEN` push **re-triggers** `push: master`. The bump commit message carries `chore(release):` + `[skip ci]`, and **both jobs** have an `if:` guard skipping those messages, so the triggered run is a clean no-op. This guard is the only loop-breaker and must stay.

## Notes

- Unit-test gate preserved (`tag` `needs: unit-tests`).
- `auto-release.yml`'s `jq` step (from #33) is left as a harmless safety net; the tagged commit now already carries the right version.
- Validated locally: YAML parses, both jobs guarded, `RELEASE_TOKEN` wired into checkout.