### PR TITLE
ci: exclude Test dir from release & only release on feat/fix/breaking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+<!--
+  PR title should follow Conventional Commits, e.g.:
+    feat: add address autocomplete to checkout
+    fix: prevent duplicate API calls on field blur
+  Include the Jira key where relevant, e.g. "LOQ-1234: ...".
+-->
+
+## 🎫 Jira ticket
+
+<!-- Link the ticket, e.g. [LOQ-1234](https://gbgplc.atlassian.net/browse/LOQ-1234) -->
+
+## 📝 Description
+
+<!-- Why is this change needed? What problem does it solve? Context for the reviewer. -->
+
+## 🔧 What changed
+
+<!-- Bullet the concrete changes. Call out anything risky or non-obvious. -->
+
+-
+-
+
+## ✅ Tests
+
+- [ ] Unit tests pass locally (`vendor/bin/phpunit`)
+- [ ] New/changed behaviour is covered by tests
+- [ ] Manually verified the change (describe how below, if applicable)
+
+<!-- Notes on what you tested and the results: -->
+
+## 📦 Conventional commits & versioning
+
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] I understand the version impact of this PR:
+  - `feat:` → **minor** bump · `fix:` → **patch** bump · `BREAKING CHANGE` → **major** bump
+  - other types (`chore:`, `docs:`, `ci:`, `refactor:`, `test:`, …) → **no release**
+
+## 👀 Reviewer checklist
+
+- [ ] Code is readable and follows the conventions of the surrounding code
+- [ ] Change matches the linked Jira ticket's scope (no unrelated changes)
+- [ ] Tests are present and meaningful; CI is green
+- [ ] Commit messages / PR title are correct Conventional Commits
+- [ ] No secrets, credentials, or debug code committed

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -105,7 +105,8 @@ jobs:
             -x "*.git*" \
             -x "*.devcontainer/*" \
             -x ".github/*" \
-            -x ".gitignore"
+            -x ".gitignore" \
+            -x "Test/*"
           
           # Verify zip was created
           if [ -f "$ZIP_NAME" ]; then

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -191,7 +191,8 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          default_bump: patch              # Default to patch bump if no conventional commit found
+          default_bump: false              # Do NOT bump when no feat/fix/BREAKING CHANGE commit is found
+                                           # (without this it defaults to 'patch' and releases on every commit)
           release_branches: master         # Only create tags from master branch
           pre_release_branches: develop,beta  # Mark tags from these branches as pre-release
           tag_prefix: v                    # Maintain 'v' prefix (e.g., v2.0.4)

--- a/README.md
+++ b/README.md
@@ -146,6 +146,6 @@ The Git tag for a Composer release is created automatically. When changes are me
 - `feat!:` or `BREAKING CHANGE:` → **MAJOR** bump (e.g. `v2.0.4` → `v3.0.0`)
 - Other types (`docs:`, `style:`, `refactor:`, etc.) → no bump (no tag created)
 
-If no conventional commit is found, the action defaults to a **PATCH** bump. The workflow also publishes a GitHub release with an auto-generated changelog. Once the new tag is pushed, Composer will automatically detect it and make the release available on [packagist](https://packagist.org/packages/lqt/loqate-integration).
+If none of the commits since the previous tag are `feat:`, `fix:`, or a breaking change, **no tag is created and no release is published** — so commits like `docs:`, `chore:`, `ci:`, `refactor:`, etc. can be merged to `master` without cutting a release. When a release *is* cut, the workflow also publishes a GitHub release with an auto-generated changelog. Once the new tag is pushed, Composer will automatically detect it and make the release available on [packagist](https://packagist.org/packages/lqt/loqate-integration).
 
 To ensure a release is tagged correctly, make sure your commit messages follow the Conventional Commits format.


### PR DESCRIPTION
## 🎫 Jira ticket

_N/A — CI/release tooling maintenance._

## 📝 Description

Two CI/release issues plus a repo-hygiene addition:

1. The release zip was shipping the `Test/` directory to end users.
2. **Every** merge to master cut a new patch release, even for non-release commit types (`chore`, `docs`, `ci`, …), because the tagging action defaulted to `default_bump: patch`. This contradicted the documented rule (`Other types → No version bump`).
3. The repo had no PR template.

## 🔧 What changed

- **`auto-release.yml`** — exclude `Test/*` from the packaged release zip.
- **`auto-tag.yml`** — set `default_bump: false` so only `feat:` (minor), `fix:` (patch), and `BREAKING CHANGE` (major) trigger a bump/tag/release. All other commit types now produce no release (steps 5/6/8 already gate on `new_version != ''`).
- **`pull_request_template.md`** — new template covering Jira ticket, description, what changed, tests, conventional-commit/version impact, and a reviewer checklist.

## ✅ Tests

- [x] No application code changed — CI config + docs only.
- N/A for unit tests; behaviour is exercised by the workflows themselves on merge.

## 📦 Conventional commits & versioning

- [x] Commits follow Conventional Commits (`ci:`, `docs:`).
- [x] These are `ci:`/`docs:` commits → **no release** is cut from this PR (which is also the fix being shipped).

## 👀 Reviewer checklist

- [ ] `default_bump: false` is the intended behaviour (no release on chore/docs/ci/etc.)
- [ ] `Test/*` exclusion pattern matches the zip's working directory layout
- [ ] PR template renders correctly on a new PR after merge to master

> Note: both the template and the `default_bump` change only take effect once merged to `master`.