### PR TITLE
fix: align module.xml setup_version and pin api-connector for 2.4.9 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "version": "2.0.14",
   "require": {
-    "lqt/api-connector": "*"
+    "lqt/api-connector": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^11.5"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Loqate_ApiIntegration" setup_version="2.0.10">
+    <module name="Loqate_ApiIntegration" setup_version="2.0.14">
     </module>
 </config>


### PR DESCRIPTION
## 🎫 Jira ticket

[LOQ-15779](https://gbg.atlassian.net/browse/LOQ-15779)

## 📝 Description

Check and update compatibility with Adobe Commerce 2.4.9

## 🔧 What changed

Nothing serious, only recommendations about the module export and the api connector

## ✅ Tests

- [x] Unit tests pass locally (`vendor/bin/phpunit`)
- [ ] New/changed behaviour is covered by tests
- [ ] Manually verified the change (describe how below, if applicable)


## 📦 Conventional commits & versioning

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I understand the version impact of this PR:
  - `feat:` → **minor** bump · `fix:` → **patch** bump · `BREAKING CHANGE` → **major** bump
  - other types (`chore:`, `docs:`, `ci:`, `refactor:`, `test:`, …) → **no release**

## 👀 Reviewer checklist

- [ ] Code is readable and follows the conventions of the surrounding code
- [ ] Change matches the linked Jira ticket's scope (no unrelated changes)
- [ ] Tests are present and meaningful; CI is green
- [ ] Commit messages / PR title are correct Conventional Commits
- [ ] No secrets, credentials, or debug code committed
