### PR TITLE
fix(LOQ-15854): remove eval() from pca.parseJSON to fix CSP unsafe-eval on Hyva Checkout

### DIFF
--- a/view/base/web/capture.js
+++ b/view/base/web/capture.js
@@ -2916,7 +2916,7 @@
               .replace(/(?:^|:|,)(?:\s*\[)+/g, "")
           )
         )
-          return typeof JSON != "undefined" ? JSON.parse(text) : eval(text);
+          return JSON.parse(text);
 
         return {};
       };


### PR DESCRIPTION
## Summary

- Removes the legacy `eval(text)` fallback from the `pca.parseJSON` helper in `capture.js`
- The fallback was a dead-code path targeting IE8 (which had no native `JSON`); all Magento 2-supported browsers have `window.JSON`
- Leaving `eval()` in the bundle causes browsers enforcing a strict CSP (`unsafe-eval` not in `script-src`) to throw an `EvalError` when `capture.js` is loaded — reproducible on the Hyva Checkout page

## Root cause (LOQ-15854)

Customers running a tight CSP (such as the one reproduced in the JIRA, which includes no `unsafe-eval` source) see the following error when `capture.js` is loaded on the Hyva Checkout page:

```
Uncaught (in promise) EvalError: Evaluating a string as JavaScript violates
the following Content Security Policy directive because 'unsafe-eval' is not
an allowed source of script: …
  at Object.initialize (node_initializer.js:11:21)
```

The Alpine.js `node_initializer.js` frame is a red herring caused by the error being thrown asynchronously during checkout-step initialisation. The actual `eval()` site is `pca.parseJSON` in our `capture.js`.

## Fix

```diff
-  return typeof JSON != "undefined" ? JSON.parse(text) : eval(text);
+  return JSON.parse(text);
```

`JSON.parse` is always available; the ternary guard and the `eval` branch are no longer needed.

## Additional context

Customers who have also installed `hyva-themes/magento2-hyva-checkout-loqate` should remove it — that package was built against the old `loqate-integration/adobe` package and is not compatible with `gbg-loqate/loqate-integration` v2+. See `CLIENT_NEEDS_TODO.md` for the full migration checklist.

## Test plan

- [ ] Load the Hyva Checkout page with a CSP that excludes `unsafe-eval`; confirm no EvalError is thrown when `capture.js` loads
- [ ] Verify the address autocomplete still works end-to-end (find + retrieve) on Hyva Checkout
- [ ] Verify standard Luma checkout still works (no regression)
- [ ] Confirm `pca.parseJSON` correctly parses valid JSON strings (unit test or browser console check)

Closes LOQ-15854