### PR TITLE
fix(LOQ-16976): dedupe batch verify, then bound and correctly key the verdict caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 composer.lock
 /.phpunit.cache/
 .phpunit.result.cache
+
+# Local code-review reports — working notes, not product
+/.naas/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this module are documented here.
+
+This file starts at the LOQ-16969 series; releases up to and including v2.0.17
+predate it and are described by their git tags and commit history.
+
+## [Unreleased]
+
+### Changed — behaviour
+
+- **Admin order create is no longer AVC-checked, and obeys only the
+  "Enable on Create Order (Admin)" toggles.** `Observer\QuoteSubmitBefore` now
+  returns early in the admin area. Previously an admin-created order was checked
+  twice — against the address quality index through `Plugin\Admin\OrderSave`, and
+  against the AVC through that observer — which billed up to two extra
+  single-address Cleansing requests per order on top of the batch call, and the two
+  paths cannot share a verdict because they judge different thresholds.
+
+  **Action required if you run "Enable on Create Order (Admin)" = No together with
+  "Enable on Checkout" = Yes** (for Address Settings or Phone Settings). In that
+  combination the observer had been the only thing verifying admin-created orders,
+  so nothing verifies them now. Set "Enable on Create Order (Admin)" to Yes to keep
+  verifying them. The admin now raises a system message naming the affected settings
+  whenever it detects this combination.
+
+- **An unrecognised "Address Quality Index" now rejects addresses instead of
+  accepting all of them.** The threshold is compared as a string, so any value
+  sorting above `E` — a lowercase `c`, a `C+`, or any stray text — previously passed
+  every address on the batch paths, including the worst grade Loqate returns. Valid
+  values are `A` to `E`; anything else is refused and logged. The setting has no
+  admin field, so this only affects installs that wrote it via a data patch,
+  `config:set`, or direct SQL.
+
+### Fixed
+
+- Repeated billable `/Cleansing/International/Batch` requests for the same address
+  in one session, at checkout and on admin order create (LOQ-16969, LOQ-16976).
+  Verify verdicts are cached per shopper for the session, keyed on the region value
+  actually sent to Loqate.
+- Multi-address verification results were collapsed onto the first row, so one
+  address's verdict could be reported against another's (LOQ-16977).
+- A cached verify success could be replayed for a region that was never verified
+  (LOQ-16979).
+- A mid-import API failure crashed the customer import with a 500 instead of
+  degrading: `array_merge()` received `false` and raised a `TypeError`, which the
+  surrounding `catch (\Exception)` could not catch.
+- The `captured_addresses` session store grew without limit for the whole session,
+  and its verify bypass survived a logout/login on a shared browser. It is now
+  bounded to 50 entries with FIFO eviction, and it and both verdict caches are
+  flushed when the logged-in customer changes (LOQ-16978).
+
+### Known limitations
+
+- Repeat-request dedupe is near-nil on the **customer import** path: the batch cache
+  holds 200 entries, and only passing verdicts are cached, so re-running a large
+  file yields few hits (LOQ-17148).
+- `loqate_email`, `loqate_phone`, `loqate_email_to_validate` and
+  `loqate_billing_errors` are still unbounded session stores and are not covered by
+  the shopper-change flush (LOQ-17149).
+- The shopper-change flush scopes by **customer** identity, so an admin-user swap
+  within one browser session is not covered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ predate it and are described by their git tags and commit history.
   admin field, so this only affects installs that wrote it via a data patch,
   `config:set`, or direct SQL.
 
+- **A customer import can now fail where it previously continued silently.** The
+  import plugin used to absorb every exception and hand back an untouched result,
+  which meant a misconfiguration inside the module surfaced as an import reporting
+  no address errors at all — indistinguishable from a clean file. It now lets
+  `\InvalidArgumentException` through. In practice that is the module reporting a
+  programming error, but a core or third-party `\InvalidArgumentException` raised
+  during verification will now fail the import rather than pass it silently. Genuine
+  runtime faults — transport, connector, unreadable source file — are still absorbed
+  as before.
+
 ### Fixed
 
 - Repeated billable `/Cleansing/International/Batch` requests for the same address
@@ -59,4 +69,4 @@ predate it and are described by their git tags and commit history.
   `loqate_billing_errors` are still unbounded session stores and are not covered by
   the shopper-change flush (LOQ-17149).
 - The shopper-change flush scopes by **customer** identity, so an admin-user swap
-  within one browser session is not covered.
+  within one browser session is not covered. Decided as part of LOQ-17149.

--- a/Helper/Controller.php
+++ b/Helper/Controller.php
@@ -21,6 +21,39 @@ class Controller
 {
     const MAX_DATA_SETS_FIELDS = 20;
 
+    /**
+     * Session attribute holding the addresses picked from the Loqate Capture lookup.
+     *
+     * An ALIAS of ShopperScopedSession::CAPTURED_ADDRESSES_SESSION_KEY, kept so that every
+     * existing reference to Controller::CAPTURED_ADDRESSES_SESSION_KEY still resolves. The
+     * name itself lives on ShopperScopedSession because that class is what ENFORCES the
+     * attribute's lifetime, and holding the name here instead made the dependency circular:
+     * the guard's flush list pointed at this class while this class constructs the guard
+     * (LOQ-16978 review). This class remains the store's only WRITER
+     * (storeCapturedAddress()); Helper\Validator is its only reader.
+     */
+    const CAPTURED_ADDRESSES_SESSION_KEY = ShopperScopedSession::CAPTURED_ADDRESSES_SESSION_KEY;
+
+    /**
+     * Maximum number of captured addresses kept per session, oldest evicted first.
+     *
+     * 50, the same bound as Validator::VERIFY_CACHE_LIMIT and for the same reasons, not
+     * the 200 of Validator::BATCH_VERIFY_CACHE_LIMIT. That larger figure exists solely to
+     * hold a customer-import chunk of 100 rows
+     * (Plugin\Admin\ValidateImportAddress.php:50), and no import writes this store: its
+     * only writer is Controller::retrieve(), i.e. a shopper or an admin PICKING an address
+     * from the Capture lookup by hand. One interactive session picks a handful of
+     * addresses - a shipping and a billing address, plus re-picks - so 50 distinct
+     * addresses is already far beyond a realistic session while keeping the session
+     * payload to a few kilobytes (one entry is a serialised six-field array).
+     *
+     * The two stores are also consulted for the SAME addresses by the same verify call
+     * (Validator::verifyAddress() reads this one first, then the verdict cache), so a
+     * different bound on each would only mean one of them holding entries the other has
+     * long since evicted.
+     */
+    const CAPTURED_ADDRESSES_LIMIT = 50;
+
     /** @var Capture $apiConnector */
     private $apiConnector;
 
@@ -33,8 +66,13 @@ class Controller
     /** @var Logger $logger */
     private $logger;
 
-    /** @var Session $session */
-    private $session;
+    /**
+     * @var ShopperScopedSession The captured-address store, behind the shopper-ownership
+     *      guard. The raw customer session is deliberately NOT kept as well: keeping it
+     *      would leave a way to reach the store without the guard - see
+     *      ShopperScopedSession.
+     */
+    private ShopperScopedSession $shopperSession;
 
     /** @var string */
     private $version = null;
@@ -51,9 +89,12 @@ class Controller
      * @param ResultFactory $resultJsonFactory
      * @param RequestInterface $request
      * @param Logger $logger
-     * @param Session $session
+     * @param Session $session Wrapped in a ShopperScopedSession and not kept raw, so the
+     *                         captured-address store can only be reached through the
+     *                         shopper-ownership guard.
      * @param ModuleListInterface $moduleList
      * @param Data $helper
+     * @param SerializerInterface $serializer
      */
     public function __construct(
         ResultFactory $resultJsonFactory,
@@ -67,7 +108,7 @@ class Controller
         $this->resultJsonFactory = $resultJsonFactory;
         $this->request = $request;
         $this->logger = $logger;
-        $this->session = $session;
+        $this->shopperSession = new ShopperScopedSession($session);
         $this->helper = $helper;
         $this->serializer = $serializer;
 
@@ -166,13 +207,33 @@ class Controller
     /**
      * Store captured address in session so verify is not performed if the address hasn't changed
      *
-     * This is the ONLY writer of "captured_addresses", which is why that bypass only ever
-     * applied to addresses picked from the Loqate lookup - addresses Loqate itself
-     * authored - and not to typed ones (see Validator::verifyAddress()).
+     * This is the ONLY writer of self::CAPTURED_ADDRESSES_SESSION_KEY, which is why that
+     * bypass only ever applied to addresses picked from the Loqate lookup - addresses
+     * Loqate itself authored - and not to typed ones (see Validator::verifyAddress()).
      *
-     * The store is unbounded: it grows for the whole session, one serialised address per
-     * retrieve, inflating the session payload. Bounding it is tracked as LOQ-16978;
-     * Validator::VERIFY_CACHE_LIMIT deliberately does not repeat the pattern.
+     * SCOPE AND LIFETIME OF THE STORE (LOQ-16978):
+     *  - BOUNDED to self::CAPTURED_ADDRESSES_LIMIT entries, evicted FIFO - oldest first -
+     *    exactly as Validator::storeVerifyResult() and Validator::storeBatchVerifyResult()
+     *    bound the two verdict caches. The address currently being checked out is the one
+     *    just captured, so it is always the newest entry and can never be the one evicted;
+     *  - re-capturing an address already in the store MOVES it to the newest position
+     *    instead of adding a copy, so repeatedly picking one address cannot fill the store
+     *    and evict every other address in it. "Already in the store" is decided by
+     *    Validator::capturedAddressSignature(), the SAME relation
+     *    Validator::checkForCapturedAddress() grants the bypass on, so for every address
+     *    the matcher CAN identify the store holds one slot and the guarantee above
+     *    actually holds - see the comment on the de-duplication below for what byte
+     *    comparison missed. Addresses the matcher identifies as nothing at all (signature
+     *    '', an entry with no identifiable content) are the documented exception: they
+     *    never match anything, so they are collapsed only when they are byte-identical
+     *    and a store can hold several of them - see isSameCapturedAddress();
+     *  - lives in the per-shopper customer session and nowhere process- or install-wide,
+     *    because "Loqate authored this address" is a statement about one shopper's
+     *    lookup, and it dies with the session;
+     *  - FLUSHED when the logged-in customer changes, in either direction (login, logout,
+     *    or one login straight after another): the store is reached through
+     *    ShopperScopedSession, so shopper B on a shared browser cannot inherit the
+     *    verify bypass shopper A earned. Read that class before adding a fourth store.
      *
      * @param $result
      */
@@ -183,14 +244,125 @@ class Controller
             $storeArray[$key] = $result[$value];
         }
 
-        $capturedAddresses = (
-            $this->session->getData('captured_addresses')
-            ? $this->session->getData('captured_addresses')
-            : []
-        );
+        $capturedAddresses = $this->shopperSession->getData(self::CAPTURED_ADDRESSES_SESSION_KEY);
+        if (!is_array($capturedAddresses)) {
+            // Covers the empty session and, defensively, an attribute another module or a
+            // truncated payload left in a shape this store cannot append to.
+            $capturedAddresses = [];
+        }
 
-        $capturedAddresses[] = $this->serializer->serialize($storeArray);
-        $this->session->setData('captured_addresses', $capturedAddresses);
+        $entry = $this->serializer->serialize($storeArray);
+        $signature = Validator::capturedAddressSignature($storeArray);
+
+        // Drop every existing copy of this address first, then re-append - the same move
+        // Validator::storeVerifyResult() makes with unset($store[$key]), and for the same
+        // two reasons: the refreshed entry becomes the newest rather than keeping the age
+        // of the one it replaces, and the store shrinks before the eviction loop, so
+        // re-capturing an address while the store is FULL does not cost an unrelated
+        // address its bypass.
+        //
+        // "The same address" is decided by Validator::capturedAddressSignature(), NOT by
+        // the serialised bytes (LOQ-16978 review). It has to be the matcher's own relation:
+        // Validator::checkForCapturedAddress() grants the bypass on the normalised,
+        // upper-cased, whitespace-collapsed projection of FIVE fields, while these entries
+        // serialise SIX raw ones. Comparing bytes therefore counted two captures that
+        // differ only in case, in whitespace, in ProvinceName - excluded from the signature
+        // altogether, and rewritten routinely by capture.js, see buildAddressSignature() -
+        // or in ''-versus-missing Line2 as TWO entries, though the store grants them ONE
+        // bypass. That is precisely how re-picking a single address could still fill a
+        // bounded store and evict every other address in it. De-duplicating on the
+        // signature makes the store self-consistent with the bypass it grants: one slot for
+        // each address the matcher can identify.
+        //
+        // The byte comparison is kept as the first test inside isSameCapturedAddress(): it
+        // is free, and it is the only thing that can de-duplicate an entry with no
+        // identifiable content, whose signature is '' and which the matcher never matches.
+        // Those entries are therefore the one case where the store can hold several slots
+        // the matcher does not distinguish - it distinguishes none of them, and collapsing
+        // them onto one another would be asserting an equality nothing else in the module
+        // grants. They cost slots and no bypass, which is the safe direction.
+        $capturedAddresses = array_values(array_filter(
+            $capturedAddresses,
+            fn ($stored): bool => !$this->isSameCapturedAddress($stored, $entry, $signature)
+        ));
+
+        // FIFO eviction, mirroring the two verdict caches. Unlike theirs, the keys here are
+        // integers, so array_shift() renumbers them - which is what a list wants. The
+        // re-indexing above is a separate concern: array_filter() PRESERVES keys, so
+        // without array_values() the store would keep a hole and the [] append below would
+        // use max+1, leaving a sparse array that count() and the readers would still
+        // process but that no longer round-trips as a JSON list. The
+        // $capturedAddresses !== [] guard keeps the loop terminating even if the limit is
+        // ever set to 0 or below, where shifting an already-empty array would otherwise
+        // spin forever inside a Capture request.
+        while ($capturedAddresses !== [] && count($capturedAddresses) >= self::CAPTURED_ADDRESSES_LIMIT) {
+            array_shift($capturedAddresses);
+        }
+
+        $capturedAddresses[] = $entry;
+        $this->shopperSession->setData(self::CAPTURED_ADDRESSES_SESSION_KEY, $capturedAddresses);
+    }
+
+    /**
+     * Is $stored the same captured address as the one being stored?
+     *
+     * Same relation as Validator::checkForCapturedAddress(), which is the whole point - see
+     * the comment in storeCapturedAddress(). Byte equality is tested first because it is
+     * free and because it is the only thing that can collapse an entry whose signature is
+     * '' (an address with nothing identifiable in it), which the matcher deliberately never
+     * matches and which must therefore never be collapsed onto another empty-ish address.
+     *
+     * @param mixed $stored Entry already in the store: normally a serialised address, but
+     *                      this attribute is a bare session key and may hold anything.
+     * @param string $entry Serialised form of the address being stored.
+     * @param string $signature Its captured-address signature, '' when unidentifiable.
+     * @return bool
+     */
+    private function isSameCapturedAddress($stored, string $entry, string $signature): bool
+    {
+        if (!is_string($stored)) {
+            // Not something this class wrote. Left in place rather than dropped: pruning
+            // foreign values is not this method's job, and Validator::checkForCapturedAddress()
+            // already skips anything it cannot read - it carries the mirror of THIS guard
+            // (`if (!is_string($stored)) { continue; }`) ahead of its own unserialize(), for
+            // the reason spelled out there: json_decode() is typed `string $json`, so handing
+            // it an array element is a TypeError rather than the \InvalidArgumentException
+            // that method catches. Keep the two in step; a value one reader survives and the
+            // other fatals on is the asymmetry both guards exist to close.
+            return false;
+        }
+
+        if ($stored === $entry) {
+            return true;
+        }
+
+        if ($signature === '') {
+            return false;
+        }
+
+        return $this->capturedEntrySignature($stored) === $signature;
+    }
+
+    /**
+     * The captured-address signature of an entry already in the store.
+     *
+     * Defensive in exactly the way Validator::checkForCapturedAddress() is, and for the
+     * same reason: this runs inside a Capture retrieve request, while the shopper is
+     * picking their address, so an entry left by an older release, a truncated session
+     * payload or another module must cost a de-duplication - never a fatal.
+     *
+     * @param string $stored Serialised entry from the store.
+     * @return string '' when the entry cannot be read back as an address.
+     */
+    private function capturedEntrySignature(string $stored): string
+    {
+        try {
+            $decoded = $this->serializer->unserialize($stored);
+        } catch (\InvalidArgumentException $e) {
+            return '';
+        }
+
+        return is_array($decoded) ? Validator::capturedAddressSignature($decoded) : '';
     }
 
     protected function getEnhancedDataSetsFields()

--- a/Helper/Controller.php
+++ b/Helper/Controller.php
@@ -24,15 +24,15 @@ class Controller
     /**
      * Session attribute holding the addresses picked from the Loqate Capture lookup.
      *
-     * An ALIAS of ShopperScopedSession::CAPTURED_ADDRESSES_SESSION_KEY, kept so that every
+     * An ALIAS of ShopperScopedAddressStores::CAPTURED_ADDRESSES_SESSION_KEY, kept so that every
      * existing reference to Controller::CAPTURED_ADDRESSES_SESSION_KEY still resolves. The
-     * name itself lives on ShopperScopedSession because that class is what ENFORCES the
+     * name itself lives on ShopperScopedAddressStores because that class is what ENFORCES the
      * attribute's lifetime, and holding the name here instead made the dependency circular:
      * the guard's flush list pointed at this class while this class constructs the guard
      * (LOQ-16978 review). This class remains the store's only WRITER
      * (storeCapturedAddress()); Helper\Validator is its only reader.
      */
-    const CAPTURED_ADDRESSES_SESSION_KEY = ShopperScopedSession::CAPTURED_ADDRESSES_SESSION_KEY;
+    const CAPTURED_ADDRESSES_SESSION_KEY = ShopperScopedAddressStores::CAPTURED_ADDRESSES_SESSION_KEY;
 
     /**
      * Maximum number of captured addresses kept per session, oldest evicted first.
@@ -67,12 +67,12 @@ class Controller
     private $logger;
 
     /**
-     * @var ShopperScopedSession The captured-address store, behind the shopper-ownership
+     * @var ShopperScopedAddressStores The captured-address store, behind the shopper-ownership
      *      guard. The raw customer session is deliberately NOT kept as well: keeping it
      *      would leave a way to reach the store without the guard - see
-     *      ShopperScopedSession.
+     *      ShopperScopedAddressStores.
      */
-    private ShopperScopedSession $shopperSession;
+    private ShopperScopedAddressStores $shopperSession;
 
     /** @var string */
     private $version = null;
@@ -89,7 +89,7 @@ class Controller
      * @param ResultFactory $resultJsonFactory
      * @param RequestInterface $request
      * @param Logger $logger
-     * @param Session $session Wrapped in a ShopperScopedSession and not kept raw, so the
+     * @param Session $session Wrapped in a ShopperScopedAddressStores and not kept raw, so the
      *                         captured-address store can only be reached through the
      *                         shopper-ownership guard.
      * @param ModuleListInterface $moduleList
@@ -108,7 +108,7 @@ class Controller
         $this->resultJsonFactory = $resultJsonFactory;
         $this->request = $request;
         $this->logger = $logger;
-        $this->shopperSession = new ShopperScopedSession($session);
+        $this->shopperSession = new ShopperScopedAddressStores($session);
         $this->helper = $helper;
         $this->serializer = $serializer;
 
@@ -232,7 +232,7 @@ class Controller
      *    lookup, and it dies with the session;
      *  - FLUSHED when the logged-in customer changes, in either direction (login, logout,
      *    or one login straight after another): the store is reached through
-     *    ShopperScopedSession, so shopper B on a shared browser cannot inherit the
+     *    ShopperScopedAddressStores, so shopper B on a shared browser cannot inherit the
      *    verify bypass shopper A earned. Read that class before adding a fourth store.
      *
      * @param $result

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -81,4 +81,21 @@ class Data extends AbstractHelper
     {
         return $this->scopeConfig->getValue($configPath, ScopeInterface::SCOPE_STORE);
     }
+
+    /**
+     * Get config value as a NAMED store view resolves it.
+     *
+     * getConfigValue() reads SCOPE_STORE with no store, which resolves to whatever store is
+     * current - and in the admin area that is the default store, so a per-store-view override
+     * is invisible to it. Anything that has to reason about the configuration of stores OTHER
+     * than the current one has to name the store, which is what this is for.
+     *
+     * @param $configPath
+     * @param $storeId
+     * @return mixed
+     */
+    public function getConfigValueForStore($configPath, $storeId)
+    {
+        return $this->scopeConfig->getValue($configPath, ScopeInterface::SCOPE_STORE, $storeId);
+    }
 }

--- a/Helper/ShopperScopedAddressStores.php
+++ b/Helper/ShopperScopedAddressStores.php
@@ -109,7 +109,9 @@ use Magento\Customer\Model\Session;
  *
  * THE MODULE HAS OTHER SESSION ATTRIBUTES, and they are NOT enrolled here - named so the
  * next reader does not conclude there are only three. Out of scope for LOQ-16978, which is
- * about the ADDRESS stores; each needs its own assessment before it is added:
+ * about the ADDRESS stores. THIS IS TRACKED, NOT ACCEPTED: enrolling them is LOQ-17149,
+ * which also covers reducing the PII the first two hold and deciding the admin-identity gap
+ * below. Each needs its own assessment before it is added:
  *  - 'loqate_email' and 'loqate_phone', written by Plugin\AbstractPlugin::shouldVerify().
  *    Unbounded lists of raw email addresses and phone numbers that skip a billable
  *    verifyEmail()/verifyPhoneNumber(), so they are bypasses of the same kind AND hold PII;
@@ -270,18 +272,18 @@ class ShopperScopedAddressStores
      * an unenrolled key through these guards any more than this code can.) So the only way
      * to trip this is a NEW call inside this module passing an unenrolled key, which is a
      * programming error that must fail at the developer's first request rather than ship as
-     * a silent bypass. ONE PATH SOFTENS THAT, named so it is not read as a claim the code
-     * does not honour: Plugin\Admin\ValidateImportAddress::afterValidateData() wraps its
-     * work in catch (\Exception) and returns the result untouched, with no log - and that
-     * catch sits OUTSIDE the chunk loop, so the throw abandons the remaining chunks and the
-     * error-reporting loop with them. On that path the mistake therefore does not reach the
-     * developer as an exception; it surfaces as an import that reports no address errors at
-     * all. That is still a total failure of the import's address validation rather than an
-     * unguarded read - no store is reached and no row is granted a bypass - so the assertion
-     * is not a bypass anywhere, merely quieter here than the throw suggests. Logging and
-     * continuing was the alternative and was rejected: the continue path IS the unguarded
-     * access the assertion exists to prevent, so it would leave the defect in place and
-     * merely record it - and this class holds no logger to record it with.
+     * a silent bypass.
+     *
+     * Every path lets it out, including the import. Plugin\Admin\ValidateImportAddress::
+     * afterValidateData() used to wrap its work in a blanket catch (\Exception), which
+     * swallowed this throw and turned it into an import that silently reported no address
+     * errors at all; that plugin now catches \InvalidArgumentException separately and
+     * rethrows it, precisely so this assertion reaches a developer. Do not restore the broad
+     * catch on the strength of an older revision of this paragraph.
+     *
+     * Logging and continuing was the alternative and was rejected: the continue path IS the
+     * unguarded access the assertion exists to prevent, so it would leave the defect in place
+     * and merely record it - and this class holds no logger to record it with.
      *
      * @param string $key Attribute the caller is trying to reach.
      * @return void

--- a/Helper/ShopperScopedAddressStores.php
+++ b/Helper/ShopperScopedAddressStores.php
@@ -51,7 +51,7 @@ use Magento\Customer\Model\Session;
  * Controller::CAPTURED_ADDRESSES_SESSION_KEY, Validator::VERIFY_CACHE_SESSION_KEY and
  * Validator::BATCH_VERIFY_CACHE_SESSION_KEY are kept as ALIASES of the constants below, so
  * every existing reference to them still resolves - including
- * ShopperScopedSessionTest's assertion on the flush list - and the attribute VALUES are
+ * ShopperScopedAddressStoresTest's assertion on the flush list - and the attribute VALUES are
  * unchanged, so the four test files that pin these names as literals keep passing and no
  * live session loses its stores at deploy time.
  *
@@ -118,7 +118,7 @@ use Magento\Customer\Model\Session;
  *  - 'loqate_billing_errors' (Plugin\Frontend\CheckoutBillingAddress, read by
  *    Plugin\Frontend\PlaceOrder and PlaceOrderGuest) - a boolean gate on placing an order.
  */
-class ShopperScopedSession
+class ShopperScopedAddressStores
 {
     /**
      * Session attribute holding the addresses picked from the Loqate Capture lookup.
@@ -294,7 +294,7 @@ class ShopperScopedSession
         }
 
         throw new \InvalidArgumentException(sprintf(
-            'Session attribute "%s" is not enrolled in ShopperScopedSession::'
+            'Session attribute "%s" is not enrolled in ShopperScopedAddressStores::'
             . 'SHOPPER_SCOPED_SESSION_KEYS, so it would be reached through the shopper-ownership guard '
             . 'without ever being flushed when the shopper changes (LOQ-16978). Add it to that list, or '
             . 'use the raw customer session if the attribute genuinely is not shopper-scoped.',

--- a/Helper/ShopperScopedSession.php
+++ b/Helper/ShopperScopedSession.php
@@ -1,0 +1,393 @@
+<?php
+
+namespace Loqate\ApiIntegration\Helper;
+
+use Magento\Customer\Model\Session;
+
+/**
+ * The single gateway to every ADDRESS store this module keeps in the customer session,
+ * and the one place that enforces those stores belong to ONE shopper (LOQ-16978).
+ *
+ * WHY THIS EXISTS AT ALL. Three session attributes hold ADDRESS data that lets an address
+ * SKIP a billable Loqate verify - self::CAPTURED_ADDRESSES_SESSION_KEY (the capture
+ * bypass), self::VERIFY_CACHE_SESSION_KEY and self::BATCH_VERIFY_CACHE_SESSION_KEY (the
+ * LOQ-16969/LOQ-16976 verdict caches).
+ * A PHP session outlives a login: Magento calls session_regenerate_id() on login and on
+ * logout, and that changes the session ID while PRESERVING every value in $_SESSION. So
+ * on a shared browser - a family device, a public terminal, a click-and-collect kiosk -
+ * shopper B could inherit shopper A's bypasses and check out an address that was never
+ * verified against B's own submission. Nothing in Magento clears third-party session
+ * attributes on an identity change, so this class does it for the three ADDRESS stores
+ * listed in self::SHOPPER_SCOPED_SESSION_KEYS. It is NOT a general answer for every
+ * session attribute this module writes - see ADDING A FOURTH STORE below for the siblings
+ * it deliberately does not cover.
+ *
+ * HOW. Ownership is recorded in a sibling attribute (self::SESSION_OWNER_KEY) holding the
+ * customer id the stores belong to, with 0 (self::GUEST_OWNER_ID) standing for "not logged
+ * in". Every read and every write checks the live identity against that marker first, so
+ * BOTH transitions are covered - logged-in -> guest (logout) and guest -> logged-in
+ * (login), as well as A -> B where one login immediately follows another. The check is
+ * lazy rather than event-driven on purpose: an observer on customer_login/customer_logout
+ * would have to be registered, would miss any path that swaps the identity without firing
+ * those events (an admin "login as customer" hand-off, a session restored from a
+ * persistent-cart cookie), and would leave the invariant enforced somewhere other than
+ * where the data is read. Here it cannot be bypassed, because the raw session is private
+ * to this class and Controller/Validator no longer hold a reference to it.
+ *
+ * WHY A COLLABORATOR RATHER THAN A COPY IN EACH CLASS. The flush has to be identical in
+ * all three stores or it is worthless - flushing two of them still leaves the third
+ * granting B a bypass earned by A - and it is the kind of rule that rots when duplicated.
+ * It is constructed in Helper\Controller's and Helper\Validator's constructors from the
+ * customer Session they are already given, rather than injected, so neither class needs a
+ * new REQUIRED constructor argument (a break for anything extending them) and no DI
+ * wiring changes; both of those classes already build collaborators inline the same way
+ * (new Capture(), new Verify()).
+ *
+ * WHY THE ATTRIBUTE NAMES LIVE HERE and are only aliased on Controller/Validator
+ * (LOQ-16978 review). This class enforces the rule, so this class owns the list of names
+ * the rule applies to. Holding them anywhere else made the dependency circular - the flush
+ * list pointed at Controller:: and Validator::, while both of those classes construct this
+ * one - and put the names in a class that has no way to enforce anything about them.
+ * Controller::CAPTURED_ADDRESSES_SESSION_KEY, Validator::VERIFY_CACHE_SESSION_KEY and
+ * Validator::BATCH_VERIFY_CACHE_SESSION_KEY are kept as ALIASES of the constants below, so
+ * every existing reference to them still resolves - including
+ * ShopperScopedSessionTest's assertion on the flush list - and the attribute VALUES are
+ * unchanged, so the four test files that pin these names as literals keep passing and no
+ * live session loses its stores at deploy time.
+ *
+ * ADOPTION, stated so it is not mistaken for a hole. When NOTHING has been recorded yet,
+ * the current identity ADOPTS whatever is in the stores instead of flushing it. That case
+ * is reachable only for data written BEFORE this class existed, because from now on the
+ * marker is written on the first access of a session, long before anything can be stored.
+ * Adopted data was, by definition, written in THIS session - though not necessarily by
+ * whoever is at the browser NOW: a session that was already live at deploy time, in which
+ * shopper A logged out before the module's first post-release access, lands in the
+ * adoption branch and hands A's stores to the guest that follows. That is accepted rather
+ * than defended against, on three grounds: it is exactly the pre-change behaviour, so it
+ * is not a regression this ticket introduces; it is bounded to one release and to sessions
+ * that were mid-flight during it; and it closes the moment ANY identity change is observed
+ * after the marker is written. The alternative - flushing on first access - would buy
+ * nothing for every session started after the deploy and would throw away every live
+ * shopper's capture bypass at deploy time.
+ *
+ * ACCEPTED LIMITS, stated (the style of Validator::verifyMultipleAddresses()):
+ *  - THE GUARD SCOPES BY CUSTOMER IDENTITY ONLY. The marker tracks
+ *    Magento\Customer\Model\Session::getCustomerId() and nothing else. An ADMIN user swap
+ *    inside one browser session is therefore NOT covered, and that is not academic:
+ *    self::BATCH_VERIFY_CACHE_SESSION_KEY is written exclusively from adminhtml
+ *    (Plugin\Admin\OrderSave, Plugin\Admin\ValidateImportAddress), where the customer
+ *    session normally holds no customer id at all - so the owner there is permanently
+ *    self::GUEST_OWNER_ID and the flush is a no-op for that path.
+ *    WHAT THAT ACTUALLY COSTS, stated precisely so nobody "fixes" a non-defect: it is a
+ *    BILLING consequence, not a data-exposure one. If two admins share one browser session,
+ *    the second can be served a batch verdict the first paid for. That verdict is not the
+ *    first admin's judgement leaking into the second's: only PASSES are stored
+ *    (storeBatchVerifyResult() caches nothing else) and Validator::buildBatchVerifyCacheKey()
+ *    already namespaces every entry by store view and by a fingerprint of the configured AQI
+ *    threshold, so a replayed entry is a pure function of (address, store view, threshold) -
+ *    exactly the verdict the second admin would have earned by submitting that address
+ *    themselves. What is shared is the billable call, and saving billable calls is what the
+ *    cache is FOR. The backend auth session (Magento\Backend\Model\Auth\Session) is therefore
+ *    deliberately NOT injected to scope it: doing so would drag a backend dependency into a
+ *    helper that is constructed on every frontend checkout request, and the only thing it
+ *    would change is that the merchant pays a second time for a verdict that is identical
+ *    by construction. The shared-browser risk this ticket exists to close is a
+ *    SHOPPER-facing one and is fully covered.
+ *  - ALL UNREADABLE CUSTOMER IDS COLLAPSE ONTO ONE OWNER, see resolveOwnerId(). Two
+ *    successive identities that both present an unreadable id would share the stores. It
+ *    cannot collide with a guest or with a real customer, which is the collision that
+ *    mattered.
+ *  - CONCURRENCY: reading the marker, flushing and rewriting it are not atomic, exactly as
+ *    on the two caches this protects (see Validator::verifyAddress()). Two concurrent
+ *    requests straddling a login can both observe the old marker; the loser re-verifies,
+ *    which costs a billable call and grants nothing.
+ *
+ * ADDING A FOURTH STORE: list it in self::SHOPPER_SCOPED_SESSION_KEYS. Reading or writing
+ * an attribute through this class does NOT enrol it in the flush; only that list does, and
+ * getData()/setData() now REJECT any key missing from it so that an un-enrolled attribute
+ * cannot quietly acquire the guard's appearance without its protection.
+ *
+ * THE MODULE HAS OTHER SESSION ATTRIBUTES, and they are NOT enrolled here - named so the
+ * next reader does not conclude there are only three. Out of scope for LOQ-16978, which is
+ * about the ADDRESS stores; each needs its own assessment before it is added:
+ *  - 'loqate_email' and 'loqate_phone', written by Plugin\AbstractPlugin::shouldVerify().
+ *    Unbounded lists of raw email addresses and phone numbers that skip a billable
+ *    verifyEmail()/verifyPhoneNumber(), so they are bypasses of the same kind AND hold PII;
+ *  - 'loqate_email_to_validate' (Plugin\Frontend\AccountManagement,
+ *    Plugin\Frontend\CheckoutShippingInformation) - one pending email address;
+ *  - 'loqate_billing_errors' (Plugin\Frontend\CheckoutBillingAddress, read by
+ *    Plugin\Frontend\PlaceOrder and PlaceOrderGuest) - a boolean gate on placing an order.
+ */
+class ShopperScopedSession
+{
+    /**
+     * Session attribute holding the addresses picked from the Loqate Capture lookup.
+     *
+     * Written only by Helper\Controller::storeCapturedAddress() and read only by
+     * Helper\Validator; the name lives HERE because this class is what enforces the
+     * attribute's lifetime, and Controller::CAPTURED_ADDRESSES_SESSION_KEY aliases it.
+     */
+    public const CAPTURED_ADDRESSES_SESSION_KEY = 'captured_addresses';
+
+    /**
+     * Session attribute holding the single-address verify verdict cache (LOQ-16969).
+     *
+     * Aliased as Validator::VERIFY_CACHE_SESSION_KEY, where the reasoning about WHAT it
+     * holds and why it is namespaced per store view and AVC threshold lives.
+     */
+    public const VERIFY_CACHE_SESSION_KEY = 'loqate_verified_addresses';
+
+    /**
+     * Session attribute holding the BATCH verify verdict cache (LOQ-16976).
+     *
+     * Aliased as Validator::BATCH_VERIFY_CACHE_SESSION_KEY, where the reasoning for it
+     * being a PHYSICALLY SEPARATE attribute from the single-address cache lives.
+     */
+    public const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
+
+    /**
+     * Session attribute recording which customer the stores below belong to.
+     *
+     * A SIBLING attribute rather than a member inside each store: the three stores have
+     * three different shapes (a list of serialised addresses, two key => serialised-verdict
+     * maps), every reader of them is defensive about that shape, and wrapping them would
+     * mean changing all three readers to unwrap an owner they must never trust anyway.
+     * One attribute also means one place to compare and one place to write.
+     */
+    private const SESSION_OWNER_KEY = 'loqate_session_cache_owner';
+
+    /**
+     * Owner id standing for "no customer is logged in".
+     *
+     * A real id, not null, so that "guest" is a value the marker can hold and be COMPARED
+     * against. Were guests left unmarked, logging out (customer -> guest) would look
+     * identical to a session that has never been marked, and the logged-in -> guest
+     * transition - the exact one that strands shopper A's bypasses in front of whoever
+     * uses the browser next - would fall into the adoption branch instead of flushing.
+     * Customer ids are positive auto-increment values, so 0 can never collide with one.
+     */
+    private const GUEST_OWNER_ID = 0;
+
+    /**
+     * Owner id standing for "the session answered a customer id we cannot read".
+     *
+     * Its own sentinel, and NEGATIVE, for exactly the reason GUEST_OWNER_ID is 0: customer
+     * ids are positive auto-increment values and the guest is 0, so -1 cannot collide with
+     * either. Mapping the unreadable case onto GUEST_OWNER_ID instead - which is what this
+     * class did before the LOQ-16978 review - was a defect, not a conservative default: it
+     * made customer-with-unreadable-id indistinguishable from a genuine guest, so a LOGOUT
+     * out of that state did not flush and the guest that followed inherited all three
+     * bypass stores, which is precisely the hand-off this class exists to stop.
+     *
+     * @see self::resolveOwnerId() for what remains uncovered, and why that is accepted.
+     */
+    private const UNREADABLE_OWNER_ID = -1;
+
+    /**
+     * Every session attribute owned by one shopper, flushed together on an identity change.
+     *
+     * All three are verify BYPASSES, which is why they share a lifetime: a stale entry in
+     * any one of them lets an address through without the billable Cleansing call that
+     * would have judged it for THIS shopper. This is also the ENROLMENT list, not merely a
+     * flush list - getData()/setData() refuse any key that is not on it, so "reachable
+     * through this class" and "flushed by this class" cannot drift apart.
+     */
+    private const SHOPPER_SCOPED_SESSION_KEYS = [
+        self::CAPTURED_ADDRESSES_SESSION_KEY,
+        self::VERIFY_CACHE_SESSION_KEY,
+        self::BATCH_VERIFY_CACHE_SESSION_KEY,
+    ];
+
+    /** @var Session Raw customer session; deliberately private, see the class docblock. */
+    private $session;
+
+    /**
+     * @param Session $session The per-shopper customer session the stores live in.
+     */
+    public function __construct(Session $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * Read one shopper-scoped attribute, after making sure it belongs to the shopper
+     * making this request.
+     *
+     * @param string $key One of self::SHOPPER_SCOPED_SESSION_KEYS.
+     * @return mixed The stored value, or null when nothing is stored or it has just been
+     *               flushed. Every caller already treats null as "nothing usable cached".
+     * @throws \InvalidArgumentException When $key is not enrolled in the flush.
+     */
+    public function getData(string $key)
+    {
+        $this->assertEnrolled($key);
+        $this->enforceOwnership();
+
+        return $this->session->getData($key);
+    }
+
+    /**
+     * Write one shopper-scoped attribute, after making sure the stores belong to the
+     * shopper making this request.
+     *
+     * The ownership check runs BEFORE the write, so a write performed on the first request
+     * after an identity change stores its value into freshly flushed stores rather than
+     * having it wiped a moment later.
+     *
+     * @param string $key One of self::SHOPPER_SCOPED_SESSION_KEYS.
+     * @param mixed $value
+     * @return void
+     * @throws \InvalidArgumentException When $key is not enrolled in the flush.
+     */
+    public function setData(string $key, $value): void
+    {
+        $this->assertEnrolled($key);
+        $this->enforceOwnership();
+
+        $this->session->setData($key, $value);
+    }
+
+    /**
+     * Refuse any attribute that is not enrolled in the flush.
+     *
+     * WHY THIS IS AN ASSERTION AND NOT A COMMENT. Without it, reading a new attribute
+     * through this class LOOKS guarded - the ownership check runs, the call site is
+     * identical to the three that are protected - while the attribute is never actually
+     * flushed, silently keeping the defect LOQ-16978 was written to close. That is the
+     * same class of trap Validator::BATCH_VERIFY_CACHE_SESSION_KEY answers with two
+     * physically separate attributes rather than a prefix: make it structurally
+     * impossible rather than merely unlikely.
+     *
+     * WHY A THROW IS SAFE HERE, despite running inside checkout. It is unreachable for
+     * correct code. Every production call site passes one of the three constants declared
+     * on this class - ten statements in all: Controller::storeCapturedAddress() reads and
+     * writes the captured store, Validator::verifyAddress() and
+     * Validator::verifyMultipleAddresses() read it, and Validator's four verdict-cache
+     * accessors account for the remaining six. No instance HELD BY THIS MODULE is reachable
+     * from outside it either: both holders keep it in a PRIVATE property and it is never
+     * placed in DI. (The class and its constructor are public, so anything can construct
+     * its OWN instance - that is a separate object over the same session and cannot reach
+     * an unenrolled key through these guards any more than this code can.) So the only way
+     * to trip this is a NEW call inside this module passing an unenrolled key, which is a
+     * programming error that must fail at the developer's first request rather than ship as
+     * a silent bypass. ONE PATH SOFTENS THAT, named so it is not read as a claim the code
+     * does not honour: Plugin\Admin\ValidateImportAddress::afterValidateData() wraps its
+     * work in catch (\Exception) and returns the result untouched, with no log - and that
+     * catch sits OUTSIDE the chunk loop, so the throw abandons the remaining chunks and the
+     * error-reporting loop with them. On that path the mistake therefore does not reach the
+     * developer as an exception; it surfaces as an import that reports no address errors at
+     * all. That is still a total failure of the import's address validation rather than an
+     * unguarded read - no store is reached and no row is granted a bypass - so the assertion
+     * is not a bypass anywhere, merely quieter here than the throw suggests. Logging and
+     * continuing was the alternative and was rejected: the continue path IS the unguarded
+     * access the assertion exists to prevent, so it would leave the defect in place and
+     * merely record it - and this class holds no logger to record it with.
+     *
+     * @param string $key Attribute the caller is trying to reach.
+     * @return void
+     * @throws \InvalidArgumentException Naming the fix, so the message is the instruction.
+     */
+    private function assertEnrolled(string $key): void
+    {
+        if (in_array($key, self::SHOPPER_SCOPED_SESSION_KEYS, true)) {
+            return;
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'Session attribute "%s" is not enrolled in ShopperScopedSession::'
+            . 'SHOPPER_SCOPED_SESSION_KEYS, so it would be reached through the shopper-ownership guard '
+            . 'without ever being flushed when the shopper changes (LOQ-16978). Add it to that list, or '
+            . 'use the raw customer session if the attribute genuinely is not shopper-scoped.',
+            $key
+        ));
+    }
+
+    /**
+     * Flush every shopper-scoped store if the logged-in identity is not the one they were
+     * written for, then record the current identity as their owner.
+     *
+     * Costs TWO session reads on the hot path - the ownership marker here, and the
+     * customer id inside resolveOwnerId() - and, when the marker matches, no writes at
+     * all. That is cheap enough to run on EVERY access rather than once per request, which
+     * is what makes it impossible to reach a store through a path that skipped the check.
+     *
+     * NOTE THAT THIS WRITES ON A READ PATH: getData() reaches here, and a first access or
+     * an identity change makes it store the owner marker (and possibly three nulls). That
+     * is harmless today because these helpers are only reached from POST and AJAX
+     * endpoints - checkout saves, the Capture retrieve controller, admin order save and
+     * customer import - never from a cacheable GET rendered into full-page cache. Do not
+     * route a read-only or cacheable path through getData() expecting it not to write.
+     *
+     * @return void
+     */
+    private function enforceOwnership(): void
+    {
+        $owner = $this->resolveOwnerId();
+        $recorded = $this->session->getData(self::SESSION_OWNER_KEY);
+
+        if (is_numeric($recorded) && (int)$recorded === $owner) {
+            // Same shopper as last time: the overwhelmingly common case, and the only one
+            // that writes nothing at all.
+            return;
+        }
+
+        if ($recorded !== null) {
+            // Either a genuine identity change, or a marker we cannot read (a corrupted
+            // session payload, another module writing to the key). Both are answered the
+            // same way, and that is deliberate: an unreadable marker cannot be shown to
+            // belong to this shopper, and flushing costs at most a few re-verified
+            // addresses, whereas trusting it risks handing one shopper another's bypass.
+            //
+            // Flushed by writing null rather than by unsetting: every reader of these
+            // three stores already degrades a non-array/falsy value to "nothing cached"
+            // (see Validator::getCachedVerifyResult() and its siblings), and null keeps
+            // this class to the two session methods - getData()/setData() - that
+            // Magento\Customer\Model\Session forwards to its storage, instead of adding a
+            // third that only this path would use.
+            foreach (self::SHOPPER_SCOPED_SESSION_KEYS as $key) {
+                $this->session->setData($key, null);
+            }
+        }
+
+        $this->session->setData(self::SESSION_OWNER_KEY, $owner);
+    }
+
+    /**
+     * The customer id that owns the stores on THIS request.
+     *
+     * Normalised to an int so that the comparison in enforceOwnership() cannot be decided
+     * by a type: Magento\Customer\Model\Session::getCustomerId() answers null for a guest
+     * and, depending on how the id reached the session, an int or a numeric string for a
+     * logged-in customer - and '5' !== 5 would flush a shopper's own caches on every
+     * request.
+     *
+     * THREE DISJOINT OWNERS, and they must stay disjoint: a positive customer id, the
+     * guest (self::GUEST_OWNER_ID, 0) and "unreadable" (self::UNREADABLE_OWNER_ID, -1).
+     * Anything not numeric and not null is unreadable. It gets its OWN sentinel rather
+     * than being folded into the guest, because folding it in made two genuinely different
+     * identities compare equal: a customer whose id could not be read, followed by a
+     * logout, produced owner 0 both times, so the stores were not flushed and the guest
+     * inherited all three bypasses.
+     *
+     * RESIDUAL, stated honestly rather than dismissed: every unreadable id maps to the one
+     * sentinel, so two successive unreadable identities would still share the stores.
+     * Accepted, because getCustomerId() cannot produce one through Magento's own API - the
+     * id is an int or a numeric string from the customer entity, or null - so reaching it
+     * needs another module writing a non-numeric value into the customer session's
+     * 'customer_id'. The collision that mattered, unreadable-versus-guest, is now
+     * structurally impossible: -1 is not 0 and cannot be a positive auto-increment id.
+     *
+     * @return int A positive customer id, self::GUEST_OWNER_ID when nobody is logged in,
+     *             or self::UNREADABLE_OWNER_ID when the session answered something else.
+     */
+    private function resolveOwnerId(): int
+    {
+        $customerId = $this->session->getCustomerId();
+
+        if ($customerId === null) {
+            return self::GUEST_OWNER_ID;
+        }
+
+        return is_numeric($customerId) ? (int)$customerId : self::UNREADABLE_OWNER_ID;
+    }
+}

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -53,6 +53,16 @@ class Validator
     private const COUNTY_FIELD = 'Address4';
 
     /**
+     * Every value address_quality_index is allowed to hold, worst ('E') to best ('A').
+     *
+     * checkQualityIndex() compares the response AQI against the threshold with <=, which is
+     * a STRING comparison, so an unrecognised threshold does not fail closed - anything
+     * sorting above 'E' passes every address. This list is what makes that comparison
+     * meaningful; see checkQualityIndex() for the failure it prevents.
+     */
+    private const VALID_QUALITY_INDEXES = ['A', 'B', 'C', 'D', 'E'];
+
+    /**
      * Version of the verify cache's KEY SCHEME. Stamped into every verdict
      * storeVerifyResult() writes and required to match on every read
      * (getCachedVerifyResult()); an entry stamped with anything else is discarded.
@@ -81,16 +91,16 @@ class Validator
      *
      * "Per-shopper" is enforced, not merely assumed: a PHP session survives a login
      * (session_regenerate_id() changes the ID and keeps the data), so this attribute is
-     * reached through ShopperScopedSession, which flushes it whenever the logged-in
+     * reached through ShopperScopedAddressStores, which flushes it whenever the logged-in
      * customer changes (LOQ-16978).
      *
-     * An ALIAS of ShopperScopedSession::VERIFY_CACHE_SESSION_KEY, kept so every existing
+     * An ALIAS of ShopperScopedAddressStores::VERIFY_CACHE_SESSION_KEY, kept so every existing
      * reference to Validator::VERIFY_CACHE_SESSION_KEY still resolves. The literal lives on
      * the guard because the guard is what enforces this attribute's lifetime, and holding
      * it here made the dependency circular - the guard's flush list pointed at this class
      * while this class constructs the guard.
      */
-    const VERIFY_CACHE_SESSION_KEY = ShopperScopedSession::VERIFY_CACHE_SESSION_KEY;
+    const VERIFY_CACHE_SESSION_KEY = ShopperScopedAddressStores::VERIFY_CACHE_SESSION_KEY;
 
     /**
      * Maximum number of verdicts kept per session, oldest evicted first.
@@ -122,16 +132,16 @@ class Validator
      *
      * Same lifetime rules as the single-address cache: a verdict is customer data, so it
      * lives in the per-shopper customer session and nowhere process- or install-wide, and
-     * it is reached through ShopperScopedSession so that it is flushed when the logged-in
+     * it is reached through ShopperScopedAddressStores so that it is flushed when the logged-in
      * customer changes (LOQ-16978) - subject to the ACCEPTED LIMITS on that class, which
      * name THIS attribute specifically: it is written only from adminhtml, where the
      * customer session carries no customer id, so the guard's flush is a no-op for it and
      * an admin-user swap inside one browser session is not covered.
      *
-     * An ALIAS of ShopperScopedSession::BATCH_VERIFY_CACHE_SESSION_KEY, for the same
+     * An ALIAS of ShopperScopedAddressStores::BATCH_VERIFY_CACHE_SESSION_KEY, for the same
      * dependency-direction reason as self::VERIFY_CACHE_SESSION_KEY above.
      */
-    const BATCH_VERIFY_CACHE_SESSION_KEY = ShopperScopedSession::BATCH_VERIFY_CACHE_SESSION_KEY;
+    const BATCH_VERIFY_CACHE_SESSION_KEY = ShopperScopedAddressStores::BATCH_VERIFY_CACHE_SESSION_KEY;
 
     /**
      * Maximum number of batch verdicts kept per session, oldest evicted first.
@@ -177,12 +187,12 @@ class Validator
     private $logger;
 
     /**
-     * @var ShopperScopedSession The captured-address store and the two verdict caches,
+     * @var ShopperScopedAddressStores The captured-address store and the two verdict caches,
      *      behind the shopper-ownership guard. The raw customer session is deliberately
      *      NOT kept as well: keeping it would leave a way to reach those stores without
-     *      the guard - see ShopperScopedSession.
+     *      the guard - see ShopperScopedAddressStores.
      */
-    private ShopperScopedSession $shopperSession;
+    private ShopperScopedAddressStores $shopperSession;
 
     /** @var RegionFactory */
     private $regionFactory;
@@ -197,7 +207,7 @@ class Validator
      * Validator construct
      *
      * @param Logger $logger
-     * @param Session $session Wrapped in a ShopperScopedSession and not kept raw, so the
+     * @param Session $session Wrapped in a ShopperScopedAddressStores and not kept raw, so the
      *                         captured-address store and both verdict caches can only be
      *                         reached through the shopper-ownership guard.
      * @param RegionFactory $regionFactory
@@ -214,7 +224,7 @@ class Validator
         SerializerInterface $serializer
     ) {
         $this->logger = $logger;
-        $this->shopperSession = new ShopperScopedSession($session);
+        $this->shopperSession = new ShopperScopedAddressStores($session);
         $this->regionFactory = $regionFactory;
         $this->helper = $helper;
         $this->serializer = $serializer;
@@ -837,22 +847,35 @@ class Validator
      * This mirrors verifyAddress()'s AVC guard, so both verify paths now draw the
      * "readable verdict" line in exactly the same place.
      *
-     * KNOWN ASYMMETRY, documented rather than changed. The two halves of this comparison
-     * fail closed for different reasons and with different strength:
-     *  - the AQI side (this guard) fails closed DELIBERATELY, by explicit shape test;
-     *  - the THRESHOLD side fails closed only INCIDENTALLY, out of comparison semantics:
-     *    'A' <= null and 'A' <= '' are both false (verified on 8.3), so were
-     *    address_quality_index ever unset, EVERY address would be rejected. That is left
-     *    exactly as it is. It is not reachable in practice - etc/config.xml:20 supplies the
-     *    default and the field is not exposed in etc/adminhtml/system.xml, so it cannot be
-     *    blanked from the admin UI - and "fixing" it by treating an absent threshold as
-     *    permissive would re-open a fail-open on the config side to close a hole that does
-     *    not exist. resolveQualityIndexThreshold() also returns the value RAW and uncast on
-     *    purpose; see its docblock before touching either side.
+     * BOTH SIDES ARE NOW GUARDED EXPLICITLY, and the threshold side had to be.
+     *
+     * An earlier revision guarded only the AQI side and reasoned about the threshold side
+     * being unset: 'A' <= null and 'A' <= '' are both false on 8.3, so a blank threshold
+     * rejects every address. True, and the safe direction - but it is the wrong case. The
+     * dangerous value is not a blank threshold, it is an UNREADABLE one. Under the same
+     * string comparison, 'A' <= 'zzz' and 'E' <= 'zzz' are both TRUE (verified on 8.3), so a
+     * threshold of any text sorting above 'E' passes EVERY address, including the worst AQI
+     * Loqate can return. That is a total bypass of the merchant's configured quality bar,
+     * arrived at silently, and no amount of guarding the response side detects it.
+     *
+     * So the threshold is required to be one of self::VALID_QUALITY_INDEXES and anything
+     * else fails closed and is logged. Rejecting is the only safe answer: the whole point of
+     * the setting is to bar addresses, and a threshold nobody can read cannot be said to
+     * admit any of them.
+     *
+     * Not reachable from the admin UI today - etc/config.xml:20 supplies the default and
+     * etc/adminhtml/system.xml exposes no field for it - but "unreachable" here rests on the
+     * absence of a form field, and the value is a plain core_config_data row that a data
+     * patch, a CLI config:set, or an admin field added later can put anything into. The
+     * guard costs one in_array() per verdict.
+     *
+     * resolveQualityIndexThreshold() still returns the value RAW and uncast, so the batch
+     * cache key keeps fingerprinting exactly what was compared; see its docblock.
      *
      * @param $qualityIndex The AQI from the response row, of any type - it is unvalidated
      *                      connector output, so this method must not assume a string.
-     * @return bool True only when the AQI is readable AND meets the configured threshold.
+     * @return bool True only when the AQI is readable, the threshold is readable, AND the
+     *              AQI meets it.
      */
     private function checkQualityIndex($qualityIndex): bool
     {
@@ -861,6 +884,18 @@ class Validator
         }
 
         $configIndex = $this->resolveQualityIndexThreshold();
+
+        if (!is_string($configIndex) || !in_array($configIndex, self::VALID_QUALITY_INDEXES, true)) {
+            $this->logger->info(sprintf(
+                'Loqate: address_quality_index is not a recognised quality index (%s of type %s); '
+                . 'rejecting the address. Set it to one of %s.',
+                var_export($configIndex, true),
+                gettype($configIndex),
+                implode(', ', self::VALID_QUALITY_INDEXES)
+            ));
+
+            return false;
+        }
 
         return $qualityIndex <= $configIndex;
     }

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -39,30 +39,36 @@ class Validator
      * Fixed by the captured-address store this signature is compared against:
      * Helper\Controller::storeCapturedAddress() writes exactly
      * ADDRESS_CAPTURE_MAPPING's keys, which carry no 'Address' at all, so no field may
-     * be added here (see buildAddressSignature()). The verify cache keys extend this
-     * list instead - see strictSignatureFields() for the invariant that governs them.
+     * be added here (see buildAddressSignature()). The verify cache key extends this
+     * list instead - see verifyCacheSignatureFields() for the invariant that governs it.
      */
     private const CAPTURED_SIGNATURE_FIELDS = ['Address1', 'Address2', 'Address3', 'PostalCode', 'Country'];
 
     /**
-     * The county/province field: present in the strict (rejection) key, absent from
-     * the lossy (success) one. That asymmetry is the whole design of the SINGLE-address
-     * cache, so the field is named once here rather than spelled out at each key builder.
+     * The region field, named once here rather than spelled out at each builder.
      *
-     * The asymmetry is NOT universal, and there is now a third KEY BUILDER that proves it:
-     * buildBatchVerifySignature() (LOQ-16976) includes the county in a SUCCESS key. It is
-     * not a third direct consumer of this constant - the only two of those are
-     * strictSignatureFields() and verifySignatureFields(); the batch builder reaches the
-     * county transitively, through buildStrictAddressSignature(). What it is a third
-     * consumer of is the ASYMMETRY, which is what this note governs. Including the county in
-     * a success key is not a violation of the rule above but a consequence of it - the
-     * asymmetry exists only to stop a cached REJECTION becoming a dead-end, and the batch
-     * cache never stores a rejection (storeBatchVerifyResult()), so it is free to key
-     * successes strictly and does, because an AQI plausibly depends on the county. Read
-     * the four numbered reasons on buildBatchVerifySignature() before assuming the
-     * strict/lossy split should be mirrored onto any new consumer.
+     * It is the one field the shared base (verifySignatureFields()) leaves out, and the key
+     * appends it last, in a segment of its own - see verifyCacheSignatureFields().
      */
     private const COUNTY_FIELD = 'Address4';
+
+    /**
+     * Version of the verify cache's KEY SCHEME. Stamped into every verdict
+     * storeVerifyResult() writes and required to match on every read
+     * (getCachedVerifyResult()); an entry stamped with anything else is discarded.
+     *
+     * A session outlives a deploy, so without this a payload written under an older key
+     * shape would be answered as though its key named the address the CURRENT shape derives
+     * from that key. Bump it whenever buildVerifyCacheSignature() or buildVerifyCacheKey()
+     * changes what a key means: stale entries are then re-verified once, which is the safe
+     * direction.
+     *
+     * Deliberately not carried on the BATCH cache: that store's payload is exactly
+     * ['valid' => true], and the shape being distinct from this one is itself the second
+     * guard against the two verdict caches being read for each other
+     * (getCachedBatchVerifyResult()), so it gets its own stamp only when its own key changes.
+     */
+    private const VERIFY_KEY_SCHEMA_VERSION = 1;
 
     /**
      * Session data key holding the verify verdict cache (LOQ-16969).
@@ -299,11 +305,11 @@ class Validator
      * So one checkout of one address reaches this method 3-5 times depending on
      * Magento version and checkout front-end, and account saves and admin re-tests
      * replay the same address on top of that. Verdicts are therefore de-duplicated on
-     * the canonical address signature and replayed from a session-scoped cache, so one
+     * the normalised address signature and replayed from a session-scoped cache, so one
      * address costs one request (LOQ-16969). verifyMultipleAddresses() now has its own
-     * equivalent guard (LOQ-16976), in its own session attribute and with its own key
-     * shape, because its verdicts come from the AQI rather than the AVC - see
-     * self::BATCH_VERIFY_CACHE_SESSION_KEY.
+     * equivalent guard (LOQ-16976), built by the same signature builder but held in its own
+     * session attribute and namespaced by its own threshold, because its verdicts come from
+     * the AQI rather than the AVC - see self::BATCH_VERIFY_CACHE_SESSION_KEY.
      *
      * CONCURRENCY - stated limit: this de-duplicates SEQUENTIAL calls only. Reading the
      * cache, issuing the billable call and writing the verdict are not atomic and
@@ -335,61 +341,44 @@ class Validator
             }
         }
 
-        // Asymmetric keys: successes on the lossy signature (county excluded) so one
-        // address is billed once across all checkout call paths; rejections on the
-        // strict signature (county included) so a shopper who corrects a wrong county
-        // is re-verified instead of locked out of checkout by a replayed rejection.
-        // Cost: a rejection may be re-billed once per call path, which is fine
-        // because a rejection blocks checkout, so later paths are rarely reached.
+        // ONE key, one read, and both verdicts written under it. Its region segment is
+        // Address4 - the region value ACTUALLY SENT to Loqate - which is what makes one key
+        // enough for successes and rejections alike; see buildVerifyCacheSignature().
         //
-        // Both verify keys are derived from the captured-address signature rather than
-        // being it: of the street, buildAddressSignature() covers lines 1 and 2 only
-        // (Address1/Address2), while the request sent to Loqate carries the FULL joined
-        // street in 'Address',
-        // so with customer/address/street_lines >= 3 an edit to line 3 or 4 would leave
-        // the signature untouched and replay a verdict for an address Loqate never saw.
+        // The key is DERIVED from the captured-address signature rather than being it: of
+        // the street, buildAddressSignature() covers lines 1 and 2 only (Address1/Address2),
+        // while the request sent to Loqate carries the FULL joined street in 'Address', so
+        // with customer/address/street_lines >= 3 an edit to line 3 or 4 would leave the
+        // signature untouched and replay a verdict for an address Loqate never saw.
         // buildVerifySignature() folds 'Address' in, and must not be pushed down into
         // buildAddressSignature(), which is also compared against the captured-address
         // store whose entries (Helper\Controller::storeCapturedAddress() via
         // ADDRESS_CAPTURE_MAPPING) have no 'Address' key at all.
         //
-        // THE INVARIANT THE WHOLE SCHEME RESTS ON: the STRICT key must project EVERY
-        // field parseAddress() sends to Loqate - that is, every value in
-        // ADDRESS_MAPPING - and the LOSSY key must be exactly the strict key minus the
-        // county (self::COUNTY_FIELD). Only then is the asymmetry safe: a rejection is
-        // recorded against the complete address Loqate actually judged, so correcting
-        // ANY field re-verifies rather than replaying a rejection (no checkout
-        // dead-end), while the lossy key ignores nothing but the churning county.
-        // A field added to ADDRESS_MAPPING but left out of the keys would be sent to
-        // Loqate yet invisible to the cache, silently re-opening BOTH the double
-        // billing and the dead-end. The field lists are therefore DERIVED from
-        // ADDRESS_MAPPING rather than written out by hand - see
-        // strictSignatureFields() / verifySignatureFields().
-        $signature = $this->buildAddressSignature($requestArray);
-        $verifySignature = $this->buildVerifySignature($signature, $requestArray);
-        $strictSignature = $this->buildStrictAddressSignature($verifySignature, $requestArray);
+        // THE INVARIANT THE WHOLE SCHEME RESTS ON: the key must project EVERY field
+        // parseAddress() sends to Loqate - that is, every value in ADDRESS_MAPPING. Only
+        // then is one key safe for both verdicts: a rejection is recorded against the
+        // complete address Loqate actually judged, so correcting ANY field re-verifies
+        // rather than replaying a rejection (no checkout dead-end), and a success is
+        // replayed only for an address Loqate actually accepted. A field added to
+        // ADDRESS_MAPPING but left out of the key would be sent to Loqate yet invisible to
+        // the cache, silently re-opening BOTH the double billing and the dead-end, so the
+        // field list is DERIVED from ADDRESS_MAPPING rather than written out by hand - see
+        // verifyCacheSignatureFields().
+        $signature = $this->buildVerifyCacheSignature($requestArray);
 
-        // Strict (rejection) key first: the two key families are disjoint, so both
-        // reads are cheap cache lookups and only one case changes - a shopper who
-        // reverts to a county Loqate explicitly rejected now gets that rejection back
-        // instead of being passed by the county-agnostic success entry.
-        // ?? short-circuits, so the lossy key is only read when the strict one misses,
-        // which is also what makes the reported key family below accurate.
-        $strictResult = $this->getCachedVerifyResult($strictSignature);
-        $cachedResult = $strictResult ?? $this->getCachedVerifyResult($verifySignature);
+        $cachedResult = $this->getCachedVerifyResult($signature);
         if ($cachedResult !== null) {
-            $this->logVerifyCacheOutcome(
-                'hit',
-                $strictResult !== null ? 'strict' : 'lossy',
-                $strictResult !== null ? $strictSignature : $verifySignature
-            );
+            $this->logVerifyCacheOutcome('hit', $signature);
 
             return $cachedResult;
         }
 
         // Every miss is followed by exactly one billable request (the call below), so
-        // counting these lines counts the Loqate invoice.
-        $this->logVerifyCacheOutcome('miss', 'none', $verifySignature);
+        // counting these lines counts the Loqate invoice. The miss and every hit that later
+        // replays it are reported under the same key, so they share a token - see
+        // logVerifyCacheOutcome().
+        $this->logVerifyCacheOutcome('miss', $signature);
 
         $response = $this->apiConnector->verifyAddress(['Addresses' => [$requestArray], 'source' => $this->version]);
 
@@ -417,36 +406,23 @@ class Validator
         }
 
         if (!$this->checkAVCStatus($avcCode)) {
-            // A real AVC that fails the thresholds is a definitive verdict, so it
-            // is cached - under the strict key only, see above.
-            $this->storeVerifyResult($strictSignature, true);
+            // A real AVC that fails the thresholds is a definitive verdict, so it is cached.
+            $this->storeVerifyResult($signature, true);
 
             return ['error' => true, 'message' => __('The provided address is invalid.')];
         }
 
-        // Accepted trade-off (LOQ-16969), stated at its true width: because the success
-        // key excludes the county, once ANY county variant of this address is accepted,
-        // every county variant Loqate has NOT explicitly rejected also passes from the
-        // cache for the rest of the session (a rejected one is caught by the strict read
-        // above, which runs first).
+        // The same key a rejection is stored under, which is safe precisely because that key
+        // is a faithful projection of the address Loqate just judged.
         //
-        // This is accepted because keying successes strictly would re-bill precisely the
-        // county churn this ticket fixes: capture.js populates the region <select> from
-        // the SDK's ProvinceName and fires a bubbling change event
-        // (view/base/web/capture.js:7932, retried with backoff at :7942-7960), and
-        // parseAddress() additionally re-resolves 'region' from region_id, so the county
-        // value is NOT stable across the call paths listed in this method's docblock.
-        //
-        // It is NOT the status quo, and must not be justified as parity with the
-        // pre-existing captured_addresses guard: that guard is written only by
-        // Helper\Controller::retrieve() -> storeCapturedAddress(), so it only ever applied
-        // to addresses picked from the Loqate lookup - addresses Loqate itself authored.
-        // Caching successes county-blind extends that county-blindness to TYPED addresses,
-        // which is a widening of the bypass. Tightening it (for instance by keying
-        // successes strictly and canonicalising the county instead) is tracked as
-        // LOQ-16979, "tighten county-blind verify verdict cache so unverified county
-        // variants cannot pass".
-        $this->storeVerifyResult($verifySignature, false);
+        // WHY THE SEPARATE SUCCESS KEY IS GONE, where its rationale used to live: it existed
+        // because the success key was LOSSY about the region, so a stricter key was needed
+        // beside it to stop a shopper being stranded on a replayed "no". Nothing is lossy
+        // now, so there is nothing for a second key to absorb - and both invariants that
+        // motivated the split still hold: a shopper who corrects a genuinely wrong region
+        // gets a different key and a fresh verification, and a success can only ever be
+        // replayed for an address Loqate actually accepted.
+        $this->storeVerifyResult($signature, false);
 
         return ['error' => false];
     }
@@ -557,17 +533,16 @@ class Validator
      *    batch can both miss and both be billed. Sequential replay - the re-submitted
      *    admin order, the re-run import - is what this de-duplicates.
      *  - a row present in the response but carrying no readable AQI is answered INVALID and
-     *    is never cached. That is a fail-closed verdict, decided in checkQualityIndex()
-     *    (Helper/Validator.php:841-843) and reached for a record whose 'Matches' list is
-     *    present but empty - the row-count guard below cannot catch that shape, because
-     *    array_column() PRESERVES such a record, see the attribution loop for the
-     *    demonstration. It is a deliberate rejection, not a gap: it costs one
-     *    re-attempt on a response we could not read, where the previous behaviour reported
-     *    "no match found" as VALID.
+     *    is never cached. That is a fail-closed verdict, decided by checkQualityIndex()'s
+     *    shape guard, and reached for a record whose 'Matches' list is present but empty -
+     *    the row-count guard below cannot catch that shape, because array_column()
+     *    PRESERVES such a record, see the attribution loop for the demonstration. It is a
+     *    deliberate rejection, not a gap: it costs one re-attempt on a response we could
+     *    not read, where the previous behaviour reported "no match found" as VALID.
      *  - the same address twice in ONE batch is billed twice: both copies miss the cache in
      *    the pre-flight pass, since nothing is written until the response comes back.
      *    Tracked as LOQ-17015. Whoever implements it MUST preserve the
-     *    ONE-RESPONSE-ROW-PER-SENT-ITEM assumption the count guard below (:643-651) and the
+     *    ONE-RESPONSE-ROW-PER-SENT-ITEM assumption the row-count guard below and the
      *    positional attribution loop after it both depend on: collapsing duplicates into a
      *    single payload slot changes the row/address arithmetic, so that dedupe and this
      *    guard have to be changed TOGETHER. Sending N slots and fanning one row out to
@@ -621,7 +596,17 @@ class Validator
                 continue;
             }
 
-            $signature = $this->buildBatchVerifySignature($parsedAddress);
+            // The SAME builder verifyAddress() uses, and now the only one there is: the
+            // region is in the key on the read exactly as on the write, so a region variant
+            // Loqate was never asked about simply misses and is billed. (That is why the
+            // warning this comment replaces - "no county rewrite may be pushed down into the
+            // shared builders" - is deletable: there is no second builder left to widen.)
+            // What stays separate is the STORE and the namespacing, because these verdicts
+            // come from the AQI: see self::BATCH_VERIFY_CACHE_SESSION_KEY and
+            // buildBatchVerifyCacheKey(). Pinned by
+            // ValidatorBatchVerifyCacheTest::testAnUnverifiedCountyVariantIsNeverServedACachedBatchPass()
+            // and ::testChangingOnlyTheCountyCostsASecondBillableAddress().
+            $signature = $this->buildVerifyCacheSignature($parsedAddress);
             $cachedVerdict = $this->getCachedBatchVerifyResult($signature);
             if ($cachedVerdict !== null) {
                 $this->logBatchVerifyCacheOutcome('hit', $signature);
@@ -729,10 +714,10 @@ class Validator
             // "valid" is the maximally wrong answer, so this is a genuinely reachable hole
             // being closed, not defence in depth.
             //
-            // checkQualityIndex() now mirrors verifyAddress()'s AVC guard
-            // (Helper/Validator.php:377); see its docblock for why the test is on the value's
-            // shape rather than on truthiness, and for the deliberately-unchanged asymmetry on
-            // the threshold side of the comparison.
+            // checkQualityIndex() now mirrors verifyAddress()'s AVC guard; see
+            // checkQualityIndex()'s own docblock for why the test is on the value's shape
+            // rather than on truthiness, and for the deliberately-unchanged asymmetry on the
+            // threshold side of the comparison.
             $isValid = $this->checkQualityIndex($qualityIndex);
             $result[$sentItem['key']] = $isValid;
 
@@ -842,15 +827,15 @@ class Validator
      *
      * WHY THIS IS NOT COSMETIC. Under PHP 8's comparison rules null <= 'A', '' <= 'A',
      * false <= 'A' and 0 <= 'A' are ALL true (verified on 8.3), so before this guard an
-     * unreadable AQI was answered VALID. The single call site
-     * (the attribution loop, Helper/Validator.php:703) reads
+     * unreadable AQI was answered VALID. The single call site - the positional attribution
+     * loop in verifyMultipleAddresses() - reads
      * $addressResponse[0]['AQI'] ?? null, which is null for a response record whose
      * 'Matches' list is present but EMPTY - i.e. Loqate saying "no match for this address",
      * the case where "valid" is the maximally wrong answer. See the comment at that call
      * site for why the row-count guard does not catch that shape.
      *
-     * This mirrors verifyAddress()'s AVC guard (Helper/Validator.php:377), so both verify
-     * paths now draw the "readable verdict" line in exactly the same place.
+     * This mirrors verifyAddress()'s AVC guard, so both verify paths now draw the
+     * "readable verdict" line in exactly the same place.
      *
      * KNOWN ASYMMETRY, documented rather than changed. The two halves of this comparison
      * fail closed for different reasons and with different strength:
@@ -1093,7 +1078,7 @@ class Validator
      * an array in the Loqate field shape (ADDRESS_CAPTURE_MAPPING's keys, or
      * parseAddress()'s output - they overlap on the fields this projects), but the internal
      * callers reach here through buildAddressSignature() with whatever
-     * checkForCapturedAddress()/buildBatchVerifySignature() were handed, which is typed
+     * checkForCapturedAddress()/buildVerifyCacheSignature() were handed, which is typed
      * `mixed`, and Helper\Controller guards its own call with is_array() only on the
      * deserialised path. Declaring `array` would convert today's graceful degradation into
      * a TypeError raised mid-checkout, which is the opposite of what every other reader in
@@ -1123,25 +1108,30 @@ class Validator
     }
 
     /**
-     * Build a normalised, comparable signature for an address: the canonical
-     * projection of the fields Loqate Verify keys on. Used to match an address
-     * against the captured-address store, and as the base both verify cache keys are
-     * derived from.
+     * Build a normalised, comparable signature for an address: the projection of the fields
+     * Loqate Verify keys on. Used to match an address against the captured-address store,
+     * and as the base the verify cache key is derived from.
      *
      * Its field list (self::CAPTURED_SIGNATURE_FIELDS) is fixed by the captured-address
      * store it is compared against (Helper\Controller::storeCapturedAddress() writes
      * exactly ADDRESS_CAPTURE_MAPPING's keys), so no field may be added here: the verify
-     * keys extend it in buildVerifySignature()/buildStrictAddressSignature() instead.
+     * cache key extends it in buildVerifySignature()/buildVerifyCacheSignature() instead.
      *
-     * Region/province (self::COUNTY_FIELD) is deliberately excluded, because the county
-     * is routinely rewritten between saves - capture.js populates the region <select>
-     * from the SDK's ProvinceName and fires a bubbling change event
-     * (view/base/web/capture.js:7932), and parseAddress() re-resolves 'region' from
-     * region_id - and that must not make an identical address look new and get re-billed,
-     * the LOQ-16969 symptom. Street, city (Address3), postcode and country already
-     * identify it; rejections, which do need the county, use
-     * buildStrictAddressSignature(). '' means "nothing identifiable" and keeps an address
-     * out of both comparisons.
+     * Region/province (self::COUNTY_FIELD) is excluded, and here that is FIXED BY THE
+     * STORE, not by any judgement about the region: Helper\Controller::storeCapturedAddress()
+     * writes ADDRESS_CAPTURE_MAPPING's keys and this projection is compared field for field
+     * against them. It is also harmless, because the region label is routinely rewritten
+     * between saves - capture.js selects the matching option in the region <select> from the
+     * SDK's ProvinceName and fires a bubbling change event (mapRegionSelectValue(),
+     * view/base/web/capture.js:7896-7940), and parseAddress() re-resolves 'region' from
+     * region_id - and an address the Loqate lookup itself authored must not look new and
+     * get re-verified over that, the LOQ-16969 symptom. Street, city (Address3), postcode
+     * and country already identify it. '' means "nothing identifiable" and keeps an address
+     * out of every comparison.
+     *
+     * THE VERIFY CACHE KEY DOES NOT INHERIT THAT EXCLUSION: it appends the region on top of
+     * this projection, at the fidelity the request itself carries - see
+     * buildVerifyCacheSignature().
      *
      * The body lives on self::capturedAddressSignature(), which
      * Helper\Controller::storeCapturedAddress() also calls so that the store de-duplicates
@@ -1157,9 +1147,64 @@ class Validator
     }
 
     /**
-     * Key successful verdicts are stored under (the LOSSY key): the captured-address
-     * signature plus every remaining field parseAddress() sends to Loqate except the
-     * county - today that is just the full joined street, 'Address'.
+     * THE verify cache key's signature - the one every read and every write on both paths
+     * goes through: the shared base plus the region, and nothing else, ever.
+     *
+     * THE REGION SEGMENT IS Address4, THE REGION VALUE ACTUALLY SENT TO LOQATE. That single
+     * choice is the whole design, and everything else follows from it:
+     *  - parseAddress() derives Address4 from region_id when a region_id is present, and
+     *    from the raw 'region' string when it is not. Keying on Address4 therefore already
+     *    IS the rule "region_id when present, normalised raw region when absent" - expressed
+     *    as the resolved region NAME rather than as the install-local numeric id;
+     *  - keying on the resolved NAME rather than on the region_id is deliberate and
+     *    load-bearing. The name is EXACTLY what was billed, so two submissions share a
+     *    verdict if and only if they asked Loqate the same question - no coarsening in
+     *    either direction. A numeric region_id would be FINER than what was sent, and would
+     *    split the quote-path shape ('region_id' => 100) from the POST-path shape
+     *    ('region' => 'Greater London') of ONE address, re-billing a single checkout twice.
+     *    Pinned by
+     *    ValidatorVerifyCacheTest::testBothCheckoutCallPathShapesOfOneAddressAreBilledOnce();
+     *  - because region_id -> name is deterministic, both required outcomes fall out with
+     *    ZERO country-specific rules. Two different region records resolve to two different
+     *    names, so 'County Dublin' and 'Dublin 1' are two keys and the second is verified in
+     *    its own right; and the raw label variants that arrive around ONE region_id
+     *    ('Meath', 'Co. Meath', 'County Meath' alongside region_id 55) are all overwritten
+     *    by parseAddress() with that record's name, so they share one key - they were never
+     *    distinct requests in the first place.
+     * The install-local numeric region_id therefore never enters the key at all; the
+     * resolved name does. These caches are session-scoped in any case, so an install-local
+     * value would have been harmless - the choice is about fidelity to the billed request,
+     * not about safety.
+     *
+     * ACCEPTED LIMIT: with no region_id - a free-text-region country - the region TEXT is
+     * the region, so re-spelling it is a different key and costs one extra verification.
+     * That is the safe direction, a re-bill and never a bypass, and it replaces the old
+     * collapse of label spellings, which was a bypass.
+     *
+     * @param $address Parsed address, as returned by parseAddress().
+     * @return string Empty when the address carries nothing identifiable, which keeps it out
+     *                of the cache entirely (neither read nor written).
+     */
+    private function buildVerifyCacheSignature($address): string
+    {
+        $base = $this->buildVerifySignature($this->buildAddressSignature($address), $address);
+
+        // Read off verifyCacheSignatureFields() rather than written here as
+        // [self::COUNTY_FIELD], so the list that encodes the "every field sent to Loqate is
+        // in the key" invariant is the list this builder actually uses. A field list nothing
+        // calls enforces nothing. The slice is that one field, by that method's construction.
+        $append = array_slice($this->verifyCacheSignatureFields(), count($this->verifySignatureFields()));
+
+        return $this->appendSignatureFields($base, $address, $append);
+    }
+
+    /**
+     * The SHARED BASE the region is appended to: the captured-address signature plus every
+     * remaining field parseAddress() sends to Loqate except the region - today that is just
+     * the full joined street, 'Address'.
+     *
+     * Not a cache key on its own: buildVerifyCacheSignature() appends the region, and that
+     * is the only signature anything is read or written under.
      *
      * buildAddressSignature() only covers Address1/Address2, but parseAddress() sends
      * implode(', ', $streetLines) as 'Address', and Magento supports up to four street
@@ -1180,66 +1225,45 @@ class Validator
      */
     private function buildVerifySignature(string $signature, $address): string
     {
-        // Everything the lossy key covers beyond what $signature already carries.
+        // Everything the shared base covers beyond what $signature already carries.
         $append = array_slice($this->verifySignatureFields(), count(self::CAPTURED_SIGNATURE_FIELDS));
 
         return $this->appendSignatureFields($signature, $address, $append);
     }
 
     /**
-     * Strict variant of the verify signature (the STRICT key): the lossy verify
-     * signature plus the normalised county/province.
-     *
-     * Rejections are keyed with this so that correcting only a wrong county
-     * re-verifies the address instead of replaying a rejection that blocks
-     * checkout. Built from the already-normalised signature, so the '' sentinel and
-     * the normalisation rules stay identical to buildAddressSignature(). Appending one
-     * more part also keeps the two key families disjoint by pipe count, which is why
-     * reading the strict key first cannot shadow an unrelated success - and that stays
-     * true however many fields ADDRESS_MAPPING grows, because both families gain the
-     * same segments and the strict one always gains exactly one more.
-     *
-     * @param string $signature Signature returned by buildVerifySignature().
-     * @param $address Parsed address the signature was built from.
-     * @return string Empty when $signature is empty, so it is neither read nor written.
-     */
-    private function buildStrictAddressSignature(string $signature, $address): string
-    {
-        // Everything the strict key covers beyond the lossy one: the county, and by the
-        // construction of strictSignatureFields() nothing else, ever.
-        $append = array_slice($this->strictSignatureFields(), count($this->verifySignatureFields()));
-
-        return $this->appendSignatureFields($signature, $address, $append);
-    }
-
-    /**
-     * Ordered field list of the STRICT (rejection) cache key.
+     * Ordered field list of THE verify cache key.
      *
      * The load-bearing invariant of LOQ-16969, expressed as code rather than as a
      * comment: as a SET this must equal array_values(self::ADDRESS_MAPPING) - every
-     * field parseAddress() actually sends to Loqate - because a rejection may only be
+     * field parseAddress() actually sends to Loqate - because a verdict may only be
      * replayed for the exact address Loqate judged. If a field reached the request but
      * not this list, editing it would replay a stale verdict: a wrong "invalid" the
      * shopper cannot clear (the checkout dead-end) or a wrong "valid" that lets an
      * unverified address through.
      *
      * It is therefore DERIVED, not hand-written: the captured base is fixed by the
-     * captured-address store, the county is appended last (it is what the lossy key
-     * drops), and anything else in ADDRESS_MAPPING is folded in automatically. So adding
-     * a mapping such as 'company' => 'Company' extends both keys by construction instead
-     * of quietly re-opening the defect.
+     * captured-address store, the region is appended last (it is the one field the shared
+     * base leaves out), and anything else in ADDRESS_MAPPING is folded in automatically. So
+     * adding a mapping such as 'company' => 'Company' extends the key by construction
+     * instead of quietly re-opening the defect.
      *
      * @return string[] Loqate field names, in the order they appear in the key.
      */
-    private function strictSignatureFields(): array
+    private function verifyCacheSignatureFields(): array
     {
         return array_merge($this->verifySignatureFields(), [self::COUNTY_FIELD]);
     }
 
     /**
-     * Ordered field list of the LOSSY (success) cache key: the strict list minus the
-     * county. See strictSignatureFields() for why the extras are derived from
-     * ADDRESS_MAPPING, and verifyAddress() for why the county is dropped here.
+     * Ordered field list of the SHARED BASE the region is appended to: the key's list minus
+     * the region. See verifyCacheSignatureFields() for why the extras are derived from
+     * ADDRESS_MAPPING.
+     *
+     * The region is held back from this list because it is appended LAST, in a segment of
+     * its own - which is what lets the middle of the list be derived by array_diff() over
+     * ADDRESS_MAPPING without the region's position depending on that mapping's declaration
+     * order. No key omits it.
      *
      * @return string[] Loqate field names, in the order they appear in the key.
      */
@@ -1257,8 +1281,8 @@ class Validator
     /**
      * Append the normalised values of $fields to an existing signature.
      *
-     * Shared by both verify key builders so the '' sentinel and the normalisation rules
-     * can only ever be defined once.
+     * Shared by the key builder and the base it is built on, so the '' sentinel and the
+     * normalisation rules can only ever be defined once.
      *
      * @param string $signature Signature to extend.
      * @param $address Parsed address the signature was built from.
@@ -1315,9 +1339,9 @@ class Validator
     /**
      * Read a previously stored verify verdict for the given address signature.
      *
-     * Only the verdict flag is cached; the message is rebuilt here so no Phrase ever
-     * passes through the serializer (its translation would be frozen at the store
-     * view that cached it, and a serializer without object support would return an
+     * Only the verdict flag and the key-scheme stamp are cached; the message is rebuilt here
+     * so no Phrase ever passes through the serializer (its translation would be frozen at the
+     * store view that cached it, and a serializer without object support would return an
      * unusable value). Defensive like checkForCapturedAddress(): an unexpected shape
      * degrades to "not cached" - one extra API call - and never throws in checkout.
      *
@@ -1346,6 +1370,14 @@ class Validator
             return null;
         }
 
+        // A verdict may only answer a lookup made under the key scheme it was written for. A
+        // session outlives a deploy, so an entry carrying another stamp sits under a key that
+        // no longer names the same address: discard it and verify once more. Compared
+        // strictly, so a serializer that hands back "1" cannot pass for 1.
+        if (($verdict['schema'] ?? null) !== self::VERIFY_KEY_SCHEMA_VERSION) {
+            return null;
+        }
+
         if (!$verdict['error']) {
             return ['error' => false];
         }
@@ -1356,8 +1388,8 @@ class Validator
     /**
      * Store a definitive verify verdict against the given address signature.
      *
-     * Only the boolean verdict is stored, never a message (see
-     * getCachedVerifyResult()). Kept in the customer session only (see
+     * Only the boolean verdict and self::VERIFY_KEY_SCHEMA_VERSION are stored, never a
+     * message (see getCachedVerifyResult()). Kept in the customer session only (see
      * self::VERIFY_CACHE_SESSION_KEY) and bounded to self::VERIFY_CACHE_LIMIT
      * entries with FIFO eviction, so in practice the address currently being
      * checked out - the one replayed on every checkout call path - survives while
@@ -1403,7 +1435,12 @@ class Validator
             array_shift($store);
         }
 
-        $store[$key] = $this->serializer->serialize(['error' => $error]);
+        // Stamped with the key scheme, so a session that spans a deploy changing the key
+        // shape cannot be answered by an entry built under a different one.
+        $store[$key] = $this->serializer->serialize([
+            'error' => $error,
+            'schema' => self::VERIFY_KEY_SCHEMA_VERSION,
+        ]);
         $this->shopperSession->setData(self::VERIFY_CACHE_SESSION_KEY, $store);
     }
 
@@ -1449,14 +1486,13 @@ class Validator
     /**
      * Debug-log the outcome of one verify cache lookup, so the drop in billable
      * Cleansing requests can be reconciled without waiting for the Loqate invoice:
-     * misses map one-to-one onto billable calls, and the key family shows whether a hit
-     * came from the strict (rejection) or the lossy (success) entry.
+     * misses map one-to-one onto billable calls.
      *
-     * A miss is reported under the LOSSY key's hash on purpose: that key is the
-     * county-blind one, so every event belonging to one address - including the county
-     * variants the shopper churns through - shares a hash and can be counted together.
-     * A strict hit is reported under the strict key's hash, which is why the family
-     * matters when reading the log.
+     * One key means one token per address: the miss, and every hit that later replays the
+     * verdict it paid for, are reported under the same hash and can be counted together.
+     * Two addresses Loqate is asked about separately - including one address in two
+     * different regions - get two tokens, which is what an operator counting misses should
+     * expect to see.
      *
      * HOW TO TURN THIS ON: Logger/Handler.php pins $loggerType = Logger::INFO, so DEBUG
      * records are dropped and nothing is written by default. Lower that handler to
@@ -1470,61 +1506,18 @@ class Validator
      * each other and with a request count, which is all the reconciliation needs.
      *
      * @param string $outcome 'hit' or 'miss'.
-     * @param string $keyFamily 'strict', 'lossy', or 'none' for a miss.
      * @param string $signature Signature the lookup was made with; never logged as-is.
      * @return void
      */
-    private function logVerifyCacheOutcome(string $outcome, string $keyFamily, string $signature): void
+    private function logVerifyCacheOutcome(string $outcome, string $signature): void
     {
         $key = $this->buildVerifyCacheKey($signature);
 
         $this->logger->debug(sprintf(
-            'Loqate verify cache %s [family=%s, key=%s]',
+            'Loqate verify cache %s [key=%s]',
             $outcome,
-            $keyFamily,
             $key === '' ? 'unkeyed' : substr(hash('sha256', $key), 0, 12)
         ));
-    }
-
-    /**
-     * Build the batch path's cache signature for one parsed address: the STRICT signature,
-     * county (self::COUNTY_FIELD) INCLUDED.
-     *
-     * STRICT-ONLY, deliberately NOT the asymmetric strict/lossy pair verifyAddress() uses
-     * (LOQ-16976). Four reasons, all of which have to stay true for this to remain correct:
-     *  1. this cache never stores a failure (storeBatchVerifyResult()), so the
-     *     rejection-replay checkout dead-end that FORCED the asymmetry over there - a
-     *     cached "invalid" the shopper cannot clear by correcting the county - is
-     *     structurally impossible here. A lossy key would buy nothing safety-wise;
-     *  2. parseAddress() (Helper/Validator.php:737-740, the region_id branch) re-derives
-     *     'region' from region_id on this exact path, canonicalising the county per
-     *     region_id. That derivation is deterministic, so the county churn the lossy key
-     *     exists to absorb is largely absent from admin order create and import;
-     *  3. it could NOT be established that view/base/web/capture.js even loads on the
-     *     admin order-create screen - the sales_order_create_customer_block layout handle
-     *     is unverifiable without Magento core vendored - so the client-side
-     *     county-rewriting premise behind the lossy key is unproven on this path;
-     *  4. an AQI plausibly depends on the county, so a county-blind SUCCESS cache here
-     *     would be a WIDER bypass than the one LOQ-16979 already tracks tightening.
-     * ACCEPTED COST: if the county is rewritten between two submissions of the same
-     * address, that address is billed once more. One request, once, per rewrite.
-     *
-     * Reuses the existing signature builders verbatim, so the '' sentinel, the
-     * normalisation rules and the "every field sent to Loqate is projected" invariant
-     * documented in verifyAddress() hold here without being restated in code.
-     *
-     * @param $address Parsed address, as returned by parseAddress().
-     * @return string Empty when the address carries nothing identifiable, which keeps it
-     *                out of the cache entirely (neither read nor written).
-     */
-    private function buildBatchVerifySignature($address): string
-    {
-        $signature = $this->buildAddressSignature($address);
-
-        return $this->buildStrictAddressSignature(
-            $this->buildVerifySignature($signature, $address),
-            $address
-        );
     }
 
     /**
@@ -1572,22 +1565,21 @@ class Validator
      * Store a batch verdict against the given address signature - if, and only if, it
      * PASSED.
      *
-     * NEVER CACHING A FAILURE is load-bearing, not tidiness: it is reason 1 for the
-     * strict-only key documented on buildBatchVerifySignature(). A cached rejection would
-     * need the county in the key to avoid stranding an admin or an import on a verdict they
-     * cannot clear by correcting a field; because no rejection is ever cached, the key can
-     * be strict without introducing that dead-end. The guard therefore lives HERE rather
-     * than at the call site, so a future caller cannot reintroduce cached failures by
-     * forgetting it.
+     * NEVER CACHING A FAILURE is load-bearing, not tidiness. Two things rest on it: an admin
+     * or an import can never be stranded on a replayed rejection, because there is none to
+     * replay; and the stored shape stays 'valid'-only, which is the second guard against
+     * this store and the single-address one being read for each other (see
+     * getCachedBatchVerifyResult()). The guard therefore lives HERE rather than at the call
+     * site, so a future caller cannot reintroduce cached failures by forgetting it.
      *
      * WHAT THIS GUARD RELIES ON, and where that half lives: "$valid === true" only means
      * checkQualityIndex() said so, and this method cannot audit that - by the time it is
      * called the response value is gone. It is safe because checkQualityIndex() itself now
-     * FAILS CLOSED on an AQI it cannot read (Helper/Validator.php:841-843): an unreadable
-     * value can no longer arrive here as a genuine-looking pass to be replayed all session.
-     * Do not relax that guard without adding a readability test at this method's call site
-     * (the attribution loop, Helper/Validator.php:703-711), or unreadable responses start
-     * being cached as passes again.
+     * FAILS CLOSED on an AQI it cannot read (its opening shape guard): an unreadable value
+     * can no longer arrive here as a genuine-looking pass to be replayed all session. Do
+     * not relax that guard without adding a readability test at this method's call site -
+     * the positional attribution loop in verifyMultipleAddresses() - or unreadable
+     * responses start being cached as passes again.
      *
      * Bounding and eviction mirror storeVerifyResult() exactly - unset-then-append so a
      * refreshed entry does not cost an unrelated address its verdict, FIFO array_shift()
@@ -1682,8 +1674,12 @@ class Validator
      * A sibling of logVerifyCacheOutcome() rather than a call to it, for one concrete
      * reason: that method hashes buildVerifyCacheKey(), the AVC-namespaced key, which for
      * an address on this path names a cache entry that does not exist - the log line would
-     * correlate with the wrong cache. The family is fixed at 'strict' because this cache
-     * has exactly one key family (see buildBatchVerifySignature()).
+     * correlate with the wrong cache.
+     *
+     * The literal "family=strict" segment is a vestige of the single-address cache once
+     * having had two key shapes. There is one signature builder now, so it distinguishes
+     * nothing; it is left in place because this line's format is pinned by
+     * ValidatorBatchVerifyCacheTest and existing log tooling parses it.
      *
      * Same PII rule, which is absolute: NEVER log the address or the raw signature. A log
      * file is not the customer session - it is readable by anyone with server access, it

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -46,8 +46,21 @@ class Validator
 
     /**
      * The county/province field: present in the strict (rejection) key, absent from
-     * the lossy (success) one. That asymmetry is the whole design, so the field is
-     * named once here rather than spelled out at each key builder.
+     * the lossy (success) one. That asymmetry is the whole design of the SINGLE-address
+     * cache, so the field is named once here rather than spelled out at each key builder.
+     *
+     * The asymmetry is NOT universal, and there is now a third KEY BUILDER that proves it:
+     * buildBatchVerifySignature() (LOQ-16976) includes the county in a SUCCESS key. It is
+     * not a third direct consumer of this constant - the only two of those are
+     * strictSignatureFields() and verifySignatureFields(); the batch builder reaches the
+     * county transitively, through buildStrictAddressSignature(). What it is a third
+     * consumer of is the ASYMMETRY, which is what this note governs. Including the county in
+     * a success key is not a violation of the rule above but a consequence of it - the
+     * asymmetry exists only to stop a cached REJECTION becoming a dead-end, and the batch
+     * cache never stores a rejection (storeBatchVerifyResult()), so it is free to key
+     * successes strictly and does, because an AQI plausibly depends on the county. Read
+     * the four numbered reasons on buildBatchVerifySignature() before assuming the
+     * strict/lossy split should be mirrored onto any new consumer.
      */
     private const COUNTY_FIELD = 'Address4';
 
@@ -67,10 +80,65 @@ class Validator
      *
      * Bounded so the cache cannot inflate the session payload the way the pre-existing
      * "captured_addresses" store does: that one grows without limit for the whole
-     * session (Helper/Controller.php:171-186), which is tracked as LOQ-16978 and is
+     * session (Helper/Controller.php:179-194), which is tracked as LOQ-16978 and is
      * deliberately not replicated here.
      */
     const VERIFY_CACHE_LIMIT = 50;
+
+    /**
+     * Session data key holding the BATCH verdict cache (LOQ-16976).
+     *
+     * A PHYSICALLY SEPARATE session attribute from self::VERIFY_CACHE_SESSION_KEY - not a
+     * prefix inside that array - because the two caches hold verdicts of different KINDS
+     * that must never answer each other's lookups. verifyAddress() judges an address
+     * against the AVC thresholds (checkAVCStatus()); verifyMultipleAddresses() judges it
+     * against the address quality index (checkQualityIndex()). The thresholds differ, so
+     * the namespacing fingerprints differ (resolveComparerAvcString() versus
+     * resolveQualityIndexThreshold()), and the stored shapes differ ('error' versus
+     * 'valid'). Sharing one array would leave conflation one missing-prefix bug away, and
+     * a key collision there would let an AVC verdict satisfy an AQI check - silently
+     * bypassing a threshold the merchant configured. Two attributes make that
+     * structurally impossible rather than merely unlikely, and cost one extra session key.
+     *
+     * Same lifetime rules as the single-address cache: a verdict is customer data, so it
+     * lives in the per-shopper customer session and nowhere process- or install-wide.
+     */
+    const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
+
+    /**
+     * Maximum number of batch verdicts kept per session, oldest evicted first.
+     *
+     * Deliberately larger than self::VERIFY_CACHE_LIMIT because this path is BATCHED:
+     * customer import verifies in chunks of 100 rows
+     * (Plugin\Admin\ValidateImportAddress.php:50), so any limit below 100 could not hold
+     * even one chunk - the eviction would discard a chunk's earliest rows before the
+     * chunk finished, and re-running a file that FITS WITHIN THIS LIMIT would re-bill them.
+     * 200 holds two full chunks while still bounding the session payload, which is the whole
+     * point of having a limit at all (see self::VERIFY_CACHE_LIMIT and LOQ-16978).
+     *
+     * READ THAT PARAGRAPH AS A FLOOR ON THE CONSTANT, NOT AS A SAVING ON THE IMPORT PATH.
+     * It is why >= 100 is asserted, and it holds only for a file whose whole working set
+     * fits inside the limit; for a file LARGER than the limit it claims nothing, because
+     * FIFO eviction leaves close to zero hits however the constant is chosen. The paragraph
+     * below is the one to quote when crediting this cache with a saving.
+     *
+     * DO NOT MEASURE THIS AGAINST THE IMPORT PATH - state the consequence plainly so the
+     * saving is not credited to the wrong place. Eviction is FIFO, so re-running a file
+     * LARGER than this limit yields close to ZERO cache hits: chunk 1's entries are already
+     * evicted by the time run 1 finishes, and re-fetching them during run 2 evicts exactly
+     * what chunk 2 would have needed. Two further facts compound it: only PASSING verdicts
+     * are cached at all (storeBatchVerifyResult()), and address_quality_index defaults to
+     * 'A' (etc/config.xml:20), the strictest value, so on a default install most rows fail
+     * and are therefore never cacheable in the first place. The practical dedupe on the
+     * import path is consequently near nil, and raising this constant would not change that
+     * - it is inherent to FIFO over a working set larger than the cache.
+     *
+     * Where this cache actually pays for itself is ADMIN ORDER CREATE: two addresses per
+     * submission, re-submitted after a validation bounce or an unrelated form error, is
+     * two billed addresses instead of two per attempt - well inside any limit. That is the
+     * win LOQ-16976 buys; a large re-run import is not.
+     */
+    const BATCH_VERIFY_CACHE_LIMIT = 200;
 
     /** @var Verify $apiConnector */
     private $apiConnector;
@@ -179,16 +247,21 @@ class Validator
     /**
      * Verify single address using Loqate API
      *
-     * The Cleansing API behind $this->apiConnector is billable per request, and this
-     * method is wired in from SIX call statements across five classes, every one of
-     * them registered GLOBALLY - etc/di.xml and etc/events.xml carry no area scoping:
+     * The Cleansing API behind $this->apiConnector is billable PER ADDRESS (see the billing
+     * note on verifyMultipleAddresses()); this method sends exactly one address per request,
+     * so here one call is one billed address. It is wired in from SIX call statements across
+     * five classes, every one of them registered GLOBALLY - etc/di.xml and etc/events.xml
+     * carry no area scoping:
      *  - Plugin\Frontend\CheckoutShippingInformation.php:32 - shipping-information POST;
      *  - Plugin\Frontend\CheckoutBillingAddress.php:34 - billing save, which
      *    savePaymentInformation replays at place order, so this one statement can run
      *    twice in a checkout;
-     *  - Observer\QuoteSubmitBefore.php:60 and :84 - shipping and billing on
+     *  - Observer\QuoteSubmitBefore.php:85 and :109 - shipping and billing on
      *    sales_model_service_quote_submit_before, a global event, so it also fires on
-     *    admin order create and multishipping, not just in checkout;
+     *    multishipping, not just in checkout; admin order create is the one path that
+     *    event reaches but these two statements no longer do - the observer returns
+     *    before them there, see QuoteSubmitBefore::isAdminArea() and the note in
+     *    etc/events.xml:14-16;
      *  - Plugin\Frontend\CustomerAccountAddress.php:37 - customer address-book save;
      *  - Plugin\Admin\ValidateAddress.php:42 - admin customer-address validation,
      *    including an admin re-testing the same address repeatedly.
@@ -196,8 +269,10 @@ class Validator
      * Magento version and checkout front-end, and account saves and admin re-tests
      * replay the same address on top of that. Verdicts are therefore de-duplicated on
      * the canonical address signature and replayed from a session-scoped cache, so one
-     * address costs one request (LOQ-16969). verifyMultipleAddresses() has no such
-     * guard yet - LOQ-16976.
+     * address costs one request (LOQ-16969). verifyMultipleAddresses() now has its own
+     * equivalent guard (LOQ-16976), in its own session attribute and with its own key
+     * shape, because its verdicts come from the AQI rather than the AVC - see
+     * self::BATCH_VERIFY_CACHE_SESSION_KEY.
      *
      * CONCURRENCY - stated limit: this de-duplicates SEQUENTIAL calls only. Reading the
      * cache, issuing the billable call and writing the verdict are not atomic and
@@ -298,10 +373,6 @@ class Validator
             ];
         }
 
-        // if (!isset($response[0][0]['AQI']) || !$this->checkQualityIndex($response[0][0]['AQI'])) {
-        //     return ['error' => true, 'message' => __('The provided address is invalid.')];
-        // }
-
         $avcCode = $response[0][0]['AVC'] ?? null;
         if (!is_string($avcCode) || $avcCode === '') {
             // No AVC at all means a response shape we cannot read (the connector
@@ -337,7 +408,7 @@ class Validator
         // It is NOT the status quo, and must not be justified as parity with the
         // pre-existing captured_addresses guard: that guard is written only by
         // Helper\Controller::retrieve() -> storeCapturedAddress()
-        // (Helper/Controller.php:171-186), so it only ever applied to addresses picked
+        // (Helper/Controller.php:179-194), so it only ever applied to addresses picked
         // from the Loqate lookup - addresses Loqate itself authored. Caching successes
         // county-blind extends that county-blindness to TYPED addresses, which is a
         // widening of the bypass. Tightening it (for instance by keying successes
@@ -353,14 +424,136 @@ class Validator
      * Verify multiple addresses using Loqate API
      *
      * Used by admin order create (Plugin\Admin\OrderSave.php:49) and customer import
-     * (Plugin\Admin\ValidateImportAddress.php:38). This path is NOT covered by the
-     * verify verdict cache that verifyAddress() uses and still bills every address on
-     * every submission: its verdicts come from the AQI (checkQualityIndex()), not the
-     * AVC, so it needs its own key and its own verdict shape - tracked as LOQ-16976.
+     * (Plugin\Admin\ValidateImportAddress.php:53).
+     *
+     * BILLING (LOQ-16976): the Cleansing API is billable PER ADDRESS, not per request, so
+     * the verdict cache is consulted PER ADDRESS, before the address is added to the
+     * payload - only misses are sent, so a five-row batch with three rows already verified
+     * in this session bills two. Verdicts live in their own session attribute
+     * (self::BATCH_VERIFY_CACHE_SESSION_KEY) with their own AQI-based namespacing, and are
+     * therefore invisible to verifyAddress()' cache and vice versa: read that constant
+     * before considering merging the two. Only PASSING verdicts are cached, see
+     * storeBatchVerifyResult(). The pre-existing captured-address guard is applied first
+     * and is likewise free.
+     *
+     * RETURN SHAPE - load-bearing in two ways, do not "simplify" either:
+     *  - one entry per input address, under the INPUT's OWN KEY. OrderSave.php:51-57
+     *    reports that key to the admin, and before LOQ-16977 the keys of a mixed batch
+     *    were wrong: the original code recovered them with
+     *    array_search(false, $addressesToCheck) over an array whose values were all
+     *    truthy, so it always got false, coerced to key 0 - every response row overwrote
+     *    $result[0], and the captured addresses' own verdicts were never merged into
+     *    $result at all. The mapping is now an explicit parallel array, see $sentItems.
+     *  - in the INPUT's OWN ORDER, because ValidateImportAddress.php:94 array_merge()s the
+     *    per-chunk arrays and then derives the import row number from the merged
+     *    $index + 1. array_merge() renumbers integer keys BY INSERTION ORDER, not by key
+     *    value, so a result that came back as [3 => .., 0 => .., 1 => .., 2 => ..] - which
+     *    is precisely what filling cache hits during the first pass and API verdicts
+     *    afterwards would otherwise produce - would silently mis-attribute EVERY reported
+     *    row number. $result is therefore pre-seeded with one slot per address in input
+     *    order before any verdict is filled in. A ksort() at the end would NOT be an
+     *    equivalent fix: it would reorder string keys (OrderSave's) and any input that is
+     *    not already in ascending key order.
+     *
+     * WHY THE ROW COUNT IS CHECKED BEFORE ANY ROW IS ATTRIBUTED, and why a mismatch fails the
+     * whole batch. Verdicts are attributed POSITIONALLY - the Nth answer belongs to the Nth
+     * address sent - and the connector makes that attribution unverifiable from the response
+     * itself: Verify::verifyAddress() (vendor/lqt/api-connector/src/Client/Verify.php:50-52)
+     * ends in array_column($response, 'Matches'), and array_column() SILENTLY DROPS every
+     * record that has no 'Matches' key and REINDEXES the survivors into a clean 0..N-1 list.
+     * So a three-address batch whose MIDDLE record came back as a PER-RECORD error envelope
+     * reaches us as a TWO-element list in which position 1 holds address 3's verdict (verified
+     * on PHP 8.3). Without the count guard below, address 2 would be handed address 3's verdict
+     * and - far worse - storeBatchVerifyResult() would persist address 3's PASS against ADDRESS
+     * 2's signature for the rest of the session: the "wrong valid replayed" failure the strict
+     * key exists to prevent, arriving through the one door the single-address path does not have
+     * (verifyAddress() sends one address, so a dropped record leaves it nothing to
+     * mis-attribute).
+     *
+     * NOTE THE EXACT SCOPE, so this guard is not credited with more than it does: array_column()
+     * drops only records MISSING the key. A record that HAS 'Matches' whose value is [] or null
+     * SURVIVES as an empty element and the count is PRESERVED (verified on PHP 8.3), so it sails
+     * past this guard and lands in the attribution loop with no readable AQI. That disjoint fault
+     * is answered there, by checkQualityIndex() failing closed - see both.
+     *
+     * The same array_column() also flattens a class of WHOLE-response faults to the same empty
+     * list: any HTTP 200 body that is not a list of records carrying 'Matches' - {"Items": ...},
+     * {"error":"Unauthorized"}, {} - since each collapses to []. None of those sets
+     * $response['error'], so before the guard they produced zero verdicts, zero log lines and an
+     * import that proceeded entirely unverified with no diagnostic at all.
+     *
+     * WHAT IS NOT IN THAT CLASS, named explicitly so this justification is not widened back out
+     * to faults that were never silent: an unparseable body and a TOP-LEVEL
+     * {"Number":..,"Description":..} envelope. The first json_decode()s to null, so
+     * is_array() fails (vendor/lqt/api-connector/src/Client/Verify.php:50) and the connector
+     * returns ['error' => true, 'message' => 'Unexpected error occurred.'] (same file, :57). The
+     * second makes HttpClient::searchForError() report an error, so post() THROWS
+     * (vendor/lqt/api-connector/src/Client/Http/HttpClient.php:53-55 over :72-74) and
+     * Verify::verifyAddress() catches it into that same shape (Verify.php:53-55). Both were
+     * therefore already answered by the isset($response['error']) branch below, before this
+     * guard existed (all traced on PHP 8.3). Such an envelope does arrive as [] in two
+     * corners, both of them just further instances of the class above rather than new ones,
+     * and both because searchForError()'s return is tested for TRUTHINESS rather than for
+     * false (HttpClient.php:53 over :72-74):
+     *  - a FALSY 'Description' - '' and '0', but equally JSON null, 0 and false;
+     *  - an ABSENT 'Description' next to a present 'Number', which HttpClient.php:73 reads
+     *    UNGUARDED. This one is decided by the error handler in force, not by the body: PHP 8
+     *    raises "Undefined array key" and evaluates the read to null, so with no throwing
+     *    handler the return is falsy and the whole envelope reaches array_column() as [] -
+     *    the count guard's branch. Under Magento's own handler
+     *    (Magento\Framework\App\ErrorHandler, registered in Bootstrap::run() and throwing
+     *    for any level error_reporting() reports) the same warning becomes an \Exception,
+     *    which Verify::verifyAddress()'s catch (Throwable) converts into
+     *    ['error' => true, ...] - the OTHER branch. So one identical body is classified two
+     *    different ways depending on the entry point (a web request, which registers that
+     *    handler, versus a context that never calls Bootstrap::run()). NOT on
+     *    developer-versus-production mode: app/bootstrap.php sets error_reporting(E_ALL) and
+     *    Bootstrap::run() registers the handler, both irrespective of MAGE_MODE. Either
+     *    branch is safe - one returns false, the other returns false - which is why this is
+     *    documented rather than defended against here.
+     *
+     * TRADE-OFF, accepted deliberately: a genuinely TRUNCATED response (Loqate answering
+     * fewer rows than it was sent) now fails the whole batch instead of reporting the rows it
+     * does hold. For the import that means one critical error and no import, where before it
+     * meant later chunks silently renumbered by ValidateImportAddress's array_merge(). That is
+     * the right direction: a mis-numbered row sends the merchant to edit a VALID row while the
+     * genuinely bad one imports unnoticed, whereas a blocked import is loud, retryable and
+     * loses nothing.
+     *
+     * ACCEPTED LIMITS, stated:
+     *  - CONCURRENCY: exactly the limit documented on verifyAddress(). Read, billable call
+     *    and write are not atomic, so two genuinely concurrent submissions of the same
+     *    batch can both miss and both be billed. Sequential replay - the re-submitted
+     *    admin order, the re-run import - is what this de-duplicates.
+     *  - a row present in the response but carrying no readable AQI is answered INVALID and
+     *    is never cached. That is a fail-closed verdict, decided in checkQualityIndex()
+     *    (Helper/Validator.php:841-843) and reached for a record whose 'Matches' list is
+     *    present but empty - the row-count guard below cannot catch that shape, because
+     *    array_column() PRESERVES such a record, see the attribution loop for the
+     *    demonstration. It is a deliberate rejection, not a gap: it costs one
+     *    re-attempt on a response we could not read, where the previous behaviour reported
+     *    "no match found" as VALID.
+     *  - the same address twice in ONE batch is billed twice: both copies miss the cache in
+     *    the pre-flight pass, since nothing is written until the response comes back.
+     *    Tracked as LOQ-17015. Whoever implements it MUST preserve the
+     *    ONE-RESPONSE-ROW-PER-SENT-ITEM assumption the count guard below (:643-651) and the
+     *    positional attribution loop after it both depend on: collapsing duplicates into a
+     *    single payload slot changes the row/address arithmetic, so that dedupe and this
+     *    guard have to be changed TOGETHER. Sending N slots and fanning one row out to
+     *    several caller keys, or sending N-k slots and re-deriving the expected row count
+     *    from the de-duplicated payload rather than from the caller's address count, are both
+     *    safe; silently comparing count($response) against the pre-dedupe count is not.
      *
      * @param $addresses
      * @param bool $checkForCaptured
-     * @return array|false
+     * @return array|false THREE shapes, and every caller has to handle all three - see
+     *                     Plugin\Admin\ValidateImportAddress::afterValidateData():19-32:
+     *                     array<int|string, bool>, one verdict per input key in input order,
+     *                     the normal case; ['noKeyFound' => true] when no API key is
+     *                     configured, which is load-bearing and must NOT be merged into
+     *                     row-indexed data (a string key there is reported as row #1); or
+     *                     false when the API call failed or answered a row count that cannot
+     *                     be attributed to the addresses sent.
      */
     public function verifyMultipleAddresses($addresses, $checkForCaptured = true)
     {
@@ -368,54 +561,166 @@ class Validator
             return ['noKeyFound' => true];
         }
 
-        if ($checkForCaptured) {
-            $storedAddresses = $this->session->getData('captured_addresses');
-        }
+        $storedAddresses = $checkForCaptured ? $this->session->getData('captured_addresses') : null;
 
+        $result = [];
         $requestArray = [];
+
+        // PARALLEL TO $requestArray BY POSITION: $sentItems[$n] describes the address sent
+        // at position $n of the payload - the caller's key to report its verdict under,
+        // and the signature to cache that verdict against. This is the whole of the
+        // LOQ-16977 fix: the key an address came in under is RECORDED when the address is
+        // added to the payload, instead of being guessed at afterwards.
+        $sentItems = [];
+
         foreach ($addresses as $index => $address) {
+            // Reserve this address's slot NOW, so the returned array follows the input key
+            // order however out of order the verdicts are filled in below. See the return
+            // shape note above: this ordering is what keeps import row numbers correct.
+            $result[$index] = null;
+
             $parsedAddress = $this->parseAddress($address);
-            if (isset($storedAddresses)
-                && $storedAddresses
-                && ($checkedAddress = $this->checkForCapturedAddress($parsedAddress, $storedAddresses))) {
-                //store all the address keys in a new array, so we can preserve the original keys/identifiers
-                //because we are not sending the original array for validation and we need them to display results
-                $addressesToCheck[$index] = $checkedAddress;
+
+            // Pre-existing guard, kept ahead of the verdict cache because it is free and
+            // Loqate authored these addresses itself.
+            if ($storedAddresses && $this->checkForCapturedAddress($parsedAddress, $storedAddresses)) {
+                $result[$index] = true;
                 continue;
             }
+
+            $signature = $this->buildBatchVerifySignature($parsedAddress);
+            $cachedVerdict = $this->getCachedBatchVerifyResult($signature);
+            if ($cachedVerdict !== null) {
+                $this->logBatchVerifyCacheOutcome('hit', $signature);
+                $result[$index] = $cachedVerdict;
+                continue;
+            }
+
+            // Every miss becomes exactly one billed address in the request below, so
+            // counting these lines counts the Loqate invoice for this path.
+            $this->logBatchVerifyCacheOutcome('miss', $signature);
+
+            $sentItems[] = ['key' => $index, 'signature' => $signature];
             $requestArray[] = $parsedAddress;
         }
 
-
-        if (!$requestArray && isset($addressesToCheck)) {
-            return $addressesToCheck;
+        if ($requestArray === []) {
+            // Nothing left to ask, because every address was captured or cached (or the
+            // batch was empty). Returning here is what makes an all-hit batch cost NO
+            // request, rather than sending an empty 'Addresses' payload to a billable
+            // endpoint and discarding the answer.
+            return $result;
         }
 
         $response = $this->apiConnector->verifyAddress(['Addresses' => $requestArray, 'source' => $this->version]);
         if (isset($response['error'])) {
+            // A transport failure is not a verdict: nothing is cached, so the next attempt
+            // retries the API instead of replaying the failure for the rest of the session.
+            // Callers MUST handle this non-array return - see
+            // Plugin\Admin\ValidateImportAddress::afterValidateData().
             $this->logger->info($response['message']);
             return false;
         }
 
-        $result = [];
-        if (isset($addressesToCheck)) {
-            foreach ($response as $address) {
-                // BROKEN, pre-existing, left alone deliberately: $addressesToCheck holds
-                // the CAPTURED addresses (all truthy), so array_search(false, ...) can
-                // only ever return false, and every response row is written to
-                // $result[false] === $result[0]. Verdicts for a mixed batch are therefore
-                // mis-attributed. Fixing it changes admin/import behaviour and needs its
-                // own regression cover - tracked as LOQ-16977.
-                $originalPos = array_search(false, $addressesToCheck);
-                $result[$originalPos] = $this->checkQualityIndex($address[0]['AQI']);
-            }
-        } else {
-            foreach ($response as $address) {
-                $result[] = $this->checkQualityIndex($address[0]['AQI']);
-            }
+        // THE PRECONDITION OF POSITIONAL ATTRIBUTION, checked before a single verdict is read
+        // or cached: exactly one answer per address sent. Everything below reads the Nth answer
+        // as the Nth address's verdict, and the connector's array_column($response, 'Matches')
+        // makes that unverifiable per row - it drops records with no 'Matches' key and
+        // reindexes the rest, so a gap arrives as a SHORTER CLEAN LIST that is indistinguishable
+        // from a truncated one and shifts every position after it. See the docblock above for
+        // the full mechanism and the accepted trade-off. Bailing out is therefore the only safe
+        // reading of a count mismatch, and it also gives the whole-response faults the connector
+        // collapses to [] - any 200 body that is not a list of records carrying 'Matches', such as
+        // {"Items": ...}, {"error":"Unauthorized"} or {} - a return value and a log line, where
+        // before they were completely silent. An unparseable body and a top-level error envelope
+        // are NOT among those: the connector reports both as ['error' => true, ...], so the branch
+        // directly above already returns for them and always did. See the docblock.
+        //
+        // Returning false, not a partial array: the callers already treat false as "no verdict
+        // for this batch" and fail closed on it - Plugin\Admin\ValidateImportAddress.php:55-75
+        // reports one critical error and stops, Plugin\Admin\OrderSave.php:59-64 blocks the
+        // order with a message.
+        if (!is_array($response) || count($response) !== count($sentItems)) {
+            $this->logger->info(sprintf(
+                'Loqate batch verify answered %d rows for %d addresses; verdicts not attributed.',
+                is_array($response) ? count($response) : 0,
+                count($sentItems)
+            ));
+
+            return false;
         }
 
-        return $result;
+        // Attribution is positional and, thanks to the guard above, total: $sentItems and
+        // $response are now known to be the same length, so an own counter walks them in
+        // lockstep and every address sent gets exactly one verdict.
+        //
+        // WHAT THE COUNTER DOES AND DOES NOT BUY, stated exactly, because it is easy to read
+        // more into it. foreach pairs the two lists by ITERATION ORDER, so this loop does
+        // depend on $response iterating in the order the payload was built - just as strong an
+        // assumption as reading $response[$position] would be, not a weaker one. That order is
+        // guaranteed upstream, not here: the connector's array_column($response, 'Matches')
+        // emits one element per source record in source order, and Loqate answers records in
+        // the order they were sent. What the counter buys is only that $sentItems is indexed by
+        // POSITION and never by $response's KEYS, so nothing breaks if those keys are ever
+        // something other than the clean 0..N-1 list array_column() happens to produce (a
+        // string key, a gap): the loop still reads the Nth iterated answer as the Nth address.
+        // The count guard above is what keeps the one realistic reordering out of this loop
+        // altogether - a dropped record shortens the list, so the counts differ and we return.
+        $position = 0;
+        foreach ($response as $addressResponse) {
+            $sentItem = $sentItems[$position];
+            $position++;
+
+            // '??' rather than a bare read: post data and connector output are both outside
+            // our control, and a missing AQI must not raise a warning mid-import.
+            $qualityIndex = $addressResponse[0]['AQI'] ?? null;
+
+            // FAILS CLOSED on an AQI we could not read, and the two guards on this path catch
+            // DISJOINT faults - neither one subsumes the other:
+            //  - the ROW-COUNT guard above catches records MISSING the 'Matches' key (the
+            //    connector's array_column($response, 'Matches') DROPS those, so the list is
+            //    shorter and the counts differ) plus the whole-response shapes that collapse
+            //    to [];
+            //  - checkQualityIndex()'s shape guard catches a record that IS PRESENT carrying
+            //    an empty or otherwise unreadable 'Matches' - semantically "Loqate found no
+            //    match for this address".
+            //
+            // The second case is FULLY REACHABLE past the count guard, and this is the
+            // correction of an earlier claim in these comments that it was not. Verified on
+            // PHP 8.3: array_column() only drops records missing the key; a record that HAS
+            // 'Matches' whose value is [] SURVIVES as an empty element and the COUNT IS
+            // PRESERVED. Three records whose middle one is ['Matches' => []] therefore yield a
+            // three-element list that passes the count guard, position 1 arrives here as [],
+            // $addressResponse[0]['AQI'] ?? null is null, and null <= 'A' is true - so before
+            // this change that row was answered VALID. "No match found" being reported as
+            // "valid" is the maximally wrong answer, so this is a genuinely reachable hole
+            // being closed, not defence in depth.
+            //
+            // checkQualityIndex() now mirrors verifyAddress()'s AVC guard
+            // (Helper/Validator.php:377); see its docblock for why the test is on the value's
+            // shape rather than on truthiness, and for the deliberately-unchanged asymmetry on
+            // the threshold side of the comparison.
+            $isValid = $this->checkQualityIndex($qualityIndex);
+            $result[$sentItem['key']] = $isValid;
+
+            // NEVER CACHE A VERDICT WE COULD NOT READ still holds, and it no longer needs a
+            // separate readability test here: an unreadable AQI is now a FALSE verdict, and
+            // storeBatchVerifyResult() caches nothing but passes. One test, one place - the
+            // previous arrangement had the readability rule stated twice (once for the verdict,
+            // once for the cache) and could drift.
+            $this->storeBatchVerifyResult($sentItem['signature'], $isValid);
+        }
+
+        // With the count guard in place this filter is a NO-OP by construction, and that is
+        // worth stating rather than deleting: every reserved slot is now necessarily filled -
+        // captured, cache hit, or sent and therefore answered, since a mismatched row count
+        // returned above - so no null can survive to here. It is kept as the enforcement of the
+        // documented return shape ("no null verdicts, ever"), so that a future edit which adds
+        // a fourth way of leaving a slot unfilled degrades to a missing key, which callers
+        // already read as "nothing to report", instead of shipping a null that
+        // ValidateImportAddress would report as an invalid row. array_filter() preserves both
+        // keys and order, so the return-shape guarantees above survive it either way.
+        return array_filter($result, static fn ($verdict) => $verdict !== null);
     }
 
     /**
@@ -488,16 +793,83 @@ class Validator
     }
 
     /**
-     * Check if response quality index matches the quality customer has set
+     * Check if response quality index matches the quality customer has set.
      *
-     * @param $qualityIndex
-     * @return bool
+     * FAILS CLOSED on an AQI it cannot read. The guard is on the value's SHAPE - "is this a
+     * non-empty string" - and deliberately not on truthiness or emptiness, because the
+     * comparison below is a STRING comparison in which 'A' is the strongest grade
+     * (etc/config.xml:20 defaults the threshold to 'A' and 'A' <= 'A' is true). Anything
+     * looser would over-reject:
+     *  - empty()/falsy would reject '0', and would reject nothing this guard does not
+     *    already catch;
+     *  - a whitelist of known grade letters would reject a grade letter Loqate adds later,
+     *    turning a forward-compatible comparison into a hard-coded one.
+     * A legitimately valid 'A' therefore still passes, and only a genuinely unreadable
+     * value - no string, or the empty string - is rejected.
+     *
+     * WHY THIS IS NOT COSMETIC. Under PHP 8's comparison rules null <= 'A', '' <= 'A',
+     * false <= 'A' and 0 <= 'A' are ALL true (verified on 8.3), so before this guard an
+     * unreadable AQI was answered VALID. The single call site
+     * (the attribution loop, Helper/Validator.php:703) reads
+     * $addressResponse[0]['AQI'] ?? null, which is null for a response record whose
+     * 'Matches' list is present but EMPTY - i.e. Loqate saying "no match for this address",
+     * the case where "valid" is the maximally wrong answer. See the comment at that call
+     * site for why the row-count guard does not catch that shape.
+     *
+     * This mirrors verifyAddress()'s AVC guard (Helper/Validator.php:377), so both verify
+     * paths now draw the "readable verdict" line in exactly the same place.
+     *
+     * KNOWN ASYMMETRY, documented rather than changed. The two halves of this comparison
+     * fail closed for different reasons and with different strength:
+     *  - the AQI side (this guard) fails closed DELIBERATELY, by explicit shape test;
+     *  - the THRESHOLD side fails closed only INCIDENTALLY, out of comparison semantics:
+     *    'A' <= null and 'A' <= '' are both false (verified on 8.3), so were
+     *    address_quality_index ever unset, EVERY address would be rejected. That is left
+     *    exactly as it is. It is not reachable in practice - etc/config.xml:20 supplies the
+     *    default and the field is not exposed in etc/adminhtml/system.xml, so it cannot be
+     *    blanked from the admin UI - and "fixing" it by treating an absent threshold as
+     *    permissive would re-open a fail-open on the config side to close a hole that does
+     *    not exist. resolveQualityIndexThreshold() also returns the value RAW and uncast on
+     *    purpose; see its docblock before touching either side.
+     *
+     * @param $qualityIndex The AQI from the response row, of any type - it is unvalidated
+     *                      connector output, so this method must not assume a string.
+     * @return bool True only when the AQI is readable AND meets the configured threshold.
      */
     private function checkQualityIndex($qualityIndex): bool
     {
-        $configIndex = $this->helper->getConfigValue('loqate_settings/address_settings/address_quality_index');
+        if (!is_string($qualityIndex) || $qualityIndex === '') {
+            return false;
+        }
+
+        $configIndex = $this->resolveQualityIndexThreshold();
 
         return $qualityIndex <= $configIndex;
+    }
+
+    /**
+     * Resolve the address quality index threshold a batch verdict is judged against.
+     *
+     * Extracted from checkQualityIndex() for exactly the reason resolveComparerAvcString()
+     * was extracted from checkAVCStatus(): the batch verdict cache key has to be
+     * namespaced by the threshold that was actually APPLIED, and both the comparison and
+     * the key MUST keep reading it through this one method, or the key can describe a
+     * threshold the verdict was not judged against - a merchant tightening the AQI would
+     * then keep being served verdicts earned under the looser one for the rest of every
+     * live session.
+     *
+     * Returns the configured value RAW and uncast on purpose: checkQualityIndex() compares
+     * it with <=, and under PHP 8's comparison rules 0 <= null (true, null coerced to 0)
+     * and 0 <= '' (false, compared as strings) disagree - so casting here would change
+     * verdicts rather than tidy them. buildBatchVerifyCacheKey() therefore fingerprints
+     * the value's TYPE as well as its text. Deliberately not memoised, for the reason
+     * given on resolveComparerAvcString().
+     *
+     * @return mixed The configured threshold, exactly as checkQualityIndex() compares it.
+     */
+    private function resolveQualityIndexThreshold()
+    {
+        return $this->helper->getConfigValue('loqate_settings/address_settings/address_quality_index');
     }
 
     /**
@@ -993,6 +1365,227 @@ class Validator
             'Loqate verify cache %s [family=%s, key=%s]',
             $outcome,
             $keyFamily,
+            $key === '' ? 'unkeyed' : substr(hash('sha256', $key), 0, 12)
+        ));
+    }
+
+    /**
+     * Build the batch path's cache signature for one parsed address: the STRICT signature,
+     * county (self::COUNTY_FIELD) INCLUDED.
+     *
+     * STRICT-ONLY, deliberately NOT the asymmetric strict/lossy pair verifyAddress() uses
+     * (LOQ-16976). Four reasons, all of which have to stay true for this to remain correct:
+     *  1. this cache never stores a failure (storeBatchVerifyResult()), so the
+     *     rejection-replay checkout dead-end that FORCED the asymmetry over there - a
+     *     cached "invalid" the shopper cannot clear by correcting the county - is
+     *     structurally impossible here. A lossy key would buy nothing safety-wise;
+     *  2. parseAddress() (Helper/Validator.php:737-740, the region_id branch) re-derives
+     *     'region' from region_id on this exact path, canonicalising the county per
+     *     region_id. That derivation is deterministic, so the county churn the lossy key
+     *     exists to absorb is largely absent from admin order create and import;
+     *  3. it could NOT be established that view/base/web/capture.js even loads on the
+     *     admin order-create screen - the sales_order_create_customer_block layout handle
+     *     is unverifiable without Magento core vendored - so the client-side
+     *     county-rewriting premise behind the lossy key is unproven on this path;
+     *  4. an AQI plausibly depends on the county, so a county-blind SUCCESS cache here
+     *     would be a WIDER bypass than the one LOQ-16979 already tracks tightening.
+     * ACCEPTED COST: if the county is rewritten between two submissions of the same
+     * address, that address is billed once more. One request, once, per rewrite.
+     *
+     * Reuses the existing signature builders verbatim, so the '' sentinel, the
+     * normalisation rules and the "every field sent to Loqate is projected" invariant
+     * documented in verifyAddress() hold here without being restated in code.
+     *
+     * @param $address Parsed address, as returned by parseAddress().
+     * @return string Empty when the address carries nothing identifiable, which keeps it
+     *                out of the cache entirely (neither read nor written).
+     */
+    private function buildBatchVerifySignature($address): string
+    {
+        $signature = $this->buildAddressSignature($address);
+
+        return $this->buildStrictAddressSignature(
+            $this->buildVerifySignature($signature, $address),
+            $address
+        );
+    }
+
+    /**
+     * Read a previously stored batch verdict for the given address signature.
+     *
+     * Only ever returns true or null, because only passing verdicts are stored: null means
+     * "not cached, bill it". Defensive in the same way as getCachedVerifyResult() - any
+     * unexpected shape degrades to "not cached", costing one extra address on the invoice,
+     * and never throws in the middle of an import.
+     *
+     * The stored member is 'valid', where the single-address cache stores 'error'. That is
+     * a second, independent guard on top of the separate session attribute: even if the two
+     * stores were ever conflated, an entry written by storeVerifyResult() would fail the
+     * shape check here and degrade to a miss rather than being read as a verdict.
+     *
+     * @param string $signature
+     * @return bool|null true for a cached pass, null when nothing usable is cached.
+     */
+    private function getCachedBatchVerifyResult(string $signature): ?bool
+    {
+        $key = $this->buildBatchVerifyCacheKey($signature);
+        if ($key === '') {
+            return null;
+        }
+
+        $store = $this->session->getData(self::BATCH_VERIFY_CACHE_SESSION_KEY);
+        if (!is_array($store) || !isset($store[$key]) || !is_string($store[$key])) {
+            return null;
+        }
+
+        try {
+            $verdict = $this->serializer->unserialize($store[$key]);
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
+
+        if (!is_array($verdict) || ($verdict['valid'] ?? null) !== true) {
+            return null;
+        }
+
+        return true;
+    }
+
+    /**
+     * Store a batch verdict against the given address signature - if, and only if, it
+     * PASSED.
+     *
+     * NEVER CACHING A FAILURE is load-bearing, not tidiness: it is reason 1 for the
+     * strict-only key documented on buildBatchVerifySignature(). A cached rejection would
+     * need the county in the key to avoid stranding an admin or an import on a verdict they
+     * cannot clear by correcting a field; because no rejection is ever cached, the key can
+     * be strict without introducing that dead-end. The guard therefore lives HERE rather
+     * than at the call site, so a future caller cannot reintroduce cached failures by
+     * forgetting it.
+     *
+     * WHAT THIS GUARD RELIES ON, and where that half lives: "$valid === true" only means
+     * checkQualityIndex() said so, and this method cannot audit that - by the time it is
+     * called the response value is gone. It is safe because checkQualityIndex() itself now
+     * FAILS CLOSED on an AQI it cannot read (Helper/Validator.php:841-843): an unreadable
+     * value can no longer arrive here as a genuine-looking pass to be replayed all session.
+     * Do not relax that guard without adding a readability test at this method's call site
+     * (the attribution loop, Helper/Validator.php:703-711), or unreadable responses start
+     * being cached as passes again.
+     *
+     * Bounding and eviction mirror storeVerifyResult() exactly - unset-then-append so a
+     * refreshed entry does not cost an unrelated address its verdict, FIFO array_shift()
+     * under a $store !== [] guard so the loop terminates even if the limit is ever set to 0
+     * or below, and only the boolean verdict is serialised so no Phrase ever reaches the
+     * serializer.
+     *
+     * @param string $signature
+     * @param bool $valid Whether the address passed the quality index check.
+     * @return void
+     */
+    private function storeBatchVerifyResult(string $signature, bool $valid): void
+    {
+        if (!$valid) {
+            return;
+        }
+
+        $key = $this->buildBatchVerifyCacheKey($signature);
+        if ($key === '') {
+            return;
+        }
+
+        $store = $this->session->getData(self::BATCH_VERIFY_CACHE_SESSION_KEY);
+        if (!is_array($store)) {
+            $store = [];
+        }
+
+        // Drop any existing entry first, then re-insert at the end - see storeVerifyResult()
+        // for why this matters at the limit. The one path that reaches this with the key
+        // already present is the same address appearing twice in ONE batch: both copies miss
+        // the cache in the pre-flight pass, so both are billed and the second response row
+        // refreshes the entry the first one wrote. That double billing is tracked as
+        // LOQ-17015; de-duplicating it must not disturb the one-response-row-per-sent-item
+        // assumption the count guard in verifyMultipleAddresses() depends on - see the
+        // ACCEPTED LIMITS note on that method.
+        unset($store[$key]);
+
+        // Cache keys always contain '|' separators, so they are never numeric keys and
+        // array_shift() cannot renumber them.
+        while ($store !== [] && count($store) >= self::BATCH_VERIFY_CACHE_LIMIT) {
+            array_shift($store);
+        }
+
+        $store[$key] = $this->serializer->serialize(['valid' => true]);
+        $this->session->setData(self::BATCH_VERIFY_CACHE_SESSION_KEY, $store);
+    }
+
+    /**
+     * Namespace a batch address signature into its session cache key.
+     *
+     * Same shape as buildVerifyCacheKey() - store view, threshold fingerprint, signature -
+     * for the same reasons, but over a DIFFERENT threshold: this path's verdicts come from
+     * the address quality index (checkQualityIndex()), so the fingerprint is taken over
+     * loqate_settings/address_settings/address_quality_index via
+     * resolveQualityIndexThreshold(), NOT over resolveComparerAvcString(). Hashing the AVC
+     * comparer here would namespace an AQI verdict by a threshold it was never judged
+     * against: tightening the AQI would not invalidate anything, and a live session would
+     * keep passing rows the merchant has just decided are too poor to accept.
+     *
+     * The store view segment is required for the same reason as over there: the threshold
+     * is read at SCOPE_STORE (Data::getConfigValue()) while one session can span store
+     * views (?___store=, a language switcher).
+     *
+     * Truncated to 12 hex characters, so it can never contain the '|' the signature parts
+     * are joined with and the session payload does not carry 64 characters per entry.
+     *
+     * @param string $signature
+     * @return string Empty when $signature is empty, keeping the '' sentinel intact.
+     */
+    private function buildBatchVerifyCacheKey(string $signature): string
+    {
+        if ($signature === '') {
+            return '';
+        }
+
+        // TYPE and text, because the threshold is compared raw: null, '' and 0 behave
+        // differently under <= in PHP 8 (see resolveQualityIndexThreshold()), so they must
+        // not share a fingerprint. Non-scalars contribute their type alone - a non-scalar
+        // threshold makes the comparison meaningless anyway, and (string) would throw.
+        $threshold = $this->resolveQualityIndexThreshold();
+        $thresholdSource = gettype($threshold) . ':' . (is_scalar($threshold) ? (string)$threshold : '');
+        $thresholdFingerprint = substr(hash('sha256', $thresholdSource), 0, 12);
+
+        return $this->helper->getCurrentStore() . '|' . $thresholdFingerprint . '|' . $signature;
+    }
+
+    /**
+     * Debug-log the outcome of one batch verdict cache lookup, so the drop in billable
+     * addresses on the admin/import path can be reconciled without waiting for the Loqate
+     * invoice: misses map one-to-one onto billed addresses.
+     *
+     * A sibling of logVerifyCacheOutcome() rather than a call to it, for one concrete
+     * reason: that method hashes buildVerifyCacheKey(), the AVC-namespaced key, which for
+     * an address on this path names a cache entry that does not exist - the log line would
+     * correlate with the wrong cache. The family is fixed at 'strict' because this cache
+     * has exactly one key family (see buildBatchVerifySignature()).
+     *
+     * Same PII rule, which is absolute: NEVER log the address or the raw signature. A log
+     * file is not the customer session - it is readable by anyone with server access, it
+     * outlives the session and it is shipped to log aggregators. A truncated SHA-256 of the
+     * namespaced key correlates the hits and misses of one address with each other and with
+     * a request count, which is all the reconciliation needs. See logVerifyCacheOutcome()
+     * for how to turn DEBUG records on.
+     *
+     * @param string $outcome 'hit' or 'miss'.
+     * @param string $signature Signature the lookup was made with; never logged as-is.
+     * @return void
+     */
+    private function logBatchVerifyCacheOutcome(string $outcome, string $signature): void
+    {
+        $key = $this->buildBatchVerifyCacheKey($signature);
+
+        $this->logger->debug(sprintf(
+            'Loqate batch verify cache %s [family=strict, key=%s]',
+            $outcome,
             $key === '' ? 'unkeyed' : substr(hash('sha256', $key), 0, 12)
         ));
     }

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -72,16 +72,30 @@ class Validator
      * process- or install-wide and would serve one shopper's verdict to another.
      * Entries are additionally namespaced per store view and per resolved AVC threshold,
      * see buildVerifyCacheKey().
+     *
+     * "Per-shopper" is enforced, not merely assumed: a PHP session survives a login
+     * (session_regenerate_id() changes the ID and keeps the data), so this attribute is
+     * reached through ShopperScopedSession, which flushes it whenever the logged-in
+     * customer changes (LOQ-16978).
+     *
+     * An ALIAS of ShopperScopedSession::VERIFY_CACHE_SESSION_KEY, kept so every existing
+     * reference to Validator::VERIFY_CACHE_SESSION_KEY still resolves. The literal lives on
+     * the guard because the guard is what enforces this attribute's lifetime, and holding
+     * it here made the dependency circular - the guard's flush list pointed at this class
+     * while this class constructs the guard.
      */
-    const VERIFY_CACHE_SESSION_KEY = 'loqate_verified_addresses';
+    const VERIFY_CACHE_SESSION_KEY = ShopperScopedSession::VERIFY_CACHE_SESSION_KEY;
 
     /**
      * Maximum number of verdicts kept per session, oldest evicted first.
      *
-     * Bounded so the cache cannot inflate the session payload the way the pre-existing
-     * "captured_addresses" store does: that one grows without limit for the whole
-     * session (Helper/Controller.php:179-194), which is tracked as LOQ-16978 and is
-     * deliberately not replicated here.
+     * Bounded so the cache cannot inflate the session payload, and small because this is
+     * the INTERACTIVE path: one shopper checking out replays a handful of addresses across
+     * the call paths listed on verifyAddress(), so 50 distinct addresses is already far
+     * beyond a realistic session. Helper\Controller::CAPTURED_ADDRESSES_LIMIT now bounds
+     * the older captured-address store at the same figure and for the same reasons
+     * (LOQ-16978); self::BATCH_VERIFY_CACHE_LIMIT is the one that is deliberately larger,
+     * because only that path has to hold a 100-row import chunk.
      */
     const VERIFY_CACHE_LIMIT = 50;
 
@@ -101,9 +115,17 @@ class Validator
      * structurally impossible rather than merely unlikely, and cost one extra session key.
      *
      * Same lifetime rules as the single-address cache: a verdict is customer data, so it
-     * lives in the per-shopper customer session and nowhere process- or install-wide.
+     * lives in the per-shopper customer session and nowhere process- or install-wide, and
+     * it is reached through ShopperScopedSession so that it is flushed when the logged-in
+     * customer changes (LOQ-16978) - subject to the ACCEPTED LIMITS on that class, which
+     * name THIS attribute specifically: it is written only from adminhtml, where the
+     * customer session carries no customer id, so the guard's flush is a no-op for it and
+     * an admin-user swap inside one browser session is not covered.
+     *
+     * An ALIAS of ShopperScopedSession::BATCH_VERIFY_CACHE_SESSION_KEY, for the same
+     * dependency-direction reason as self::VERIFY_CACHE_SESSION_KEY above.
      */
-    const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
+    const BATCH_VERIFY_CACHE_SESSION_KEY = ShopperScopedSession::BATCH_VERIFY_CACHE_SESSION_KEY;
 
     /**
      * Maximum number of batch verdicts kept per session, oldest evicted first.
@@ -114,7 +136,9 @@ class Validator
      * even one chunk - the eviction would discard a chunk's earliest rows before the
      * chunk finished, and re-running a file that FITS WITHIN THIS LIMIT would re-bill them.
      * 200 holds two full chunks while still bounding the session payload, which is the whole
-     * point of having a limit at all (see self::VERIFY_CACHE_LIMIT and LOQ-16978).
+     * point of having a limit at all (see self::VERIFY_CACHE_LIMIT and
+     * Helper\Controller::CAPTURED_ADDRESSES_LIMIT, both 50 because no import writes to
+     * them).
      *
      * READ THAT PARAGRAPH AS A FLOOR ON THE CONSTANT, NOT AS A SAVING ON THE IMPORT PATH.
      * It is why >= 100 is asserted, and it holds only for a file whose whole working set
@@ -146,8 +170,13 @@ class Validator
     /** @var Logger $logger */
     private $logger;
 
-    /** @var Session $session */
-    private $session;
+    /**
+     * @var ShopperScopedSession The captured-address store and the two verdict caches,
+     *      behind the shopper-ownership guard. The raw customer session is deliberately
+     *      NOT kept as well: keeping it would leave a way to reach those stores without
+     *      the guard - see ShopperScopedSession.
+     */
+    private ShopperScopedSession $shopperSession;
 
     /** @var RegionFactory */
     private $regionFactory;
@@ -162,7 +191,9 @@ class Validator
      * Validator construct
      *
      * @param Logger $logger
-     * @param Session $session
+     * @param Session $session Wrapped in a ShopperScopedSession and not kept raw, so the
+     *                         captured-address store and both verdict caches can only be
+     *                         reached through the shopper-ownership guard.
      * @param RegionFactory $regionFactory
      * @param ModuleListInterface $moduleList
      * @param Data $helper
@@ -177,7 +208,7 @@ class Validator
         SerializerInterface $serializer
     ) {
         $this->logger = $logger;
-        $this->session = $session;
+        $this->shopperSession = new ShopperScopedSession($session);
         $this->regionFactory = $regionFactory;
         $this->helper = $helper;
         $this->serializer = $serializer;
@@ -297,7 +328,8 @@ class Validator
         }
 
         $requestArray = $this->parseAddress($address);
-        if ($checkForCaptured && ($storedAddresses = $this->session->getData('captured_addresses'))) {
+        $capturedKey = Controller::CAPTURED_ADDRESSES_SESSION_KEY;
+        if ($checkForCaptured && ($storedAddresses = $this->shopperSession->getData($capturedKey))) {
             if ($this->checkForCapturedAddress($requestArray, $storedAddresses)) {
                 return ['error' => false];
             }
@@ -407,14 +439,13 @@ class Validator
         //
         // It is NOT the status quo, and must not be justified as parity with the
         // pre-existing captured_addresses guard: that guard is written only by
-        // Helper\Controller::retrieve() -> storeCapturedAddress()
-        // (Helper/Controller.php:179-194), so it only ever applied to addresses picked
-        // from the Loqate lookup - addresses Loqate itself authored. Caching successes
-        // county-blind extends that county-blindness to TYPED addresses, which is a
-        // widening of the bypass. Tightening it (for instance by keying successes
-        // strictly and canonicalising the county instead) is tracked as LOQ-16979,
-        // "tighten county-blind verify verdict cache so unverified county variants
-        // cannot pass".
+        // Helper\Controller::retrieve() -> storeCapturedAddress(), so it only ever applied
+        // to addresses picked from the Loqate lookup - addresses Loqate itself authored.
+        // Caching successes county-blind extends that county-blindness to TYPED addresses,
+        // which is a widening of the bypass. Tightening it (for instance by keying
+        // successes strictly and canonicalising the county instead) is tracked as
+        // LOQ-16979, "tighten county-blind verify verdict cache so unverified county
+        // variants cannot pass".
         $this->storeVerifyResult($verifySignature, false);
 
         return ['error' => false];
@@ -561,7 +592,9 @@ class Validator
             return ['noKeyFound' => true];
         }
 
-        $storedAddresses = $checkForCaptured ? $this->session->getData('captured_addresses') : null;
+        $storedAddresses = $checkForCaptured
+            ? $this->shopperSession->getData(Controller::CAPTURED_ADDRESSES_SESSION_KEY)
+            : null;
 
         $result = [];
         $requestArray = [];
@@ -975,8 +1008,22 @@ class Validator
 
     /**
      * Check for captured addresses, so they should not be verified if already captured
+     *
+     * DEFENSIVE ABOUT THE STORE'S SHAPE, AT BOTH LEVELS (LOQ-16978). The store is read
+     * from the bare Controller::CAPTURED_ADDRESSES_SESSION_KEY session attribute, which
+     * this module does not own exclusively: another module, an older release or a
+     * truncated session payload can leave a non-array THERE, or a non-string element
+     * INSIDE it. Both are checked here rather than at the two call sites (verifyAddress()
+     * and verifyMultipleAddresses()) so the single relation that grants the verify bypass
+     * carries the single guard, and neither caller can be the one that forgot it.
+     *
+     * Neither shape may cost more than a missed bypass. This runs mid-checkout, so a
+     * malformed store must fall through to a normal verify - never a fatal, and never a
+     * warning either: under developer mode Magento's ErrorHandler promotes E_WARNING to
+     * an exception, so "degrades to a skipped loop" is not a safe resting place here.
+     *
      * @param $address
-     * @param $storedAddresses
+     * @param $storedAddresses Normally a list of serialised addresses, but see above.
      * @return bool
      */
     private function checkForCapturedAddress($address, $storedAddresses): bool
@@ -986,7 +1033,26 @@ class Validator
             return false;
         }
 
+        if (!is_array($storedAddresses)) {
+            // A truthy non-array whole attribute - both call sites only test the value for
+            // truthiness before handing it over. foreach over a scalar is an E_WARNING and
+            // an exception in developer mode, so it is rejected before the loop, not by it.
+            return false;
+        }
+
         foreach ($storedAddresses as $stored) {
+            if (!is_string($stored)) {
+                // Not something Controller::storeCapturedAddress() wrote. Skipped rather
+                // than unserialised: the production serializer
+                // (Magento\Framework\Serialize\Serializer\Json) hands its argument straight
+                // to json_decode(), whose first parameter is declared `string $json`, so an
+                // array or object element raises a TypeError - which is an \Error, not the
+                // \InvalidArgumentException caught below. This is the mirror of the guard in
+                // Helper\Controller::isSameCapturedAddress() (LOQ-16978); the two read the
+                // same store and must survive the same values.
+                continue;
+            }
+
             try {
                 $storedData = $this->serializer->unserialize($stored);
             } catch (\InvalidArgumentException $e) {
@@ -1003,6 +1069,57 @@ class Validator
         }
 
         return false;
+    }
+
+    /**
+     * The captured-address equality relation, exposed so the STORE and the MATCHER agree.
+     *
+     * WHY THIS IS PUBLIC AND STATIC (LOQ-16978 review). Two addresses are "the same
+     * captured address" if and only if they project onto the same signature - that is the
+     * relation checkForCapturedAddress() grants the verify bypass on. The store's writer,
+     * Helper\Controller::storeCapturedAddress(), has to de-duplicate on the SAME relation,
+     * or the two drift apart: it used to compare the exact serialised bytes of the six
+     * ADDRESS_CAPTURE_MAPPING fields, so two captures differing only in letter case, in
+     * whitespace, in ProvinceName (which this signature excludes entirely) or in ''-versus-
+     * missing Line2 were ONE address for bypass purposes but TWO slots in a bounded store -
+     * which is exactly the "cycling one address through the lookup fills every slot"
+     * failure the de-duplication exists to prevent.
+     *
+     * Static because the projection is pure - it reads only self::CAPTURED_SIGNATURE_FIELDS
+     * and normalises - so Controller can call it without constructing a Validator (which
+     * would need five more collaborators and would build a billable API connector).
+     *
+     * NO PARAMETER TYPE DECLARATION, deliberately (LOQ-16978 review). The intended input is
+     * an array in the Loqate field shape (ADDRESS_CAPTURE_MAPPING's keys, or
+     * parseAddress()'s output - they overlap on the fields this projects), but the internal
+     * callers reach here through buildAddressSignature() with whatever
+     * checkForCapturedAddress()/buildBatchVerifySignature() were handed, which is typed
+     * `mixed`, and Helper\Controller guards its own call with is_array() only on the
+     * deserialised path. Declaring `array` would convert today's graceful degradation into
+     * a TypeError raised mid-checkout, which is the opposite of what every other reader in
+     * this class does. Anything that is not an array degrades to '': `$address[$key] ?? null`
+     * yields null for a scalar or null $address (a string index with a non-numeric key
+     * likewise), null normalises to '', and an all-'' projection returns the ''
+     * "nothing identifiable" sentinel - so an unusable input is simply kept out of every
+     * comparison instead of matching something.
+     *
+     * @param mixed $address Normally an array in the Loqate field shape; any other value
+     *                       degrades to the '' sentinel as described above.
+     * @return string '' when the address carries nothing identifiable, which keeps it out
+     *                of every comparison rather than matching other empty addresses.
+     */
+    public static function capturedAddressSignature($address): string
+    {
+        $parts = [];
+        foreach (self::CAPTURED_SIGNATURE_FIELDS as $key) {
+            $parts[] = self::normaliseSignatureValue($address[$key] ?? null);
+        }
+
+        if (trim(implode('', $parts)) === '') {
+            return '';
+        }
+
+        return implode('|', $parts);
     }
 
     /**
@@ -1026,21 +1143,17 @@ class Validator
      * buildStrictAddressSignature(). '' means "nothing identifiable" and keeps an address
      * out of both comparisons.
      *
+     * The body lives on self::capturedAddressSignature(), which
+     * Helper\Controller::storeCapturedAddress() also calls so that the store de-duplicates
+     * on the very relation this comparison grants the bypass on. This remains the name the
+     * rest of this class - and the tests - use.
+     *
      * @param $address
      * @return string
      */
     private function buildAddressSignature($address): string
     {
-        $parts = [];
-        foreach (self::CAPTURED_SIGNATURE_FIELDS as $key) {
-            $parts[] = $this->normaliseSignatureValue($address[$key] ?? null);
-        }
-
-        if (trim(implode('', $parts)) === '') {
-            return '';
-        }
-
-        return implode('|', $parts);
+        return self::capturedAddressSignature($address);
     }
 
     /**
@@ -1160,7 +1273,7 @@ class Validator
 
         $parts = [$signature];
         foreach ($fields as $field) {
-            $parts[] = $this->normaliseSignatureValue($address[$field] ?? null);
+            $parts[] = self::normaliseSignatureValue($address[$field] ?? null);
         }
 
         return implode('|', $parts);
@@ -1172,10 +1285,14 @@ class Validator
      * the signature. Non-scalars (Magento's street array, objects) and missing
      * values normalise to '' rather than throwing.
      *
+     * Static so that self::capturedAddressSignature() - the projection Helper\Controller
+     * shares - can be static too. Every call site inside this class uses self:: rather
+     * than $this->: both resolve, but $this-> on a static method reads as an oversight.
+     *
      * @param $value
      * @return string
      */
-    private function normaliseSignatureValue($value): string
+    private static function normaliseSignatureValue($value): string
     {
         if (!is_scalar($value)) {
             return '';
@@ -1214,7 +1331,7 @@ class Validator
             return null;
         }
 
-        $store = $this->session->getData(self::VERIFY_CACHE_SESSION_KEY);
+        $store = $this->shopperSession->getData(self::VERIFY_CACHE_SESSION_KEY);
         if (!is_array($store) || !isset($store[$key]) || !is_string($store[$key])) {
             return null;
         }
@@ -1257,7 +1374,7 @@ class Validator
             return;
         }
 
-        $store = $this->session->getData(self::VERIFY_CACHE_SESSION_KEY);
+        $store = $this->shopperSession->getData(self::VERIFY_CACHE_SESSION_KEY);
         if (!is_array($store)) {
             $store = [];
         }
@@ -1287,7 +1404,7 @@ class Validator
         }
 
         $store[$key] = $this->serializer->serialize(['error' => $error]);
-        $this->session->setData(self::VERIFY_CACHE_SESSION_KEY, $store);
+        $this->shopperSession->setData(self::VERIFY_CACHE_SESSION_KEY, $store);
     }
 
     /**
@@ -1433,7 +1550,7 @@ class Validator
             return null;
         }
 
-        $store = $this->session->getData(self::BATCH_VERIFY_CACHE_SESSION_KEY);
+        $store = $this->shopperSession->getData(self::BATCH_VERIFY_CACHE_SESSION_KEY);
         if (!is_array($store) || !isset($store[$key]) || !is_string($store[$key])) {
             return null;
         }
@@ -1493,7 +1610,7 @@ class Validator
             return;
         }
 
-        $store = $this->session->getData(self::BATCH_VERIFY_CACHE_SESSION_KEY);
+        $store = $this->shopperSession->getData(self::BATCH_VERIFY_CACHE_SESSION_KEY);
         if (!is_array($store)) {
             $store = [];
         }
@@ -1515,7 +1632,7 @@ class Validator
         }
 
         $store[$key] = $this->serializer->serialize(['valid' => true]);
-        $this->session->setData(self::BATCH_VERIFY_CACHE_SESSION_KEY, $store);
+        $this->shopperSession->setData(self::BATCH_VERIFY_CACHE_SESSION_KEY, $store);
     }
 
     /**

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -63,20 +63,28 @@ class Validator
     private const VALID_QUALITY_INDEXES = ['A', 'B', 'C', 'D', 'E'];
 
     /**
-     * Version of the verify cache's KEY SCHEME. Stamped into every verdict
-     * storeVerifyResult() writes and required to match on every read
-     * (getCachedVerifyResult()); an entry stamped with anything else is discarded.
+     * Version of the verify caches' KEY SCHEME. Stamped into every verdict written by
+     * storeVerifyResult() AND storeBatchVerifyResult(), and required to match on every read
+     * (getCachedVerifyResult(), getCachedBatchVerifyResult()); an entry stamped with anything
+     * else is discarded.
      *
      * A session outlives a deploy, so without this a payload written under an older key
      * shape would be answered as though its key named the address the CURRENT shape derives
-     * from that key. Bump it whenever buildVerifyCacheSignature() or buildVerifyCacheKey()
-     * changes what a key means: stale entries are then re-verified once, which is the safe
-     * direction.
+     * from that key. Bump it whenever buildVerifyCacheSignature() or either cache's key
+     * builder changes what a key means: stale entries are then re-verified once, which is the
+     * safe direction.
      *
-     * Deliberately not carried on the BATCH cache: that store's payload is exactly
-     * ['valid' => true], and the shape being distinct from this one is itself the second
-     * guard against the two verdict caches being read for each other
-     * (getCachedBatchVerifyResult()), so it gets its own stamp only when its own key changes.
+     * ONE version covers BOTH caches because both key builders sit on the same signature -
+     * buildVerifyCacheSignature() - so any change to what a key means changes it for both at
+     * once. A second constant would be two things to bump and one of them would be forgotten.
+     *
+     * An earlier revision carried this on the single-address cache only, reasoning that the
+     * batch payload's distinct shape (['valid' => ...] against ['error' => ...]) already
+     * guards the two caches from being read for each other. True, and unrelated: that guard
+     * is about CROSS-CACHE conflation, while this stamp is about CROSS-DEPLOY staleness. The
+     * batch cache needed it more, not less - storeBatchVerifyResult() stores only PASSES, so
+     * every stale batch replay is a false ACCEPT, where the single-address cache stores
+     * rejections too and can at worst replay a stale refusal.
      */
     private const VERIFY_KEY_SCHEMA_VERSION = 1;
 
@@ -172,6 +180,12 @@ class Validator
      * and are therefore never cacheable in the first place. The practical dedupe on the
      * import path is consequently near nil, and raising this constant would not change that
      * - it is inherent to FIFO over a working set larger than the cache.
+     *
+     * THIS IS TRACKED, NOT ACCEPTED. LOQ-16976 was raised for admin order create AND customer
+     * import; this cache delivers the first. The import half is LOQ-17148, which is where the
+     * two fixable causes belong - caching failed verdicts on that path, where a failure costs
+     * a re-verify rather than a bypass, and exposing address_quality_index in
+     * etc/adminhtml/system.xml so the default cannot silently fail every row.
      *
      * Where this cache actually pays for itself is ADMIN ORDER CREATE: two addresses per
      * submission, re-submitted after a validation bounce or an unrelated form error, is
@@ -726,8 +740,8 @@ class Validator
             //
             // checkQualityIndex() now mirrors verifyAddress()'s AVC guard; see
             // checkQualityIndex()'s own docblock for why the test is on the value's shape
-            // rather than on truthiness, and for the deliberately-unchanged asymmetry on the
-            // threshold side of the comparison.
+            // rather than on truthiness, and for why an unrecognised THRESHOLD rejects rather
+            // than - as it once did - passing every address.
             $isValid = $this->checkQualityIndex($qualityIndex);
             $result[$sentItem['key']] = $isValid;
 
@@ -1593,6 +1607,13 @@ class Validator
             return null;
         }
 
+        // Written under an older key scheme, so the key no longer names the address it was
+        // derived from. Discarding re-verifies once; replaying would be a false ACCEPT,
+        // because this store holds only passes. Same check as getCachedVerifyResult().
+        if (($verdict['schema'] ?? null) !== self::VERIFY_KEY_SCHEMA_VERSION) {
+            return null;
+        }
+
         return true;
     }
 
@@ -1658,7 +1679,15 @@ class Validator
             array_shift($store);
         }
 
-        $store[$key] = $this->serializer->serialize(['valid' => true]);
+        // 'valid' rather than 'error' keeps the payload shape distinct from the single-address
+        // cache's, which is the second guard against the two caches answering each other's
+        // lookups. The schema stamp is a different guard, against a session that outlives a
+        // deploy; see self::VERIFY_KEY_SCHEMA_VERSION for why this store needs it MORE than
+        // the other one.
+        $store[$key] = $this->serializer->serialize([
+            'valid' => true,
+            'schema' => self::VERIFY_KEY_SCHEMA_VERSION,
+        ]);
         $this->shopperSession->setData(self::BATCH_VERIFY_CACHE_SESSION_KEY, $store);
     }
 

--- a/Model/AdminNotification/UnverifiedAdminOrderMessage.php
+++ b/Model/AdminNotification/UnverifiedAdminOrderMessage.php
@@ -3,6 +3,7 @@
 namespace Loqate\ApiIntegration\Model\AdminNotification;
 
 use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Logger\Logger;
 use Magento\Framework\Notification\MessageInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -51,14 +52,19 @@ class UnverifiedAdminOrderMessage implements MessageInterface
     /** @var StoreManagerInterface */
     private $storeManager;
 
+    /** @var Logger */
+    private $logger;
+
     /**
      * @param Data $helper
      * @param StoreManagerInterface $storeManager
+     * @param Logger $logger
      */
-    public function __construct(Data $helper, StoreManagerInterface $storeManager)
+    public function __construct(Data $helper, StoreManagerInterface $storeManager, Logger $logger)
     {
         $this->helper = $helper;
         $this->storeManager = $storeManager;
+        $this->logger = $logger;
     }
 
     /**
@@ -153,13 +159,24 @@ class UnverifiedAdminOrderMessage implements MessageInterface
     }
 
     /**
-     * Store views to evaluate, or [null] meaning "read at the current scope".
+     * ACTIVE store views to evaluate, or [null] meaning "read at the current scope".
      *
-     * Falls back to the current scope when the store list cannot be read. getStores() touches
-     * the database, and a system message is rendered on admin pages that must not be brought
-     * down by it - including, in the worst case, the very pages an admin would use to fix a
-     * broken store table. A missed notice is a far better failure than an unusable admin, and
-     * the fallback still catches the default-scope case, which is the common one.
+     * Only active stores. An INACTIVE store view cannot take an order, so warning that its
+     * orders go unverified is a warning about something that cannot happen - and this notice is
+     * MAJOR severity, so spurious entries are what teach an admin to dismiss it unread.
+     *
+     * Falls back to the current scope if the store list cannot be read at all. Not because that
+     * read is expensive - getStores() resolves the memoised 'scopes' app config, normally from
+     * the config cache, and is already loaded during bootstrap, so an install where it fails is
+     * an install whose admin cannot render anyway - but because a config NOTICE has no business
+     * being the thing that turns a degraded admin into an unusable one. The fallback still
+     * catches the default-scope case, which is the common one.
+     *
+     * Catches \Throwable, not \Exception: a TypeError or an Error from a third-party store
+     * implementation would otherwise escape, which is the same failure the narrower catch was
+     * written to avoid. Observer\QuoteSubmitBefore::isAdminArea() catches \Throwable for this
+     * same reason. Logged so a silent downgrade to the scope-blind read - the very thing this
+     * method exists to remove - cannot pass unnoticed.
      *
      * @return array<int|null>
      */
@@ -168,9 +185,19 @@ class UnverifiedAdminOrderMessage implements MessageInterface
         try {
             $storeIds = [];
             foreach ($this->storeManager->getStores() as $store) {
+                if (method_exists($store, 'getIsActive') && !$store->getIsActive()) {
+                    continue;
+                }
+
                 $storeIds[] = (int)$store->getId();
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            $this->logger->info(
+                'Loqate: could not read the store list to check whether admin order create is verified; '
+                . 'falling back to the current scope, so a per-store-view setting may go unreported. '
+                . $e->getMessage()
+            );
+
             return [null];
         }
 

--- a/Model/AdminNotification/UnverifiedAdminOrderMessage.php
+++ b/Model/AdminNotification/UnverifiedAdminOrderMessage.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Loqate\ApiIntegration\Model\AdminNotification;
+
+use Loqate\ApiIntegration\Helper\Data;
+use Magento\Framework\Notification\MessageInterface;
+
+/**
+ * Admin system message for the one toggle combination that verifies nothing.
+ *
+ * Observer\QuoteSubmitBefore returns early for the admin area, because Plugin\Admin\OrderSave
+ * already verifies both addresses of an admin-created order in ONE batch call and running the
+ * observer as well would bill up to two more single-address calls for the same order. The
+ * consequence is that admin order create is governed SOLELY by the
+ * loqate_settings/*_settings/enable_create_order_admin toggles.
+ *
+ * That is the intended reading of those toggles - "enable create order admin = No" is the
+ * merchant asking for admin order create not to be verified - EXCEPT in one combination. With
+ * enable_create_order_admin OFF and enable_checkout ON, the observer used to be the only thing
+ * verifying an admin-created order, and now nothing is. A merchant who set those two toggles
+ * that way believed they had verification switched on somewhere.
+ *
+ * This exists because that fact was previously recorded only in a docblock, which is not a
+ * place a merchant looks. The check is evaluated per request rather than stored, so the notice
+ * appears and clears as the configuration changes.
+ */
+class UnverifiedAdminOrderMessage implements MessageInterface
+{
+    /**
+     * Identity of this message.
+     *
+     * Fixed rather than derived from the current configuration: Magento uses the identity to
+     * remember that an admin dismissed the notice, so varying it per config state would make a
+     * dismissal apply to only one combination and resurface the notice on the next change.
+     */
+    const MESSAGE_IDENTITY = 'loqate_unverified_admin_order_create';
+
+    /**
+     * Config groups whose enable_create_order_admin / enable_checkout pair this notice covers.
+     *
+     * Exactly the groups Observer\QuoteSubmitBefore gated on before its early return - address
+     * and phone. Email is absent because that observer never verified email on this path, so
+     * the early return took nothing away from it.
+     */
+    const AFFECTED_GROUPS = ['address_settings', 'phone_settings'];
+
+    /** @var Data */
+    private $helper;
+
+    /**
+     * @param Data $helper
+     */
+    public function __construct(Data $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentity()
+    {
+        return self::MESSAGE_IDENTITY;
+    }
+
+    /**
+     * Show only when at least one group is in the combination that verifies nothing.
+     *
+     * No API-key check: the notice is about a configuration contradiction, and it is worth
+     * correcting whether or not a key is currently installed.
+     *
+     * @return bool
+     */
+    public function isDisplayed()
+    {
+        return $this->affectedGroups() !== [];
+    }
+
+    /**
+     * @return \Magento\Framework\Phrase|string
+     */
+    public function getText()
+    {
+        $groups = $this->affectedGroups();
+
+        return __(
+            'Loqate: admin order create is not being verified for %1. Those settings have '
+            . '"Enable on Create Order (Admin)" set to No while "Enable on Checkout" is Yes, and '
+            . 'admin order create obeys only the admin toggle - so no verification runs there at '
+            . 'all. Set "Enable on Create Order (Admin)" to Yes to verify admin-created orders.',
+            implode(', ', $groups)
+        );
+    }
+
+    /**
+     * Major: it reports addresses or phone numbers going unverified, which is a correctness
+     * problem for the merchant's data, but it is a configuration choice they can act on rather
+     * than a fault, so it is not critical.
+     *
+     * @return int
+     */
+    public function getSeverity()
+    {
+        return self::SEVERITY_MAJOR;
+    }
+
+    /**
+     * Human-readable names of the groups currently in the unverified combination.
+     *
+     * @return string[]
+     */
+    private function affectedGroups(): array
+    {
+        $affected = [];
+
+        foreach (self::AFFECTED_GROUPS as $group) {
+            $adminEnabled = $this->helper->getConfigValue(
+                'loqate_settings/' . $group . '/enable_create_order_admin'
+            );
+            $checkoutEnabled = $this->helper->getConfigValue(
+                'loqate_settings/' . $group . '/enable_checkout'
+            );
+
+            // Compared as ints because these are Magento yes/no selects, which arrive as the
+            // strings '0' and '1' from core_config_data but as ints from a data patch.
+            if ((int)$adminEnabled === 0 && (int)$checkoutEnabled === 1) {
+                $affected[] = $group === 'address_settings' ? 'Address Settings' : 'Phone Settings';
+            }
+        }
+
+        return $affected;
+    }
+}

--- a/Model/AdminNotification/UnverifiedAdminOrderMessage.php
+++ b/Model/AdminNotification/UnverifiedAdminOrderMessage.php
@@ -4,6 +4,7 @@ namespace Loqate\ApiIntegration\Model\AdminNotification;
 
 use Loqate\ApiIntegration\Helper\Data;
 use Magento\Framework\Notification\MessageInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Admin system message for the one toggle combination that verifies nothing.
@@ -47,12 +48,17 @@ class UnverifiedAdminOrderMessage implements MessageInterface
     /** @var Data */
     private $helper;
 
+    /** @var StoreManagerInterface */
+    private $storeManager;
+
     /**
      * @param Data $helper
+     * @param StoreManagerInterface $storeManager
      */
-    public function __construct(Data $helper)
+    public function __construct(Data $helper, StoreManagerInterface $storeManager)
     {
         $this->helper = $helper;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -107,6 +113,15 @@ class UnverifiedAdminOrderMessage implements MessageInterface
     /**
      * Human-readable names of the groups currently in the unverified combination.
      *
+     * EVALUATED PER STORE VIEW, not once at the current scope, and that is not incidental.
+     * enable_checkout is showInStore="1" (etc/adminhtml/system.xml) so a merchant can switch
+     * it on for one store view over a default of off, while enable_create_order_admin is
+     * showInDefault only. Data::getConfigValue() reads SCOPE_STORE with no store, which in the
+     * admin area resolves to the DEFAULT store - so a single read would miss exactly the
+     * configuration that produces the gap, and the notice would stay silent in the case it
+     * exists for. One store view in the combination is one set of orders going unverified, so
+     * any store tripping it raises the notice.
+     *
      * @return string[]
      */
     private function affectedGroups(): array
@@ -114,20 +129,51 @@ class UnverifiedAdminOrderMessage implements MessageInterface
         $affected = [];
 
         foreach (self::AFFECTED_GROUPS as $group) {
-            $adminEnabled = $this->helper->getConfigValue(
-                'loqate_settings/' . $group . '/enable_create_order_admin'
-            );
-            $checkoutEnabled = $this->helper->getConfigValue(
-                'loqate_settings/' . $group . '/enable_checkout'
-            );
+            $adminPath = 'loqate_settings/' . $group . '/enable_create_order_admin';
+            $checkoutPath = 'loqate_settings/' . $group . '/enable_checkout';
 
-            // Compared as ints because these are Magento yes/no selects, which arrive as the
-            // strings '0' and '1' from core_config_data but as ints from a data patch.
-            if ((int)$adminEnabled === 0 && (int)$checkoutEnabled === 1) {
-                $affected[] = $group === 'address_settings' ? 'Address Settings' : 'Phone Settings';
+            foreach ($this->storeIds() as $storeId) {
+                $adminEnabled = $storeId === null
+                    ? $this->helper->getConfigValue($adminPath)
+                    : $this->helper->getConfigValueForStore($adminPath, $storeId);
+                $checkoutEnabled = $storeId === null
+                    ? $this->helper->getConfigValue($checkoutPath)
+                    : $this->helper->getConfigValueForStore($checkoutPath, $storeId);
+
+                // Compared as ints because these are Magento yes/no selects, which arrive as
+                // the strings '0' and '1' from core_config_data but as ints from a data patch.
+                if ((int)$adminEnabled === 0 && (int)$checkoutEnabled === 1) {
+                    $affected[] = $group === 'address_settings' ? 'Address Settings' : 'Phone Settings';
+                    break;
+                }
             }
         }
 
         return $affected;
+    }
+
+    /**
+     * Store views to evaluate, or [null] meaning "read at the current scope".
+     *
+     * Falls back to the current scope when the store list cannot be read. getStores() touches
+     * the database, and a system message is rendered on admin pages that must not be brought
+     * down by it - including, in the worst case, the very pages an admin would use to fix a
+     * broken store table. A missed notice is a far better failure than an unusable admin, and
+     * the fallback still catches the default-scope case, which is the common one.
+     *
+     * @return array<int|null>
+     */
+    private function storeIds(): array
+    {
+        try {
+            $storeIds = [];
+            foreach ($this->storeManager->getStores() as $store) {
+                $storeIds[] = (int)$store->getId();
+            }
+        } catch (\Exception $e) {
+            return [null];
+        }
+
+        return $storeIds === [] ? [null] : $storeIds;
     }
 }

--- a/Observer/QuoteSubmitBefore.php
+++ b/Observer/QuoteSubmitBefore.php
@@ -5,6 +5,8 @@ namespace Loqate\ApiIntegration\Observer;
 use Loqate\ApiIntegration\Helper\Data;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -24,14 +26,26 @@ class QuoteSubmitBefore implements ObserverInterface
     /** @var Logger */
     private $logger;
 
+    /** @var State */
+    private $appState;
+
+    /**
+     * @param Data $helper
+     * @param Validator $validator
+     * @param Logger $logger
+     * @param State $appState Appended, never reordered: the existing three positions are
+     *                        wired positionally by every di.xml/test that builds this class.
+     */
     public function __construct(
         Data $helper,
         Validator $validator,
-        Logger $logger
+        Logger $logger,
+        State $appState
     ) {
         $this->helper  = $helper;
         $this->validator = $validator;
         $this->logger  = $logger;
+        $this->appState = $appState;
     }
 
     /**
@@ -39,6 +53,17 @@ class QuoteSubmitBefore implements ObserverInterface
      */
     public function execute(Observer $observer): void
     {
+        // Admin order create is verified by Plugin\Admin\OrderSave, which sends BOTH
+        // addresses in ONE batch call (verifyMultipleAddresses()). This observer would then
+        // add up to two further single-address calls for the same order, and the two paths
+        // cannot share a verdict - one judges the AVC, the other the AQI - so the duplicate
+        // billing can only be removed by not running here. That also means admin order create
+        // is no longer AVC-checked at all and obeys only the *_create_order_admin toggles -
+        // see isAdminArea() for what that changes and the one configuration it leaves unverified.
+        if ($this->isAdminArea()) {
+            return;
+        }
+
         if (empty($this->helper->getConfigValue('loqate_settings/settings/api_key'))) {
             return;
         }
@@ -101,6 +126,74 @@ class QuoteSubmitBefore implements ObserverInterface
 
         if ($errors) {
             throw new LocalizedException(__(implode(PHP_EOL, $errors)));
+        }
+    }
+
+    /**
+     * Is this request being handled in the admin area?
+     *
+     * WHY THIS IS A RUNTIME CHECK AND NOT etc/frontend/events.xml. Moving the registration
+     * into etc/frontend/ would look tidier and would be WRONG: this observer exists
+     * precisely because Hyvä's GraphQL checkout does not use the REST
+     * ShippingInformationManagement / BillingAddressManagement services the other plugins
+     * intercept (see the comment in etc/events.xml), and 'graphql' and 'webapi_rest' are
+     * separate area codes that do NOT inherit 'frontend'. A frontend-only registration
+     * would therefore silently disable verification on the exact path this observer was
+     * built for. The global registration is deliberate; only adminhtml is excluded, and
+     * only here.
+     *
+     * WHAT THIS CHANGED FOR ADMIN ORDER CREATE, stated because it is a behaviour change and
+     * not a refactor. Before this early return, an admin-created order had to pass BOTH
+     * checks: the AQI, through Plugin\Admin\OrderSave (verifyMultipleAddresses()), AND the
+     * AVC, through this observer. It now passes the AQI only. From here on, address, phone
+     * and email verification of admin order create is governed SOLELY by the
+     * loqate_settings/*_settings/enable_create_order_admin toggles, and the AVC check no
+     * longer applies on that path at all.
+     *
+     * The sharp case, so nobody discovers it in production: with
+     * loqate_settings/address_settings/enable_create_order_admin OFF and
+     * loqate_settings/address_settings/enable_checkout ON, this observer used to be the ONLY
+     * thing verifying an admin-created order's addresses - and now NOTHING does. The same
+     * holds for the matching pair of phone toggles. The blanket early return is nevertheless
+     * kept deliberately: "enable create order admin = No" is the merchant asking for admin
+     * order create not to be verified, and honouring it through one setting is the intended
+     * reading of those toggles, whereas the previous behaviour made an admin-side feature
+     * switch silently overridable by a checkout-side one.
+     *
+     * HOW IT FAILS: State::getAreaCode() throws when no area code has been set yet, and
+     * this method then answers "not admin", so verification RUNS. That direction is chosen
+     * because the two failure modes are not symmetric: skipping verification on an unknown
+     * area would silently let unverified addresses through checkout (a correctness and
+     * compliance failure that no one would notice), whereas running it on an unknown area
+     * costs at worst a duplicate billable call - visible on the invoice, and never a
+     * blocked order or a broken checkout. The throwable is swallowed and logged rather
+     * than propagated for the same reason: an exception out of this observer aborts the
+     * order submission.
+     *
+     * The catch is \Throwable rather than just LocalizedException on purpose, and it is the
+     * paragraph above that demands it: State is an interceptable @api class, so a plugin, a
+     * broken DI compilation or a not-yet-initialised object manager can raise something that
+     * is not a LocalizedException, and with a narrower catch that would propagate out of a
+     * sales_model_service_quote_submit_before observer and KILL THE ORDER - a failure mode
+     * that did not exist before this class took a State dependency. Real Magento only
+     * documents LocalizedException here, so the wider catch costs nothing in practice; what
+     * it buys is that resolving the area can never be the reason an order fails. Diagnosis is
+     * preserved instead of traded away: the throwable is logged with its message, identically
+     * for every type.
+     *
+     * @return bool
+     */
+    private function isAdminArea(): bool
+    {
+        try {
+            return $this->appState->getAreaCode() === Area::AREA_ADMINHTML;
+        } catch (\Throwable $exception) {
+            $this->logger->info(
+                'Loqate could not resolve the application area on quote submit; '
+                . 'verifying anyway: ' . $exception->getMessage()
+            );
+
+            return false;
         }
     }
 

--- a/Observer/QuoteSubmitBefore.php
+++ b/Observer/QuoteSubmitBefore.php
@@ -150,8 +150,7 @@ class QuoteSubmitBefore implements ObserverInterface
      * loqate_settings/*_settings/enable_create_order_admin toggles, and the AVC check no
      * longer applies on that path at all.
      *
-     * The sharp case, so nobody discovers it in production: with
-     * loqate_settings/address_settings/enable_create_order_admin OFF and
+     * The sharp case: with loqate_settings/address_settings/enable_create_order_admin OFF and
      * loqate_settings/address_settings/enable_checkout ON, this observer used to be the ONLY
      * thing verifying an admin-created order's addresses - and now NOTHING does. The same
      * holds for the matching pair of phone toggles. The blanket early return is nevertheless
@@ -159,6 +158,13 @@ class QuoteSubmitBefore implements ObserverInterface
      * order create not to be verified, and honouring it through one setting is the intended
      * reading of those toggles, whereas the previous behaviour made an admin-side feature
      * switch silently overridable by a checkout-side one.
+     *
+     * That case is NOT documented only here, because a merchant does not read docblocks and
+     * they are the only person who can act on it. Model\AdminNotification\
+     * UnverifiedAdminOrderMessage raises an admin system message naming the affected settings
+     * whenever it detects the combination, and CHANGELOG.md records it as an action-required
+     * behaviour change. If the toggles or this early return are reworked, those two have to
+     * move with it or the warning becomes a lie.
      *
      * HOW IT FAILS: State::getAreaCode() throws when no area code has been set yet, and
      * this method then answers "not admin", so verification RUNS. That direction is chosen

--- a/Plugin/Admin/ValidateImportAddress.php
+++ b/Plugin/Admin/ValidateImportAddress.php
@@ -116,7 +116,30 @@ class ValidateImportAddress extends AbstractPlugin
                         }
                     }
                 }
+            } catch (\InvalidArgumentException $exception) {
+                // Deliberately NOT swallowed. On this path an \InvalidArgumentException can
+                // only be ShopperScopedAddressStores::assertEnrolled() reporting that a
+                // session store was reached without being enrolled in the shopper-ownership
+                // flush - a programming error a developer has to fix, not a runtime failure
+                // to absorb.
+                //
+                // It cannot be a deserialisation failure: the serializer forwards to
+                // json_decode() and every call site that unserialises a cache entry
+                // (Validator::getCachedVerifyResult(), getCachedBatchVerifyResult(),
+                // checkForCapturedAddress() and Controller::storeCapturedAddress()) already
+                // catches \InvalidArgumentException itself and degrades to a cache miss, so
+                // a malformed entry never reaches this far.
+                //
+                // This plugin has no logger - its base class serves ten plugins and does not
+                // carry one - so swallowing here would leave no trace anywhere and silently
+                // defeat the one assertion that exists to catch an unguarded store. Letting
+                // it out is the only way it reaches anybody.
+                throw $exception;
             } catch (\Exception $exception) {
+                // Everything else is a runtime failure - transport, connector, source file -
+                // and must not hard-fail the merchant's import. Rows already checked keep
+                // their verdicts; the rest go unverified, which the chunk handling above
+                // reports to the merchant.
                 return $result;
             }
         }

--- a/Plugin/Admin/ValidateImportAddress.php
+++ b/Plugin/Admin/ValidateImportAddress.php
@@ -123,12 +123,19 @@ class ValidateImportAddress extends AbstractPlugin
                 // flush - a programming error a developer has to fix, not a runtime failure
                 // to absorb.
                 //
-                // It cannot be a deserialisation failure: the serializer forwards to
-                // json_decode() and every call site that unserialises a cache entry
-                // (Validator::getCachedVerifyResult(), getCachedBatchVerifyResult(),
-                // checkForCapturedAddress() and Controller::storeCapturedAddress()) already
-                // catches \InvalidArgumentException itself and degrades to a cache miss, so
-                // a malformed entry never reaches this far.
+                // It cannot be one of this module's deserialisation failures: the serializer
+                // forwards to json_decode(), and every call site that unserialises a cache
+                // entry - Validator::getCachedVerifyResult(), getCachedBatchVerifyResult()
+                // and checkForCapturedAddress(), plus Controller::capturedEntrySignature() -
+                // already catches \InvalidArgumentException itself and degrades to a cache
+                // miss, so a malformed entry never reaches this far.
+                //
+                // It could still be a core or third-party \InvalidArgumentException raised
+                // inside the try, which this now turns into a failed import where it would
+                // previously have degraded silently. That is the safe direction - loud, not
+                // wrong - but the premise is worth removing rather than arguing: giving
+                // assertEnrolled() a module-specific exception subclass and catching THAT
+                // would make this narrowing exact instead of merely well-reasoned.
                 //
                 // This plugin has no logger - its base class serves ten plugins and does not
                 // carry one - so swallowing here would leave no trace anywhere and silently

--- a/Plugin/Admin/ValidateImportAddress.php
+++ b/Plugin/Admin/ValidateImportAddress.php
@@ -16,6 +16,21 @@ class ValidateImportAddress extends AbstractPlugin
     /**
      * Check if addresses are valid for batch import
      *
+     * Validator::verifyMultipleAddresses() has THREE return shapes and all three have to be
+     * handled here before anything is merged:
+     *  - array<int, bool>, keys 0..N-1 per chunk - the normal case;
+     *  - false, when the billable API call failed OR answered a row count that cannot be
+     *    attributed to the addresses sent (see the count guard in that method: the connector's
+     *    array_column() drops unanswerable records and reindexes the rest, so a partial
+     *    response is indistinguishable from a shifted one and neither may be merged);
+     *  - ['noKeyFound' => true], when no API key is configured.
+     * Passing either non-verdict shape to array_merge() is what made a mid-import API
+     * failure a HARD CRASH: array_merge($allRowsResult, false) is a TypeError in PHP 8, and
+     * the catch (\Exception) below does NOT catch it - TypeError is an \Error, not an
+     * \Exception - so the import died with a 500 instead of degrading. 'noKeyFound' merges
+     * cleanly but is worse in its own way: a string key in row-indexed data, reported to the
+     * merchant as "Invalid address at row #1" because ($index + 1) of the string key 'noKeyFound' is 1.
+     *
      * @param Address $subject
      * @param $result
      * @return void
@@ -35,9 +50,59 @@ class ValidateImportAddress extends AbstractPlugin
                     $batches = array_chunk($sourceArray, 100);
                     $allRowsResult = [];
                     foreach ($batches as $batch) {
-                        $allRowsResult = array_merge($allRowsResult, $this->validator->verifyMultipleAddresses($batch, false));
+                        $batchResult = $this->validator->verifyMultipleAddresses($batch, false);
+
+                        if ($batchResult === false) {
+                            // The billable API call failed for this chunk, so we hold no
+                            // verdict for any of its rows. Reported ONCE, as a critical
+                            // error with no row number, and verification stops: continuing
+                            // would either pass unverified rows silently or attribute a
+                            // transport failure to individual rows the merchant would then
+                            // "fix". Failing the validation rather than letting the import
+                            // through is the same fail-closed stance the module already
+                            // takes on this kind of failure in admin order create
+                            // (Plugin\Admin\OrderSave.php:59-64) and at checkout.
+                            $result->addError(
+                                AbstractEntity::ERROR_CODE_SYSTEM_EXCEPTION,
+                                ProcessingError::ERROR_LEVEL_CRITICAL,
+                                null,
+                                null,
+                                __('Addresses could not be validated: the Loqate service did not respond. '
+                                    . 'Please try the import again.')
+                            );
+
+                            return $result;
+                        }
+
+                        if (!is_array($batchResult) || isset($batchResult['noKeyFound'])) {
+                            // No API key (or any other non-verdict shape a future change
+                            // might add): there is nothing to validate in THIS chunk, so
+                            // verification stops here. Never merged - a 'noKeyFound' key in
+                            // row-indexed data is reported as row #1.
+                            //
+                            // break, NOT return: unlike the false branch above, this branch
+                            // adds no error of its own, so the import proceeds either way -
+                            // and returning here would throw away $allRowsResult, silently
+                            // discarding every genuinely invalid row already found in earlier
+                            // chunks and importing it. Breaking keeps those verdicts and lets
+                            // the reporting loop below run on them. Reaching this on a LATER
+                            // chunk means the key was removed mid-import, in which case the
+                            // rows verified before that is strictly better than nothing.
+                            break;
+                        }
+
+                        $allRowsResult = array_merge($allRowsResult, $batchResult);
                     }
 
+                    // Row numbering is CORRECT as written and must not be "fixed": each
+                    // chunk returns keys 0..N-1 in input order (guaranteed by
+                    // Validator::verifyMultipleAddresses(), which pre-seeds its result in
+                    // input key order for exactly this reason), so array_merge() renumbering
+                    // by insertion order yields 0..149 across chunks of 100 and ($index + 1)
+                    // is the import row number by construction. A chunk can no longer come back
+                    // SHORT either - a row count that does not match the addresses sent returns
+                    // false and is handled above - so the one case that could renumber later
+                    // chunks is now unreachable rather than merely improbable.
                     //check for invalid addresses
                     foreach ($allRowsResult as $index => $validAddress) {
                         if (!$validAddress) {

--- a/Plugin/Admin/ValidateImportAddress.php
+++ b/Plugin/Admin/ValidateImportAddress.php
@@ -117,11 +117,11 @@ class ValidateImportAddress extends AbstractPlugin
                     }
                 }
             } catch (\InvalidArgumentException $exception) {
-                // Deliberately NOT swallowed. On this path an \InvalidArgumentException can
-                // only be ShopperScopedAddressStores::assertEnrolled() reporting that a
-                // session store was reached without being enrolled in the shopper-ownership
-                // flush - a programming error a developer has to fix, not a runtime failure
-                // to absorb.
+                // Deliberately NOT swallowed. The \InvalidArgumentException this is FOR is
+                // ShopperScopedAddressStores::assertEnrolled() reporting that a session store
+                // was reached without being enrolled in the shopper-ownership flush - a
+                // programming error a developer has to fix, not a runtime failure to absorb.
+                // It is not provably the only source; see the third paragraph.
                 //
                 // It cannot be one of this module's deserialisation failures: the serializer
                 // forwards to json_decode(), and every call site that unserialises a cache

--- a/Test/Unit/Helper/CapturedAddressStoreTest.php
+++ b/Test/Unit/Helper/CapturedAddressStoreTest.php
@@ -5,7 +5,7 @@ namespace Loqate\ApiIntegration\Test\Unit\Helper;
 use Loqate\ApiConnector\Client\Verify;
 use Loqate\ApiIntegration\Helper\Controller;
 use Loqate\ApiIntegration\Helper\Data;
-use Loqate\ApiIntegration\Helper\ShopperScopedSession;
+use Loqate\ApiIntegration\Helper\ShopperScopedAddressStores;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
 use Magento\Customer\Model\Session;
@@ -76,7 +76,7 @@ use stdClass;
  * against.
  *
  * WHAT A MALFORMED STORE MAY COST, and why that is asserted on BOTH READERS. This is a bare
- * session key shared with every other module on the installation, ShopperScopedSession flushes
+ * session key shared with every other module on the installation, ShopperScopedAddressStores flushes
  * it by writing null, and sessions come back from storage that truncates - so "not a list of
  * entries this module wrote" is a routine state, not a hypothetical one. The contract is
  * therefore a DEGRADATION, stated as such: a store that cannot be read costs a MISSED BYPASS -
@@ -96,7 +96,7 @@ use stdClass;
  *
  * The OWNERSHIP half of LOQ-16978 - that this store is flushed when the logged-in shopper
  * changes - is not repeated here: it belongs to the seam that enforces it and is covered by
- * ShopperScopedSessionTest, together with the two verdict caches that share the rule. What
+ * ShopperScopedAddressStoresTest, together with the two verdict caches that share the rule. What
  * IS pinned here is that this class cannot reach the store any other way, see
  * testTheStoreIsReachedOnlyThroughTheShopperOwnershipGuard().
  */
@@ -217,8 +217,8 @@ class CapturedAddressStoreTest extends TestCase
             }
         );
         // One shopper, one identity, for the whole of this file: the store belongs to the
-        // same customer throughout, so ShopperScopedSession adopts it and never flushes.
-        // The identity-change behaviour is ShopperScopedSessionTest's subject, and leaving it
+        // same customer throughout, so ShopperScopedAddressStores adopts it and never flushes.
+        // The identity-change behaviour is ShopperScopedAddressStoresTest's subject, and leaving it
         // out here is what keeps a failure in these tests attributable to the bound itself.
         $sessionMock->method('getCustomerId')->willReturn(7);
 
@@ -871,7 +871,7 @@ class CapturedAddressStoreTest extends TestCase
      * that is not a list of addresses.
      *
      * Reachable in more ways than a corrupted payload: this attribute is a bare session key
-     * shared with every other module on the installation, ShopperScopedSession deliberately
+     * shared with every other module on the installation, ShopperScopedAddressStores deliberately
      * FLUSHES it by writing null (see that class for why null rather than an unset), and
      * sessions are restored from storage that can truncate. A fatal here would happen inside
      * a Capture retrieve request, i.e. while the shopper is picking their address, so the
@@ -911,7 +911,7 @@ class CapturedAddressStoreTest extends TestCase
     public static function corruptStoreValueProvider(): array
     {
         return [
-            // What ShopperScopedSession itself writes when it flushes the store, so this case
+            // What ShopperScopedAddressStores itself writes when it flushes the store, so this case
             // is not hypothetical: it is reached on the first capture after a login.
             'null left by a shopper-ownership flush' => [null],
             'a truncated string payload' => ['a:1:{i:0;s:5:"parti'],
@@ -1211,7 +1211,7 @@ class CapturedAddressStoreTest extends TestCase
      * verifyThrough().
      *
      * WHY THE ATTRIBUTE IS NOT A LIST, in practice: it is a bare session key shared with every
-     * other module on the installation, ShopperScopedSession deliberately writes null into it
+     * other module on the installation, ShopperScopedAddressStores deliberately writes null into it
      * to flush it, and sessions are restored from storage that can truncate - the same reasons
      * spelled out on corruptStoreValueProvider(), which pins the WRITER against this same set.
      * Only truthy values appear here, because a falsy one never reaches the reader at all.
@@ -1281,7 +1281,7 @@ class CapturedAddressStoreTest extends TestCase
      * The store must not be reachable except through the shopper-ownership guard.
      *
      * Helper\Controller is handed the raw Magento\Customer\Model\Session by DI and wraps it
-     * in a ShopperScopedSession; if it ALSO kept the raw session in a property, a later edit
+     * in a ShopperScopedAddressStores; if it ALSO kept the raw session in a property, a later edit
      * could read or write captured_addresses directly and silently skip the identity check
      * that stops shopper B inheriting shopper A's verify bypasses (LOQ-16978). Asserted on
      * the constructed object rather than by reading the source, so it holds however the
@@ -1298,18 +1298,18 @@ class CapturedAddressStoreTest extends TestCase
                 $value,
                 sprintf(
                     'Helper\Controller::$%s holds the raw customer session. The captured-address store must '
-                    . 'be reachable only through ShopperScopedSession, or a future edit can read and write it '
+                    . 'be reachable only through ShopperScopedAddressStores, or a future edit can read and write it '
                     . 'without the shopper-ownership check that flushes it on a login or a logout.',
                     $name
                 )
             );
         }
 
-        $guards = array_filter($held, static fn ($value): bool => $value instanceof ShopperScopedSession);
+        $guards = array_filter($held, static fn ($value): bool => $value instanceof ShopperScopedAddressStores);
         $this->assertCount(
             1,
             $guards,
-            'Helper\Controller must hold exactly one ShopperScopedSession: that is the seam every access to '
+            'Helper\Controller must hold exactly one ShopperScopedAddressStores: that is the seam every access to '
             . 'the captured-address store has to go through.'
         );
     }

--- a/Test/Unit/Helper/CapturedAddressStoreTest.php
+++ b/Test/Unit/Helper/CapturedAddressStoreTest.php
@@ -1,0 +1,1766 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Helper;
+
+use Loqate\ApiConnector\Client\Verify;
+use Loqate\ApiIntegration\Helper\Controller;
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\ShopperScopedSession;
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Logger\Logger;
+use Magento\Customer\Model\Session;
+use Magento\Directory\Model\RegionFactory;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use ArrayObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use stdClass;
+
+/**
+ * Unit tests for the captured-address store: Helper\Controller::storeCapturedAddress()
+ * and the session attribute it owns, Controller::CAPTURED_ADDRESSES_SESSION_KEY.
+ *
+ * WHAT THIS STORE IS. Every address a shopper picks from the Loqate Capture lookup is
+ * serialised into this session attribute by Controller::retrieve(), its only writer.
+ * Helper\Validator then treats a match against it as "Loqate authored this address" and
+ * SKIPS the billable Cleansing verify entirely - on both the single-address path
+ * (verifyAddress()) and the batch path (verifyMultipleAddresses()). It is therefore a
+ * verify BYPASS held in session state, which is what makes both of its properties matter:
+ * how much of it there is, and whose it is.
+ *
+ * WHAT LOQ-16978 CHANGED, and what these tests pin. The store used to grow WITHOUT LIMIT
+ * for the whole session and to append a fresh copy of an address every time it was
+ * re-picked, so a shopper cycling one address through the lookup inflated the session
+ * payload unboundedly (a PHP session is read, unserialised and written on EVERY request,
+ * so this is paid per request and, on the Redis/database session handlers, over the wire).
+ * It is now bounded to Controller::CAPTURED_ADDRESSES_LIMIT entries with FIFO eviction -
+ * oldest first, mirroring Validator::storeVerifyResult() - and a re-captured address MOVES
+ * to the newest position instead of being duplicated. Both halves are asserted here twice
+ * over: structurally, on the array actually left in the session
+ * (testCapturedAddressStoreIsBoundedToTheDocumentedLimit(),
+ * testRecapturingAnAddressStoresNoSecondCopy()), and behaviourally, through the bypass the
+ * store exists to grant - because a bound that quietly dropped the WRONG entry, or an
+ * eviction that fired one entry too early, would satisfy a count assertion while costing a
+ * shopper a billable verify (testEveryCapturedAddressUpToTheLimitStillSkipsVerification(),
+ * testOnlyTheEvictedCapturedAddressIsVerifiedAgain()).
+ *
+ * The FIFO direction is not interchangeable: the address currently being checked out is
+ * always the one most recently captured, so evicting the NEWEST entry would defeat the
+ * bypass for exactly the address that is about to be verified 3-5 times (see the call-path
+ * list on Validator::verifyAddress()).
+ *
+ * WHAT "ALREADY IN THE STORE" MEANS, and why it is a subject in its own right here. The
+ * de-duplication is decided by Validator::capturedAddressSignature() - the very relation
+ * Validator::checkForCapturedAddress() grants the bypass on - and NOT by the serialised
+ * bytes it used to compare. Byte comparison disagreed with the matcher in four ways, always
+ * in the damaging direction, so a bounded store could still be filled by one address cycled
+ * through the lookup. That relation, and the requirement that the store and the matcher
+ * AGREE about it, is pinned by
+ * testTheStoreDeDuplicatesOnExactlyTheRelationTheBypassMatcherUses() over a table of pairs
+ * that must and must not collapse, with
+ * testALegacyEntryWithNoSecondLineAtAllCollapsesOntoTheSameAddress() and
+ * testTwoDifferentUnidentifiableCapturesAreNeverCollapsedOntoEachOther() covering the two
+ * shapes that table cannot express.
+ *
+ * THE LIMIT'S VALUE is pinned separately from its use, in
+ * testTheCapturedStoreBoundIsTheSameAsTheSingleAddressVerdictCacheBound(). Every other bound
+ * test here reads the constant, which is correct but leaves them all satisfied by a limit of
+ * 1; the requirement is that this bound stay consistent with the neighbours it is documented
+ * against.
+ *
+ * WHAT A MALFORMED STORE MAY COST, and why that is asserted on BOTH READERS. This is a bare
+ * session key shared with every other module on the installation, ShopperScopedSession flushes
+ * it by writing null, and sessions come back from storage that truncates - so "not a list of
+ * entries this module wrote" is a routine state, not a hypothetical one. The contract is
+ * therefore a DEGRADATION, stated as such: a store that cannot be read costs a MISSED BYPASS -
+ * the address is verified, which means BILLED - and never a fatal. Both halves are asserted
+ * every time (the accepted verdict AND the billable request, see billedStreets()), because
+ * either one alone is satisfied by the opposite defect. It is asserted through
+ * Validator::verifyAddress() AND Validator::verifyMultipleAddresses() because they are two
+ * separate call sites of the same matcher, each testing the attribute for TRUTHINESS only -
+ * which is exactly why the whole-attribute guard has to live inside the matcher, ahead of its
+ * loop, rather than in either caller. See
+ * testAForeignElementInTheStoreCostsABypassRatherThanAFatalInEitherReader() and
+ * testATruthyNonListStoreCostsABypassRatherThanAFatalInEitherReader(), with
+ * testAForeignElementDoesNotHideACapturedAddressBehindItFromEitherReader() pinning that an
+ * unreadable element is stepped OVER rather than ending the search. Those tests run the reader
+ * under Magento's own error handler (verifyThrough()), since half of what has to be prevented
+ * is an E_WARNING that a live store promotes to an exception.
+ *
+ * The OWNERSHIP half of LOQ-16978 - that this store is flushed when the logged-in shopper
+ * changes - is not repeated here: it belongs to the seam that enforces it and is covered by
+ * ShopperScopedSessionTest, together with the two verdict caches that share the rule. What
+ * IS pinned here is that this class cannot reach the store any other way, see
+ * testTheStoreIsReachedOnlyThroughTheShopperOwnershipGuard().
+ */
+class CapturedAddressStoreTest extends TestCase
+{
+    /** Any non-empty key lets both helpers build their API connectors. */
+    private const API_KEY = 'TEST-API-KEY-0000';
+
+    /** AVC strictly better than the baked-in default threshold "P40-U00-P0-95" => accepted. */
+    private const PASSING_AVC = 'V55-I22-P9-99';
+
+    /** Threshold the BATCH reader judges an AQI against; the connector double answers 'A'. */
+    private const AQI_CONFIG_PATH = 'loqate_settings/address_settings/address_quality_index';
+
+    /** The module's own shipped default for that threshold - etc/config.xml:20. */
+    private const DEFAULT_AQI_THRESHOLD = 'A';
+
+    /** Session attribute the captured-address store must live under. */
+    private const CAPTURED_ADDRESSES_SESSION_KEY = 'captured_addresses';
+
+    /**
+     * The two readers of the captured-address store, by the method that reads it.
+     *
+     * Both are named in every malformed-store test below because they are two separate call
+     * sites of Validator::checkForCapturedAddress() with two separate pre-checks on the
+     * attribute - each only tests it for TRUTHINESS - so a guard that lives in one caller
+     * protects one path and leaves the other one fatal (LOQ-16978).
+     */
+    private const READER_SINGLE = 'verifyAddress';
+    private const READER_BATCH = 'verifyMultipleAddresses';
+
+    /** The address every malformed-store test captures, verifies and expects to be billed. */
+    private const ADDRESS_UNDER_TEST = 1;
+
+    /**
+     * Stands in, inside a malformedStoreProvider() row, for the serialised entry the store
+     * legitimately holds for the address under test - as the WHOLE attribute rather than as an
+     * element of it.
+     *
+     * A placeholder for the same reason as self::THE_ADDRESS_BEING_CAPTURED: the provider is
+     * static and the entry is whatever Controller::storeCapturedAddress() actually wrote.
+     */
+    private const THE_ENTRY_UNWRAPPED = '<the serialised entry, stored bare instead of in a list>';
+
+    /**
+     * Stands in, inside a malformedStoreProvider() row, for an OBJECT whose public property
+     * holds that same entry.
+     *
+     * The one malformed whole attribute that foreach() accepts - iterating an object's public
+     * properties is legal - so it is the row that pins the guard as a guard on the TYPE of the
+     * store rather than as a way of dodging the foreach() warning.
+     */
+    private const AN_OBJECT_AROUND_THE_ENTRY = '<an object whose public property holds the entry>';
+
+    /**
+     * Stands in, inside a mixedStoreProvider() row, for the serialised entry the capture under
+     * test is going to de-duplicate.
+     *
+     * A placeholder rather than the entry itself because the provider is static and the entry
+     * is whatever the serializer double produces; substituting it inside the test lets a row
+     * put the existing entry at any position among the foreign elements, which is the whole
+     * point of those rows.
+     */
+    private const THE_ADDRESS_BEING_CAPTURED = '<the address already in the store>';
+
+    /**
+     * Build one independent "shopper": a Helper\Controller (which writes the captured-address
+     * store) and a Helper\Validator (which reads it) wired to the SAME customer session
+     * double, plus the Validator's own billable connector mock.
+     *
+     * The two helpers have to share one session for these tests to mean anything: the whole
+     * point of the store is that what Controller::retrieve() wrote on one request is what
+     * lets Validator::verifyAddress() skip the billable call on the next.
+     *
+     * Pass an existing $session to model the same browser session on a later request.
+     *
+     * @param ArrayObject|null $session Session backing store to reuse, or null for a new session.
+     * @return array{controller: Controller, validator: Validator, connector: Verify&MockObject,
+     *     requests: ArrayObject, session: ArrayObject}
+     */
+    private function createShopper(?ArrayObject $session = null): array
+    {
+        $sessionStore = $session ?? new ArrayObject();
+        $requests = new ArrayObject();
+
+        $logger = $this->createMock(Logger::class);
+
+        // The shared Test/stubs Session is a no-op (getData() returns null, setData() stores
+        // nothing), so the captured-address store could never survive between calls. This
+        // double retains data in $sessionStore, which also lets the tests assert exactly what
+        // was written.
+        //
+        // getData()/setData() have to be *added* to the double when the real
+        // Magento\Customer\Model\Session is present, because it does not declare them:
+        // SessionManager __call-forwards them to Session\Storage, so createMock() could not
+        // configure them. The Test/stubs Session used when Magento is absent does declare
+        // them, and PHPUnit refuses to "add" a method that already exists - hence the
+        // method_exists() filter, which keeps this double working on both sides.
+        $sessionBuilder = $this->getMockBuilder(Session::class)->disableOriginalConstructor();
+        $undeclared = array_values(array_filter(
+            ['getData', 'setData'],
+            static fn (string $method): bool => !method_exists(Session::class, $method)
+        ));
+        if ($undeclared) {
+            $sessionBuilder->addMethods($undeclared);
+        }
+        $sessionMock = $sessionBuilder->getMock();
+        $sessionMock->method('getData')->willReturnCallback(
+            static function ($key = '', $clear = false) use ($sessionStore) {
+                return $sessionStore[$key] ?? null;
+            }
+        );
+        $sessionMock->method('setData')->willReturnCallback(
+            static function ($key, $value = null) use ($sessionStore, $sessionMock) {
+                $sessionStore[$key] = $value;
+
+                return $sessionMock;
+            }
+        );
+        // One shopper, one identity, for the whole of this file: the store belongs to the
+        // same customer throughout, so ShopperScopedSession adopts it and never flushes.
+        // The identity-change behaviour is ShopperScopedSessionTest's subject, and leaving it
+        // out here is what keeps a failure in these tests attributable to the bound itself.
+        $sessionMock->method('getCustomerId')->willReturn(7);
+
+        $moduleList = $this->createMock(ModuleListInterface::class);
+        $moduleList->method('getOne')->willReturn(['setup_version' => '9.9.9']);
+
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturnCallback(
+            static function ($configPath) {
+                // A non-empty API key is required twice over: both constructors only build
+                // their connector when it is set, and verifyAddress() short-circuits with
+                // noKeyFound when it is not.
+                if ($configPath === 'loqate_settings/settings/api_key') {
+                    return self::API_KEY;
+                }
+
+                // The BATCH reader judges its verdicts against this threshold instead of
+                // against an AVC, and an unset one would make every billed address in
+                // verifyMultipleAddresses() come back INVALID ('A' <= '' is false as a string
+                // comparison) - which would leave the batch half of the malformed-store tests
+                // asserting a verdict that says more about this harness than about the store.
+                // The module's own default is used so the answer stays the shipped one.
+                if ($configPath === self::AQI_CONFIG_PATH) {
+                    return self::DEFAULT_AQI_THRESHOLD;
+                }
+
+                // Everything else reads as empty, which is what an untouched admin field
+                // leaves behind - in particular show_advanced_avc_settings != 1, so
+                // checkAVCStatus() uses the baked-in default thresholds.
+                return '';
+            }
+        );
+        $helper->method('getCurrentStore')->willReturn(0);
+
+        $serializer = $this->createSerializerDouble();
+
+        $controller = new Controller(
+            $this->createMock(ResultFactory::class),
+            $this->createMock(RequestInterface::class),
+            $logger,
+            $sessionMock,
+            $moduleList,
+            $helper,
+            $serializer
+        );
+
+        $validator = new Validator(
+            $logger,
+            $sessionMock,
+            $this->createMock(RegionFactory::class),
+            $moduleList,
+            $helper,
+            $serializer
+        );
+
+        // The connector is built inside the constructor (new Verify($apiKey)), so the only
+        // way to intercept the billable call is to swap the private property afterwards.
+        $connector = $this->createMock(Verify::class);
+        $connector->method('verifyAddress')->willReturnCallback(
+            static function ($params) use ($requests) {
+                $requests[] = $params;
+
+                return [[['AVC' => self::PASSING_AVC, 'AQI' => 'A']]];
+            }
+        );
+        $apiConnector = new ReflectionProperty(Validator::class, 'apiConnector');
+        $apiConnector->setAccessible(true);
+        $apiConnector->setValue($validator, $connector);
+
+        return [
+            'controller' => $controller,
+            'validator' => $validator,
+            'connector' => $connector,
+            'requests' => $requests,
+            'session' => $sessionStore,
+        ];
+    }
+
+    /**
+     * A SerializerInterface double that fails the way the production serializer fails.
+     *
+     * The configured serializer for this module is Magento\Framework\Serialize\Serializer\Json,
+     * and its unserialize() THROWS \InvalidArgumentException on anything it cannot decode -
+     * including the empty string and null - rather than answering null. A double written as
+     * `fn ($v) => json_decode($v, true)` therefore makes the whole
+     * "an entry in the store cannot be read back" family of paths unreachable from the
+     * harness: Controller::capturedEntrySignature() and Validator::checkForCapturedAddress()
+     * both wrap the call in `try { ... } catch (\InvalidArgumentException $e)`, and against a
+     * lenient double those catch blocks can never run, so deleting either of them would leave
+     * the suite green while a truncated session payload became a fatal mid-checkout
+     * (LOQ-16978 review). Mirroring the real failure mode here is what makes
+     * testAnUnreadableEntryInTheStoreCostsADeDuplicationRatherThanAFatal() a real test.
+     *
+     * The SECOND failure mode it has to mirror is the TypeError, and that one is answered by
+     * the READER's is_string() guard: json_decode()'s first parameter is declared
+     * `string $json`, so an array or object element raises an \Error, which the
+     * \InvalidArgumentException catch above does NOT cover. A lenient double swallows that as
+     * well, and testAForeignElementInTheStoreCostsABypassRatherThanAFatalInEitherReader() would
+     * then pass against a build that fatals in front of a shopper. Hence the note below.
+     *
+     * @return SerializerInterface&MockObject
+     */
+    private function createSerializerDouble()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
+        $serializer->method('unserialize')->willReturnCallback(
+            static function ($value) {
+                // Magento\Framework\Serialize\Serializer\Json::unserialize(), verbatim in
+                // behaviour: the two rejected-outright values first, then a decode whose
+                // failure is reported by json_last_error() rather than by a null return -
+                // null being a legitimately decodable value.
+                if ($value === false || $value === null || $value === '') {
+                    throw new \InvalidArgumentException('Unable to unserialize value.');
+                }
+
+                // NOT cast to string first, because the production serializer does not cast
+                // either: an array or an object reaching json_decode() is a TypeError there
+                // and must be one here, or this double would quietly make a caller that hands
+                // it a non-string look safe when production would fatal.
+                $decoded = json_decode($value, true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    throw new \InvalidArgumentException('Unable to unserialize value, string is corrupted.');
+                }
+
+                return $decoded;
+            }
+        );
+
+        return $serializer;
+    }
+
+    /**
+     * THE bound. Capturing more addresses than the limit must leave EXACTLY the limit's worth
+     * of entries: no more, because an unbounded store is re-read, unserialised and written on
+     * every single request for the rest of the session, and no fewer, because a store that
+     * under-fills re-bills addresses it had room to keep.
+     */
+    public function testCapturedAddressStoreIsBoundedToTheDocumentedLimit(): void
+    {
+        $limit = $this->capturedLimit();
+        $shopper = $this->createShopper();
+
+        for ($i = 1; $i <= $limit + 5; $i++) {
+            $this->captureAddress($shopper, $i);
+        }
+
+        $this->assertCount(
+            $limit,
+            $this->capturedStore($shopper),
+            'Once more than Controller::CAPTURED_ADDRESSES_LIMIT addresses have been captured the store must '
+            . 'hold exactly CAPTURED_ADDRESSES_LIMIT entries: the session payload must stay bounded, and it '
+            . 'must still use every slot it advertises.'
+        );
+    }
+
+    /**
+     * The limit's VALUE, not merely its use - the one thing every other bound test in this
+     * file is blind to.
+     *
+     * All of them read Controller::CAPTURED_ADDRESSES_LIMIT from the constant, which is
+     * correct (they must not restate a number that may legitimately be tuned) but means the
+     * whole file would pass with the limit set to 1 - a store that holds one address, evicts
+     * the shopper's shipping address the moment they capture their billing address, and
+     * re-bills it. The requirement LOQ-16978 actually states is that this bound be CONSISTENT
+     * WITH ITS NEIGHBOURS, so that is what is asserted here.
+     */
+    public function testTheCapturedStoreBoundIsTheSameAsTheSingleAddressVerdictCacheBound(): void
+    {
+        $this->assertSame(
+            $this->verifyCacheLimit(),
+            $this->capturedLimit(),
+            'Controller::CAPTURED_ADDRESSES_LIMIT and Validator::VERIFY_CACHE_LIMIT must be the same number. '
+            . 'The two stores are consulted for the SAME addresses by the SAME verify call - '
+            . 'Validator::verifyAddress() reads the captured-address store first and then the verdict cache - '
+            . 'so a different bound on each only means one of them still holding entries the other has long '
+            . 'since evicted: either capacity nothing can use, or a bypass that expires while the verdict '
+            . 'behind it is still live. Neither store is written by an import, which is why both are '
+            . 'deliberately smaller than the batch cache; if one of them genuinely needs a different figure, '
+            . 'the reason belongs in both docblocks and in this message.'
+        );
+
+        $this->assertGreaterThan(
+            1,
+            $this->capturedLimit(),
+            'The store must hold more than one address. The shortest realistic session captures two - a '
+            . 'shipping address and a billing address - so a limit of 1 would evict the first the moment the '
+            . 'second is picked and re-bill it on every one of the call paths listed on '
+            . 'Validator::verifyAddress().'
+        );
+
+        $this->assertLessThan(
+            $this->batchCacheLimit(),
+            $this->capturedLimit(),
+            'The captured-address store must stay SMALLER than Validator::BATCH_VERIFY_CACHE_LIMIT. That '
+            . 'larger figure exists solely to hold a 100-row customer-import chunk, and no import writes this '
+            . 'store: its only writer is a person picking an address out of the Capture lookup by hand.'
+        );
+    }
+
+    /**
+     * The eviction DIRECTION, which no count assertion can express and which is not
+     * interchangeable: the oldest entry goes first.
+     *
+     * The address currently being checked out is always the most recently captured one, so a
+     * store that dropped the NEWEST entry would remove the bypass for precisely the address
+     * about to be verified 3-5 times over (see the call-path list on
+     * Validator::verifyAddress()) - a change that a "count === limit" test cannot see.
+     */
+    public function testTheOldestCapturedAddressesAreTheOnesEvicted(): void
+    {
+        $limit = $this->capturedLimit();
+        $shopper = $this->createShopper();
+
+        for ($i = 1; $i <= $limit + 5; $i++) {
+            $this->captureAddress($shopper, $i);
+        }
+
+        $this->assertSame(
+            $this->expectedStreets(range(6, $limit + 5)),
+            $this->capturedStreets($shopper),
+            'Eviction must be FIFO: the five oldest captures must be the ones dropped, and the survivors must '
+            . 'stay in capture order with the newest last.'
+        );
+    }
+
+    /**
+     * The store is a LIST and has to stay one. array_shift() renumbers integer keys, but the
+     * unset() that removes a re-captured address does not, so the store is re-indexed after
+     * it: without that, the attribute serialised into the session degrades from a JSON array
+     * into a JSON object with sparse numeric keys, and grows a key per eviction.
+     */
+    public function testTheStoreStaysACleanZeroIndexedList(): void
+    {
+        $limit = $this->capturedLimit();
+        $shopper = $this->createShopper();
+
+        // Overflow the store AND re-capture an address, so both the eviction path and the
+        // unset-then-append path have run before the keys are inspected.
+        for ($i = 1; $i <= $limit + 5; $i++) {
+            $this->captureAddress($shopper, $i);
+        }
+        $this->captureAddress($shopper, $limit);
+
+        $store = $this->capturedStore($shopper);
+
+        $this->assertSame(
+            range(0, $limit - 1),
+            array_keys($store),
+            'The captured-address store must remain a clean 0-indexed list: a sparse array serialises into '
+            . 'the session as an object and carries a redundant key per entry.'
+        );
+        $this->assertTrue(array_is_list($store), 'The store must be a list, not a keyed map.');
+    }
+
+    /**
+     * The bound must be a bound, not a cliff: every one of the CAPTURED_ADDRESSES_LIMIT
+     * addresses the store claims to hold has to genuinely still skip the billable verify.
+     *
+     * This is what distinguishes a real FIFO store of LIMIT entries from one that keeps only
+     * the newest capture, or one whose effective limit is far smaller than advertised - both
+     * of which satisfy a bare "count <= limit" assertion while quietly re-billing shoppers.
+     */
+    public function testEveryCapturedAddressUpToTheLimitStillSkipsVerification(): void
+    {
+        $limit = $this->capturedLimit();
+        $shopper = $this->createShopper();
+
+        for ($i = 1; $i <= $limit; $i++) {
+            $this->captureAddress($shopper, $i);
+        }
+
+        // Verify all of them, oldest first.
+        for ($i = 1; $i <= $limit; $i++) {
+            $result = $shopper['validator']->verifyAddress($this->magentoAddress($i));
+            $this->assertSame(
+                ['error' => false],
+                $result,
+                'Captured address ' . $i . ' must be accepted without being verified.'
+            );
+        }
+
+        $this->assertSame(
+            0,
+            $this->apiCallCount($shopper),
+            'A store bounded to ' . $limit . ' entries must actually grant the bypass to all ' . $limit
+            . ' of them: not one of these addresses may reach the billable Loqate API.'
+        );
+    }
+
+    /**
+     * The other side of the same coin, and the only address the bound is allowed to cost:
+     * once the store overflows, the evicted (oldest) address is verified again while the
+     * newest still is not.
+     *
+     * Asserted in this order on purpose - the evicted address first - so the second assertion
+     * cannot be satisfied by a store that simply stopped granting the bypass to anything.
+     */
+    public function testOnlyTheEvictedCapturedAddressIsVerifiedAgain(): void
+    {
+        $limit = $this->capturedLimit();
+        $shopper = $this->createShopper();
+
+        for ($i = 1; $i <= $limit + 1; $i++) {
+            $this->captureAddress($shopper, $i);
+        }
+
+        $shopper['validator']->verifyAddress($this->magentoAddress(1));
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'The oldest captured address must have been evicted, so it no longer skips the billable verify.'
+        );
+
+        $shopper['validator']->verifyAddress($this->magentoAddress($limit + 1));
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'The most recently captured address is the one being checked out, so it must survive eviction and '
+            . 'keep its bypass.'
+        );
+    }
+
+    /**
+     * Re-picking an address from the lookup - which a shopper does routinely, correcting a
+     * typo and searching again, or capturing the same address into the billing form - must
+     * not add a second copy of it.
+     *
+     * Duplicates are what made the old store grow without bound in the one scenario a bound
+     * alone does not fix: cycling ONE address through the lookup would otherwise fill every
+     * slot with copies of it and evict every other address the shopper had captured.
+     *
+     * This is the EXACT re-capture - the same lookup record twice - which is the easy half
+     * and the only one byte comparison ever caught. The near-identical re-captures that byte
+     * comparison missed, and that the shopper actually produces (a re-search that returns the
+     * same address with a different ProvinceName, or in a different case), are the subject of
+     * testTheStoreDeDuplicatesOnExactlyTheRelationTheBypassMatcherUses(); both live here
+     * because the "cannot be filled by one address" guarantee needs both.
+     */
+    public function testRecapturingAnAddressStoresNoSecondCopy(): void
+    {
+        $shopper = $this->createShopper();
+
+        $this->captureAddress($shopper, 1);
+        $this->captureAddress($shopper, 2);
+        $this->captureAddress($shopper, 1);
+
+        $this->assertCount(
+            2,
+            $this->capturedStore($shopper),
+            'Re-capturing an address already in the store must refresh it, not append a duplicate.'
+        );
+        $this->assertSame(
+            $this->expectedStreets([2, 1]),
+            $this->capturedStreets($shopper),
+            'The re-captured address must MOVE to the newest position, so it is the last thing evicted rather '
+            . 'than keeping the age of the copy it replaced.'
+        );
+    }
+
+    /**
+     * THE DE-DUPLICATION RELATION ITSELF, and the property the LOQ-16978 review turned it
+     * into: the store must collapse two captures if and only if the BYPASS MATCHER treats
+     * them as one address.
+     *
+     * WHAT CHANGED. De-duplication used to compare the SERIALISED BYTES of the six
+     * ADDRESS_CAPTURE_MAPPING fields, while Validator::checkForCapturedAddress() grants the
+     * bypass on Validator::capturedAddressSignature() - a normalised, upper-cased,
+     * whitespace-collapsed projection of FIVE of them, with ProvinceName excluded outright.
+     * The two relations therefore disagreed, and always in the damaging direction: two
+     * captures that differ only in letter case, in whitespace, in ProvinceName - which
+     * capture.js rewrites routinely - or in an empty versus an absent Line2 were ONE address
+     * for bypass purposes but TWO slots in a bounded store. That is exactly how cycling a
+     * SINGLE address through the lookup could still fill every slot and evict every other
+     * address the shopper had captured, which is the failure the de-duplication exists to
+     * prevent. Both are now decided by capturedAddressSignature().
+     *
+     * WHY THE TWO HALVES ARE ASSERTED TOGETHER, in one test over one table of pairs. Either
+     * relation is easy to satisfy alone - a store that collapsed everything would pass a
+     * "one slot" assertion, and a matcher that matched everything would pass a "bypass
+     * granted" one. What has to hold is that they AGREE, so the same pair drives both: how
+     * many slots the pair occupies, and whether the second address skips the billable verify
+     * after only the first was captured. A widening of one without the other re-opens the
+     * defect in whichever direction it was widened.
+     *
+     * THE NEGATIVE ROWS ARE NOT PADDING. A "collapse whenever in doubt" store would satisfy
+     * every positive row while silently merging genuinely different addresses - the shopper
+     * would then be granted a bypass for an address Loqate never authored, which is a wider
+     * hole than the one being fixed. One row per matched field, so dropping any single field
+     * from the projection fails here.
+     *
+     * @param array $first Loqate lookup record captured first.
+     * @param array $second Loqate lookup record captured second.
+     * @param bool $sameAddress Whether the two are the same address for bypass purposes.
+     */
+    #[DataProvider('capturedAddressPairProvider')]
+    public function testTheStoreDeDuplicatesOnExactlyTheRelationTheBypassMatcherUses(
+        array $first,
+        array $second,
+        bool $sameAddress
+    ): void {
+        // Half one: how many SLOTS the pair occupies in the store.
+        $store = $this->createShopper();
+        $this->captureRecord($store, $first);
+        $this->captureRecord($store, $second);
+
+        $this->assertSame(
+            $sameAddress ? [$this->projection($second)] : [$this->projection($first), $this->projection($second)],
+            $this->capturedProjections($store),
+            $sameAddress
+                ? 'These two captures are ONE address as far as Validator::checkForCapturedAddress() is '
+                    . 'concerned, so they must occupy ONE slot - holding the newest of the two, because a '
+                    . 'refreshed entry must not keep the age of the one it replaces. Two slots for one '
+                    . 'address is how re-picking a single address fills a bounded store and evicts every '
+                    . 'other address in it.'
+                : 'These two captures differ in a field the bypass matcher compares, so they are two '
+                    . 'different addresses and must keep their own slots. Collapsing them would silently '
+                    . 'discard a bypass the shopper earned - and, worse, a de-duplication looser than the '
+                    . 'matcher would let one captured address stand in for another.'
+        );
+
+        // Half two: whether the MATCHER agrees, asserted through the bypass itself rather
+        // than on the signature, so it holds for whatever relation the matcher actually
+        // applies. A fresh session, holding only the FIRST address.
+        $matcher = $this->createShopper();
+        $this->captureRecord($matcher, $first);
+
+        $result = $matcher['validator']->verifyAddress($this->magentoShapeOf($second));
+
+        $this->assertSame(
+            $sameAddress ? 0 : 1,
+            $this->apiCallCount($matcher),
+            $sameAddress
+                ? 'The store collapsed these two captures into one slot, so the matcher MUST also treat the '
+                    . 'second as already captured and skip the billable verify. If it does not, the store is '
+                    . 'de-duplicating more aggressively than the bypass it feeds and the shopper has just '
+                    . 'lost a bypass they earned.'
+                : 'The store gave these two captures separate slots, so the matcher must NOT hand the second '
+                    . 'one the first one\'s bypass: it is a different address and Loqate has never judged it.'
+        );
+        $this->assertSame(
+            ['error' => false],
+            $result,
+            'Either way the address is accepted here - by the bypass or by the passing stub verdict - so the '
+            . 'call count above is what distinguishes the two, not the return value.'
+        );
+    }
+
+    /**
+     * Pairs of Loqate lookup records, and whether they are the same address for bypass
+     * purposes.
+     *
+     * The positive rows are precisely the four ways byte comparison used to disagree with the
+     * matcher, plus the '|' substitution normaliseSignatureValue() applies (documented on
+     * that method as a deliberate, symmetric widening). The negative rows walk the five
+     * fields capturedAddressSignature() actually projects, one at a time.
+     *
+     * @return array<string, array{0: array, 1: array, 2: bool}>
+     */
+    public static function capturedAddressPairProvider(): array
+    {
+        $base = self::baseLookupRecord();
+
+        return [
+            // ---- the same address: differences the matcher normalises or ignores ----
+            'differing only in letter case' => [
+                $base,
+                array_merge($base, [
+                    'Line1' => '1 hIGH sTREET',
+                    'Line2' => 'fLAT 2',
+                    'City' => 'lONDON',
+                    'PostalCode' => 'sw1a 1aa',
+                    'CountryIso2' => 'gb',
+                ]),
+                true,
+            ],
+            'differing only in whitespace' => [
+                $base,
+                array_merge($base, [
+                    'Line1' => "  1   High \t Street  ",
+                    'PostalCode' => ' SW1A  1AA ',
+                    'City' => " London\n",
+                ]),
+                true,
+            ],
+            // The field capture.js rewrites from the SDK's ProvinceName on a bubbling change
+            // event, which is why capturedAddressSignature() excludes it altogether.
+            'differing only in the province name' => [
+                $base,
+                array_merge($base, ['ProvinceName' => 'London']),
+                true,
+            ],
+            'differing only in an empty versus an absent second line' => [
+                array_merge($base, ['Line2' => '']),
+                array_merge($base, ['Line2' => null]),
+                true,
+            ],
+            // '|' joins the signature parts, so normaliseSignatureValue() replaces it with a
+            // space on BOTH sides of every comparison.
+            'differing only by the signature separator character' => [
+                $base,
+                array_merge($base, ['Line1' => '1 High|Street']),
+                true,
+            ],
+
+            // ---- different addresses: one row per projected field ----
+            'a different first line' => [$base, array_merge($base, ['Line1' => '2 High Street']), false],
+            'a different second line' => [$base, array_merge($base, ['Line2' => 'Flat 3']), false],
+            'a different city' => [$base, array_merge($base, ['City' => 'Manchester']), false],
+            'a different postcode' => [$base, array_merge($base, ['PostalCode' => 'SW1A 2AA']), false],
+            'a different country' => [$base, array_merge($base, ['CountryIso2' => 'IE']), false],
+        ];
+    }
+
+    /**
+     * An entry written by an OLDER release, whose serialised form has no Address2 key at all,
+     * must still collapse onto a capture of the same address with an empty second line.
+     *
+     * Not hypothetical, and not reachable through the writer: storeCapturedAddress() always
+     * projects all six mapped fields, so only an entry left in the session by a previous
+     * deployment - or by a truncated payload - can be missing one. It matters because the
+     * matcher reads `$address['Address2'] ?? null`, so it already treats such an entry as
+     * having an empty second line and grants the bypass on it; the store has to agree, or
+     * that legacy entry occupies a slot forever while a duplicate of it accumulates
+     * alongside. This also exercises the unserialize-then-project path
+     * (Controller::capturedEntrySignature()) rather than the byte comparison, which cannot
+     * see through a difference in serialised shape.
+     */
+    public function testALegacyEntryWithNoSecondLineAtAllCollapsesOntoTheSameAddress(): void
+    {
+        $shopper = $this->createShopper();
+        $legacy = $this->projection(self::baseLookupRecord());
+        unset($legacy['Address2']);
+        $shopper['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = [json_encode($legacy)];
+
+        $this->captureRecord($shopper, array_merge(self::baseLookupRecord(), ['Line2' => '']));
+
+        $this->assertSame(
+            [$this->projection(array_merge(self::baseLookupRecord(), ['Line2' => '']))],
+            $this->capturedProjections($shopper),
+            'A stored entry with no Address2 key and a capture whose Line2 is empty are the same address to '
+            . 'Validator::capturedAddressSignature(), which reads the field with ?? null - so they must share '
+            . 'one slot, and the freshly captured entry must be the one that survives.'
+        );
+    }
+
+    /**
+     * The de-duplication must never collapse two entries that carry nothing identifiable.
+     *
+     * capturedAddressSignature() answers '' for such an address, and the matcher deliberately
+     * refuses to match on '' - otherwise every empty-ish address would be granted every other
+     * one's bypass. The store has to honour that same sentinel, which is why byte equality is
+     * kept as the FIRST test inside isSameCapturedAddress(): it is the only thing that can
+     * still collapse an exact duplicate of an unidentifiable entry, and it collapses nothing
+     * else.
+     */
+    public function testTwoDifferentUnidentifiableCapturesAreNeverCollapsedOntoEachOther(): void
+    {
+        $empty = [
+            'Line1' => '',
+            'Line2' => '',
+            'CountryIso2' => '',
+            'PostalCode' => '',
+            'City' => '',
+            'ProvinceName' => 'Greater London',
+        ];
+        $shopper = $this->createShopper();
+
+        $this->captureRecord($shopper, $empty);
+        // Differs ONLY in ProvinceName, which the signature excludes - so both signatures are
+        // '' and only the bytes tell them apart.
+        $this->captureRecord($shopper, array_merge($empty, ['ProvinceName' => 'Kent']));
+
+        $this->assertCount(
+            2,
+            $this->capturedStore($shopper),
+            'Two captures whose signature is the "nothing identifiable" sentinel must not be collapsed onto '
+            . 'each other: the matcher never matches on that sentinel, so treating them as the same address '
+            . 'in the store would make the store disagree with the bypass in the one case the sentinel exists '
+            . 'to keep out of every comparison.'
+        );
+
+        // ...while an EXACT duplicate of one of them still collapses, on bytes alone.
+        $this->captureRecord($shopper, $empty);
+
+        $this->assertCount(
+            2,
+            $this->capturedStore($shopper),
+            'An exact byte-for-byte duplicate must still be de-duplicated even when its signature is empty: '
+            . 'that is the one thing the byte comparison is retained for, and without it a shopper cycling an '
+            . 'unidentifiable capture could still fill the store.'
+        );
+    }
+
+    /**
+     * The observable consequence of dropping the existing copy BEFORE the eviction loop
+     * rather than after it: re-capturing an address while the store is FULL must not cost an
+     * unrelated address its bypass.
+     *
+     * Without the unset, the store is still at the limit when the loop runs, so it shifts the
+     * oldest entry out and then appends a DUPLICATE of the re-captured one - the shopper pays
+     * a billable verify for an address they never touched, and the store holds the same
+     * address twice. The re-captured address must not be the oldest one for this to be
+     * visible, since refreshing the front entry evicts and immediately re-appends that same
+     * entry, which harms nothing.
+     */
+    public function testRecapturingWhileTheStoreIsFullDoesNotCostAnUnrelatedAddressItsBypass(): void
+    {
+        $limit = $this->capturedLimit();
+        $shopper = $this->createShopper();
+
+        for ($i = 1; $i <= $limit; $i++) {
+            $this->captureAddress($shopper, $i);
+        }
+
+        // Refresh the SECOND oldest entry: the oldest (#1) is the one a stray eviction takes.
+        $this->captureAddress($shopper, 2);
+
+        $this->assertCount(
+            $limit,
+            $this->capturedStore($shopper),
+            'Refreshing an entry that is already present replaces it, so the store must stay exactly full.'
+        );
+
+        $shopper['validator']->verifyAddress($this->magentoAddress(1));
+
+        $this->assertSame(
+            0,
+            $this->apiCallCount($shopper),
+            'Re-capturing an address while the store is full must not evict an UNRELATED address: that address '
+            . 'would then be re-verified - and re-billed - for no reason.'
+        );
+
+        // ...and the refreshed entry really is the newest, so the NEXT capture takes #1
+        // rather than it.
+        $this->captureAddress($shopper, $limit + 1);
+
+        $this->assertSame(
+            $this->expectedStreets(array_merge(range(3, $limit), [2, $limit + 1])),
+            $this->capturedStreets($shopper),
+            'The refreshed entry must have been moved to the newest position, so the next eviction takes the '
+            . 'genuinely oldest address instead.'
+        );
+    }
+
+    /**
+     * The store must degrade rather than throw when the session attribute holds something
+     * that is not a list of addresses.
+     *
+     * Reachable in more ways than a corrupted payload: this attribute is a bare session key
+     * shared with every other module on the installation, ShopperScopedSession deliberately
+     * FLUSHES it by writing null (see that class for why null rather than an unset), and
+     * sessions are restored from storage that can truncate. A fatal here would happen inside
+     * a Capture retrieve request, i.e. while the shopper is picking their address, so the
+     * only acceptable behaviour is to start a fresh list.
+     *
+     * @param mixed $corrupt Value found in the session attribute instead of a list.
+     */
+    #[DataProvider('corruptStoreValueProvider')]
+    public function testANonArrayValueInTheSessionAttributeIsReplacedRatherThanAppendedTo($corrupt): void
+    {
+        $shopper = $this->createShopper();
+        $shopper['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = $corrupt;
+
+        $this->captureAddress($shopper, 1);
+
+        $this->assertSame(
+            $this->expectedStreets([1]),
+            $this->capturedStreets($shopper),
+            'An unusable value in the session attribute must be replaced by a fresh list holding just the '
+            . 'address being captured.'
+        );
+
+        $result = $shopper['validator']->verifyAddress($this->magentoAddress(1));
+
+        $this->assertSame(['error' => false], $result);
+        $this->assertSame(
+            0,
+            $this->apiCallCount($shopper),
+            'The address captured over the corrupt value must still be granted its bypass: recovering from '
+            . 'the corruption may not silently cost the shopper a billable verify.'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function corruptStoreValueProvider(): array
+    {
+        return [
+            // What ShopperScopedSession itself writes when it flushes the store, so this case
+            // is not hypothetical: it is reached on the first capture after a login.
+            'null left by a shopper-ownership flush' => [null],
+            'a truncated string payload' => ['a:1:{i:0;s:5:"parti'],
+            'an empty string' => [''],
+            'an integer' => [42],
+            'a boolean' => [true],
+            'an object' => [new stdClass()],
+        ];
+    }
+
+    /**
+     * A foreign ELEMENT inside the store - as opposed to a foreign value in place of the whole
+     * attribute - must be stepped over: it neither breaks the de-duplication nor gets pruned
+     * by it.
+     *
+     * WHY THIS IS A SEPARATE CASE FROM
+     * testANonArrayValueInTheSessionAttributeIsReplacedRatherThanAppendedTo(). That test
+     * corrupts the WHOLE attribute, so it is answered by the `!is_array($capturedAddresses)`
+     * check at the top of storeCapturedAddress() and never reaches the de-duplication at all.
+     * The array itself being a list of addresses says nothing about its ELEMENTS: this is a
+     * bare session key shared with every other module on the installation, and appending to a
+     * list somebody else populated is exactly as reachable as replacing it. Until the
+     * `!is_string($stored)` guard existed, an element of the wrong type reached
+     * Controller::capturedEntrySignature(), whose parameter is declared `string` - so an array
+     * element was a TypeError raised inside a Capture retrieve request, i.e. while the shopper
+     * was picking their address (LOQ-16978 review).
+     *
+     * BOTH HALVES ARE ASSERTED, and the second is the one a "does not fatal" test would miss.
+     * Skipping a foreign element must mean "this is not the address being stored", NOT "this
+     * is the address being stored": treating it as a match would DELETE it - the store would
+     * silently prune another module's data on every capture, which is a worse outcome than the
+     * TypeError, because nothing would report it. Asserting the exact resulting array pins
+     * both directions at once, plus the position: the foreign elements keep their order, the
+     * duplicate entry is gone, and the freshly captured one is last.
+     *
+     * @param array $seed Session attribute before the capture, with
+     *                    self::THE_ADDRESS_BEING_CAPTURED marking the entry to be collapsed.
+     */
+    #[DataProvider('mixedStoreProvider')]
+    public function testAForeignElementInsideTheStoreIsSteppedOverRatherThanPrunedOrMatched(array $seed): void
+    {
+        $shopper = $this->createShopper();
+        $record = self::baseLookupRecord();
+        $entry = json_encode($this->projection($record));
+
+        $shopper['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = array_map(
+            static fn ($element) => $element === self::THE_ADDRESS_BEING_CAPTURED ? $entry : $element,
+            $seed
+        );
+
+        $expected = array_values(array_filter(
+            $seed,
+            static fn ($element): bool => $element !== self::THE_ADDRESS_BEING_CAPTURED
+        ));
+        $expected[] = $entry;
+
+        $this->captureRecord($shopper, $record);
+
+        $this->assertSame(
+            $expected,
+            $this->capturedStore($shopper),
+            'Every element of this store that this class did not write must come out of a capture EXACTLY as '
+            . 'it went in, in the same order: pruning another module\'s data is not this writer\'s job, and '
+            . 'the alternative failure - counting a foreign element as the address being stored - would delete '
+            . 'it silently on every capture. Meanwhile the entry this class DID write for the same address '
+            . 'must still have been collapsed and re-appended last, so a foreign neighbour cannot cost the '
+            . 'store its de-duplication and let one address fill a bounded store.'
+        );
+    }
+
+    /**
+     * Elements a list of captured addresses can hold that this class never wrote, and where
+     * they sit relative to the entry the capture is going to collapse.
+     *
+     * One row per type that reaches isSameCapturedAddress() differently: the scalars are
+     * harmless to `===` but fatal to a `string` parameter, the array and the object are fatal
+     * to both, and null is what a half-written entry leaves. The positions vary so that the
+     * re-indexing after array_filter() is exercised with survivors before, after and on both
+     * sides of the hole.
+     *
+     * @return array<string, array{0: array}>
+     */
+    public static function mixedStoreProvider(): array
+    {
+        return [
+            'an integer before the stored address' => [[42, self::THE_ADDRESS_BEING_CAPTURED]],
+            'a nested array after the stored address' => [[self::THE_ADDRESS_BEING_CAPTURED, ['nested']]],
+            'a null on either side of the stored address' => [[null, self::THE_ADDRESS_BEING_CAPTURED, null]],
+            'a boolean and a float around the stored address' => [
+                [true, self::THE_ADDRESS_BEING_CAPTURED, 1.5],
+            ],
+            'an object before the stored address' => [[new stdClass(), self::THE_ADDRESS_BEING_CAPTURED]],
+            // The whole list from the LOQ-16978 review, in one row: every foreign type at once
+            // with the entry to be collapsed last, so the re-index leaves three survivors and
+            // the append lands behind all of them.
+            'the full mixed list' => [[42, ['nested'], null, self::THE_ADDRESS_BEING_CAPTURED]],
+        ];
+    }
+
+    /**
+     * An entry that IS a string but cannot be read back as an address must cost a
+     * de-duplication and nothing more - specifically, it must not escape as an exception from
+     * inside a Capture retrieve request.
+     *
+     * WHAT MAKES THIS TEST POSSIBLE, and why it did not exist before. The production
+     * serializer, Magento\Framework\Serialize\Serializer\Json, reports a payload it cannot
+     * decode by THROWING \InvalidArgumentException - it does not answer null. That is why
+     * Controller::capturedEntrySignature() wraps the call in a try/catch at all, and it is why
+     * the doubles in this file now fail the same way (see createSerializerDouble()): against a
+     * `json_decode()`-shaped double that answers null on garbage, this catch block is
+     * unreachable, so removing it left the whole suite green while a truncated session payload
+     * became a fatal in front of a shopper.
+     *
+     * A truncated payload is the reachable case: the attribute is written on every request and
+     * restored from storage - Redis, the database, files - that can and does truncate, which
+     * is exactly why corruptStoreValueProvider() carries the same shape for the whole
+     * attribute. The unreadable entry must SURVIVE for the same reason a foreign element does:
+     * pruning is not this writer's job, and the matcher already steps over it.
+     */
+    public function testAnUnreadableEntryInTheStoreCostsADeDuplicationRatherThanAFatal(): void
+    {
+        $shopper = $this->createShopper();
+        // A truncated serialised address: a genuine string, so it gets past the is_string()
+        // guard and is actually handed to the serializer, and not byte-equal to the entry
+        // being stored, so the signature comparison - the only path that unserialises - is the
+        // one that has to answer for it.
+        $truncated = '{"Address1":"1 High Str';
+        $shopper['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = [$truncated];
+
+        $record = self::baseLookupRecord();
+        $this->captureRecord($shopper, $record);
+
+        $this->assertSame(
+            [$truncated, json_encode($this->projection($record))],
+            $this->capturedStore($shopper),
+            'An entry the serializer refuses to decode must cost this capture nothing but the chance to '
+            . 'de-duplicate against it: the exception must be caught, the unreadable entry must be left where '
+            . 'it is, and the address being captured must be appended as usual. Letting the exception out '
+            . 'would abort the Capture retrieve request the shopper is in the middle of, over a session value '
+            . 'this class is not even the author of.'
+        );
+
+        // ...and the same capture repeated still de-duplicates against ITSELF, so the
+        // unreadable neighbour has not disabled the de-duplication for the rest of the list.
+        $this->captureRecord($shopper, $record);
+
+        $this->assertCount(
+            2,
+            $this->capturedStore($shopper),
+            'The unreadable entry must not stop the readable ones being de-duplicated: an entry that throws '
+            . 'has to be skipped, not treated as the end of the store.'
+        );
+    }
+
+    /**
+     * A foreign ELEMENT in the store must cost the READERS a bypass and nothing more - on BOTH
+     * of them.
+     *
+     * THE OTHER SIDE OF testAForeignElementInsideTheStoreIsSteppedOverRatherThanPrunedOrMatched().
+     * That test covers the WRITER, Helper\Controller::isSameCapturedAddress(), which guards its
+     * own `string` parameter with is_string(). The same session attribute is READ by
+     * Validator::checkForCapturedAddress(), which hands each element to the serializer - and
+     * the production serializer, Magento\Framework\Serialize\Serializer\Json::unserialize(),
+     * passes its argument straight to json_decode(), whose first parameter is declared
+     * `string $json`. An array or object element is therefore a TypeError, which is an \Error
+     * and NOT covered by that method's `catch (\InvalidArgumentException)` - so it escaped as a
+     * fatal from inside a checkout submission until the mirror is_string() guard was added
+     * (LOQ-16978). The double this file uses fails exactly that way; see
+     * createSerializerDouble().
+     *
+     * THE DEGRADATION CONTRACT, asserted rather than assumed: a store this class cannot read is
+     * allowed to cost a MISSED BYPASS - the address is verified, which means BILLED - and is
+     * never allowed to cost an exception. Both halves are needed, because "did not blow up" is
+     * also satisfied by a reader that answered "captured" and skipped the verify, and "was
+     * billed" is also satisfied by a reader that threw before it ever got there. So the test
+     * demands the billable request AND the ordinary accepted verdict that follows it.
+     *
+     * @param mixed $element Element found in the store that this module never wrote.
+     * @param string $reader Which reader of the store is under test.
+     */
+    #[DataProvider('foreignStoreElementAndReaderProvider')]
+    public function testAForeignElementInTheStoreCostsABypassRatherThanAFatalInEitherReader(
+        $element,
+        string $reader
+    ): void {
+        $shopper = $this->createShopper();
+        $shopper['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = [$element];
+
+        $result = $this->verifyThrough($shopper, $reader, $this->magentoAddress(self::ADDRESS_UNDER_TEST));
+
+        $this->assertSame(
+            $this->acceptedVerdict($reader),
+            $result,
+            $reader . '() must answer an ordinary verdict over a store element it cannot read: the shopper is '
+            . 'in the middle of a checkout submission, so the only acceptable cost of somebody else\'s data in '
+            . 'this shared session key is the bypass itself.'
+        );
+        $this->assertSame(
+            $this->expectedStreets([self::ADDRESS_UNDER_TEST]),
+            $this->billedStreets($shopper),
+            $reader . '() must have gone on to BILL this address. Asserting the verdict alone would not say '
+            . 'that: the accepted verdict is byte-identical to the one the bypass returns, so a reader that '
+            . 'wrongly matched the unreadable element would satisfy it while silently waving an unverified '
+            . 'address through.'
+        );
+    }
+
+    /**
+     * ...and a foreign element must be STEPPED OVER, not treated as the end of the store: a
+     * genuine entry sitting behind one still has to be found, by both readers.
+     *
+     * Without this, the guard could be satisfied by a `break` or an early `return false`, which
+     * would turn one foreign element - in a session key shared with every other module on the
+     * installation - into a lost bypass for EVERY address captured after it, i.e. into a
+     * re-billing of the whole store. This is the reader's counterpart of the "must still
+     * de-duplicate" half of
+     * testAnUnreadableEntryInTheStoreCostsADeDuplicationRatherThanAFatal().
+     *
+     * @param mixed $element Element found in the store that this module never wrote.
+     * @param string $reader Which reader of the store is under test.
+     */
+    #[DataProvider('foreignStoreElementAndReaderProvider')]
+    public function testAForeignElementDoesNotHideACapturedAddressBehindItFromEitherReader(
+        $element,
+        string $reader
+    ): void {
+        $shopper = $this->createShopper();
+        $this->captureAddress($shopper, self::ADDRESS_UNDER_TEST);
+
+        // The foreign element FIRST, so the genuine entry is only reachable by stepping over it.
+        $store = $this->capturedStore($shopper);
+        array_unshift($store, $element);
+        $shopper['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = $store;
+
+        $result = $this->verifyThrough($shopper, $reader, $this->magentoAddress(self::ADDRESS_UNDER_TEST));
+
+        $this->assertSame(
+            $this->acceptedVerdict($reader),
+            $result,
+            $reader . '() must still accept an address this shopper captured from the Loqate lookup.'
+        );
+        $this->assertSame(
+            [],
+            $this->billedStreets($shopper),
+            'An element ' . $reader . '() cannot read must be SKIPPED, not treated as the end of the store: '
+            . 'the captured address behind it must keep its bypass, or one foreign element in a shared session '
+            . 'key re-bills every address the shopper captured after it.'
+        );
+    }
+
+    /**
+     * Elements a captured-address store can hold that this module never wrote, crossed with the
+     * two readers of that store.
+     *
+     * ONE ROW PER TYPE THE READER REACHES DIFFERENTLY, mirroring mixedStoreProvider() so the
+     * writer and the readers are pinned against the same values - they read the same session
+     * key and must survive the same content. Where they differ is which of these is FATAL: the
+     * writer's `string` parameter rejects every non-string, whereas the reader hands the element
+     * to the serializer, so the array and the object are TypeErrors from json_decode() while
+     * the scalars are coerced to strings and merely fail to decode, and null is rejected by the
+     * serializer itself as an \InvalidArgumentException. The harmless rows are kept because a
+     * guard that admitted them would still be wrong, and because they are what proves the fatal
+     * rows are fatal for the reason claimed.
+     *
+     * @return array<string, array{0: mixed, 1: string}>
+     */
+    public static function foreignStoreElementAndReaderProvider(): array
+    {
+        $elements = [
+            // json_decode() TypeError: neither is coercible to string, so these two are the
+            // rows that were fatal in production before the is_string() guard.
+            'a nested array' => [['Address1' => '1 Test Street']],
+            'an object' => [new stdClass()],
+            // Coerced to '42' / '1' / '1.5', decoded to a non-array, stepped over.
+            'an integer' => [42],
+            'a boolean' => [true],
+            'a float' => [1.5],
+            // What a half-written entry leaves; rejected by the serializer itself.
+            'a null' => [null],
+        ];
+
+        return self::crossWithReaders($elements);
+    }
+
+    /**
+     * The WHOLE attribute being something other than a list must cost a bypass too, on both
+     * readers - and this guard has to sit BEFORE the loop, where neither caller's own check can
+     * substitute for it.
+     *
+     * WHY IT CANNOT LIVE IN THE CALLERS. Both of them test the attribute for TRUTHINESS only -
+     * `if ($checkForCaptured && ($storedAddresses = ...))` in verifyAddress() and
+     * `if ($storedAddresses && ...)` in verifyMultipleAddresses() - so a truthy non-array
+     * reached the foreach(). Iterating a scalar is an E_WARNING, and Magento's error handler
+     * turns every reported PHP error into an exception (Magento\Framework\App\ErrorHandler,
+     * registered by Bootstrap::run() with error_reporting(E_ALL)), so in a live store that
+     * warning IS the fatal - which is why these tests install the same handler; see
+     * verifyThrough().
+     *
+     * WHY THE ATTRIBUTE IS NOT A LIST, in practice: it is a bare session key shared with every
+     * other module on the installation, ShopperScopedSession deliberately writes null into it
+     * to flush it, and sessions are restored from storage that can truncate - the same reasons
+     * spelled out on corruptStoreValueProvider(), which pins the WRITER against this same set.
+     * Only truthy values appear here, because a falsy one never reaches the reader at all.
+     *
+     * @param mixed $malformed Value found in the session attribute instead of a list.
+     * @param string $reader Which reader of the store is under test.
+     */
+    #[DataProvider('malformedStoreAndReaderProvider')]
+    public function testATruthyNonListStoreCostsABypassRatherThanAFatalInEitherReader(
+        $malformed,
+        string $reader
+    ): void {
+        $shopper = $this->createShopper();
+        $this->captureAddress($shopper, self::ADDRESS_UNDER_TEST);
+        $entry = $this->capturedStore($shopper)[0];
+
+        $shopper['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = $this->materialise($malformed, $entry);
+
+        $result = $this->verifyThrough($shopper, $reader, $this->magentoAddress(self::ADDRESS_UNDER_TEST));
+
+        $this->assertSame(
+            $this->acceptedVerdict($reader),
+            $result,
+            $reader . '() must answer an ordinary verdict when the captured-address attribute is not a list at '
+            . 'all: iterating it is an E_WARNING, and under Magento\'s error handler that warning aborts the '
+            . 'request the shopper is in the middle of.'
+        );
+        $this->assertSame(
+            $this->expectedStreets([self::ADDRESS_UNDER_TEST]),
+            $this->billedStreets($shopper),
+            'A store that is not a list of entries this module wrote grants NO bypass: ' . $reader . '() must '
+            . 'bill the address instead. The two rows that carry a genuine entry are the point - reaching into '
+            . 'a value of the wrong shape to honour it is exactly the "it happened to work" behaviour that put '
+            . 'a foreach() over a scalar in front of a shopper.'
+        );
+    }
+
+    /**
+     * Truthy values the captured-address attribute can hold instead of a list, crossed with the
+     * two readers.
+     *
+     * The last two rows are placeholders resolved in the test body (see materialise()), and
+     * they are the strongest ones: both carry a GENUINE entry for the address under test, one
+     * bare and one behind an object property. A reader without the is_array() guard answers
+     * them differently from each other - the bare string warns and, under Magento, throws,
+     * while the object iterates cleanly and grants a bypass off a store shape this module never
+     * wrote - so between them they pin the guard from both sides.
+     *
+     * @return array<string, array{0: mixed, 1: string}>
+     */
+    public static function malformedStoreAndReaderProvider(): array
+    {
+        $malformed = [
+            'a truncated string payload' => ['a:1:{i:0;s:5:"parti'],
+            'an integer' => [42],
+            'a boolean' => [true],
+            'a float' => [1.5],
+            'a bare object' => [new stdClass()],
+            'a genuine entry stored bare instead of in a list' => [self::THE_ENTRY_UNWRAPPED],
+            'an object whose property holds a genuine entry' => [self::AN_OBJECT_AROUND_THE_ENTRY],
+        ];
+
+        return self::crossWithReaders($malformed);
+    }
+
+    /**
+     * The store must not be reachable except through the shopper-ownership guard.
+     *
+     * Helper\Controller is handed the raw Magento\Customer\Model\Session by DI and wraps it
+     * in a ShopperScopedSession; if it ALSO kept the raw session in a property, a later edit
+     * could read or write captured_addresses directly and silently skip the identity check
+     * that stops shopper B inheriting shopper A's verify bypasses (LOQ-16978). Asserted on
+     * the constructed object rather than by reading the source, so it holds however the
+     * property is declared.
+     */
+    public function testTheStoreIsReachedOnlyThroughTheShopperOwnershipGuard(): void
+    {
+        $shopper = $this->createShopper();
+        $held = $this->propertyValues($shopper['controller']);
+
+        foreach ($held as $name => $value) {
+            $this->assertNotInstanceOf(
+                Session::class,
+                $value,
+                sprintf(
+                    'Helper\Controller::$%s holds the raw customer session. The captured-address store must '
+                    . 'be reachable only through ShopperScopedSession, or a future edit can read and write it '
+                    . 'without the shopper-ownership check that flushes it on a login or a logout.',
+                    $name
+                )
+            );
+        }
+
+        $guards = array_filter($held, static fn ($value): bool => $value instanceof ShopperScopedSession);
+        $this->assertCount(
+            1,
+            $guards,
+            'Helper\Controller must hold exactly one ShopperScopedSession: that is the seam every access to '
+            . 'the captured-address store has to go through.'
+        );
+    }
+
+    /**
+     * Capture one distinct address, exactly as Controller::retrieve() does with a Loqate
+     * lookup record.
+     *
+     * storeCapturedAddress() is protected, so it is invoked by reflection rather than through
+     * retrieve(): retrieve() would additionally need the Capture connector swapped out and the
+     * request/result factory driven, none of which this store's behaviour depends on.
+     *
+     * @param array $shopper Harness from createShopper().
+     * @param int $index Which distinct address to capture.
+     */
+    private function captureAddress(array $shopper, int $index): void
+    {
+        if (!method_exists(Controller::class, 'storeCapturedAddress')) {
+            $this->fail(
+                'Helper\Controller::storeCapturedAddress() does not exist: the captured-address store must '
+                . 'have exactly one writer, so its bound and its de-duplication live in one place.'
+            );
+        }
+
+        $this->captureRecord($shopper, $this->lookupRecord($index));
+    }
+
+    /**
+     * Capture one arbitrary Loqate lookup record, for the tests that care about the exact
+     * field values rather than about "the Nth distinct address".
+     *
+     * @param array $shopper Harness from createShopper().
+     * @param array $record A Loqate Capture "retrieve" record.
+     */
+    private function captureRecord(array $shopper, array $record): void
+    {
+        if (!method_exists(Controller::class, 'storeCapturedAddress')) {
+            $this->fail(
+                'Helper\Controller::storeCapturedAddress() does not exist: the captured-address store must '
+                . 'have exactly one writer, so its bound and its de-duplication live in one place.'
+            );
+        }
+
+        $method = new ReflectionMethod(Controller::class, 'storeCapturedAddress');
+        $method->setAccessible(true);
+        $method->invoke($shopper['controller'], $record);
+    }
+
+    /**
+     * A single, fully populated Loqate lookup record the de-duplication pairs are varied
+     * from.
+     *
+     * Every mapped source field is populated because storeCapturedAddress() projects them all
+     * unguarded, and Line2 is non-empty so that a genuinely different second line is a
+     * variation this base can express.
+     *
+     * @return array<string, string>
+     */
+    private static function baseLookupRecord(): array
+    {
+        return [
+            'Line1' => '1 High Street',
+            'Line2' => 'Flat 2',
+            'CountryIso2' => 'GB',
+            'PostalCode' => 'SW1A 1AA',
+            'City' => 'London',
+            'ProvinceName' => 'Greater London',
+        ];
+    }
+
+    /**
+     * A lookup record projected exactly as storeCapturedAddress() stores it - through
+     * Validator::ADDRESS_CAPTURE_MAPPING, in that constant's key order, so the result can be
+     * compared with assertSame() against what the store actually holds.
+     *
+     * @param array $record A Loqate Capture "retrieve" record.
+     * @return array<string, mixed>
+     */
+    private function projection(array $record): array
+    {
+        $projected = [];
+        foreach (Validator::ADDRESS_CAPTURE_MAPPING as $stored => $source) {
+            $projected[$stored] = $record[$source] ?? null;
+        }
+
+        return $projected;
+    }
+
+    /**
+     * The same lookup record in the Magento shape checkout submits, so it reaches
+     * Validator::checkForCapturedAddress() through parseAddress() exactly as a real
+     * submission would - including parseAddress()'s own handling of an empty or absent second
+     * line, which extractStreetLines() drops.
+     *
+     * @param array $record A Loqate Capture "retrieve" record.
+     * @return array
+     */
+    private function magentoShapeOf(array $record): array
+    {
+        return [
+            'street' => [$record['Line1'] ?? null, $record['Line2'] ?? null],
+            'city' => $record['City'] ?? null,
+            'region' => $record['ProvinceName'] ?? null,
+            'postcode' => $record['PostalCode'] ?? null,
+            'country_id' => $record['CountryIso2'] ?? null,
+        ];
+    }
+
+    /**
+     * The store's entries decoded back into the projected address arrays they hold, in stored
+     * order - so a de-duplication failure reports which ADDRESSES are in the store rather
+     * than a diff of JSON blobs.
+     *
+     * @param array $shopper Harness from createShopper().
+     * @return array<int, mixed>
+     */
+    private function capturedProjections(array $shopper): array
+    {
+        $decoded = [];
+        foreach ($this->capturedStore($shopper) as $entry) {
+            $decoded[] = json_decode((string)$entry, true);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * A Loqate Capture "retrieve" record, in the shape ADDRESS_CAPTURE_MAPPING reads.
+     *
+     * Every mapped source field is populated, because storeCapturedAddress() projects them
+     * all unguarded - a fixture missing one would raise a PHP warning rather than test the
+     * store.
+     *
+     * @param int $index Distinguishes one captured address from another.
+     * @return array<string, string>
+     */
+    private function lookupRecord(int $index): array
+    {
+        return [
+            'Line1' => $index . ' Test Street',
+            'Line2' => '',
+            'CountryIso2' => 'GB',
+            'PostalCode' => 'SW1A ' . $index . 'AA',
+            'City' => 'London',
+            'ProvinceName' => 'Greater London',
+        ];
+    }
+
+    /**
+     * The same address as lookupRecord(), in the Magento shape checkout submits, so that
+     * Validator::parseAddress() projects it onto the identical captured-address signature.
+     *
+     * @param int $index Distinguishes one address from another.
+     * @return array
+     */
+    private function magentoAddress(int $index): array
+    {
+        return [
+            'street' => [$index . ' Test Street'],
+            'city' => 'London',
+            'region' => 'Greater London',
+            'postcode' => 'SW1A ' . $index . 'AA',
+            'country_id' => 'GB',
+        ];
+    }
+
+    /**
+     * The captured-address store as currently held in the session.
+     *
+     * @param array $shopper Harness from createShopper().
+     * @return array
+     */
+    private function capturedStore(array $shopper): array
+    {
+        $store = $shopper['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] ?? [];
+
+        return is_array($store) ? $store : [];
+    }
+
+    /**
+     * The store rendered as the street lines it holds, in stored order - a readable stand-in
+     * for the serialised entries, so an eviction-order failure reports which addresses are
+     * actually in the store rather than a diff of JSON blobs.
+     *
+     * @param array $shopper Harness from createShopper().
+     * @return string[]
+     */
+    private function capturedStreets(array $shopper): array
+    {
+        $streets = [];
+        foreach ($this->capturedStore($shopper) as $entry) {
+            $decoded = json_decode((string)$entry, true);
+            $streets[] = is_array($decoded) ? (string)($decoded['Address1'] ?? '') : '(unreadable)';
+        }
+
+        return $streets;
+    }
+
+    /**
+     * The street lines the given capture indexes are expected to leave, in order.
+     *
+     * @param int[] $indexes Capture indexes, oldest first.
+     * @return string[]
+     */
+    private function expectedStreets(array $indexes): array
+    {
+        return array_map(static fn (int $index): string => $index . ' Test Street', array_values($indexes));
+    }
+
+    /** Number of billable Loqate Cleansing requests the shopper's Validator has issued. */
+    private function apiCallCount(array $shopper): int
+    {
+        return count($shopper['requests']);
+    }
+
+    /**
+     * The street lines of every address actually SENT to the billable Cleansing API, in the
+     * order they were sent, across every request.
+     *
+     * Addresses, not requests, because the Cleansing API is billed PER ADDRESS (see the billing
+     * note on Validator::verifyMultipleAddresses()) - so this is the invoice, and it is the
+     * same measure for the single-address reader, which sends one address per request, and for
+     * the batch one, which sends several. Reporting the STREETS rather than a count is what
+     * makes a failure say WHICH address lost or gained its bypass.
+     *
+     * @param array $shopper Harness from createShopper().
+     * @return string[]
+     */
+    private function billedStreets(array $shopper): array
+    {
+        $streets = [];
+        foreach ($shopper['requests'] as $request) {
+            foreach ($request['Addresses'] ?? [] as $address) {
+                $streets[] = (string)($address['Address1'] ?? '');
+            }
+        }
+
+        return $streets;
+    }
+
+    /**
+     * Run one address through one of the two readers of the captured-address store, under the
+     * error handler a live Magento installation has installed, and report a reader-specific
+     * failure if anything escapes.
+     *
+     * WHY THE ERROR HANDLER. Magento\Framework\App\ErrorHandler, registered by
+     * Bootstrap::run(), THROWS on every PHP error that error_reporting() reports, and
+     * app/bootstrap.php sets error_reporting(E_ALL) - so in a live store an E_WARNING such as
+     * "foreach() argument must be of type array|object" is not a log line, it is an aborted
+     * request in front of a shopper. Reproducing that here is what makes the is_array() guard
+     * testable at all: with PHP's default handler the warning is emitted and execution
+     * continues, so a test could only assert the guard's SIDE EFFECTS and would pass against a
+     * build that fatals in production.
+     *
+     * WHY $this->fail() RATHER THAN LETTING IT PROPAGATE: an escaping Throwable is the defect
+     * itself, so it is reported as a failed EXPECTATION naming the reader, the exception class
+     * and the line - not as an errored test that reads like the harness broke.
+     *
+     * The batch reader is given a ONE-address batch deliberately: createShopper()'s connector
+     * answers exactly one response row, and verifyMultipleAddresses() returns false unless the
+     * row count matches the number of addresses sent, so a longer batch would fail for a reason
+     * that has nothing to do with the captured-address store.
+     *
+     * @param array $shopper Harness from createShopper().
+     * @param string $reader self::READER_SINGLE or self::READER_BATCH.
+     * @param array $address The address to verify, in the Magento shape checkout submits.
+     * @return mixed Whatever the reader answered.
+     */
+    private function verifyThrough(array $shopper, string $reader, array $address)
+    {
+        $validator = $shopper['validator'];
+        $call = match ($reader) {
+            self::READER_SINGLE => static fn () => $validator->verifyAddress($address),
+            self::READER_BATCH => static fn () => $validator->verifyMultipleAddresses([$address]),
+            default => null,
+        };
+
+        if ($call === null) {
+            $this->fail(sprintf('Unknown captured-address store reader "%s".', $reader));
+        }
+
+        // BOTH HALVES OF app/bootstrap.php, and the error_reporting() call is NOT optional
+        // here. PHP invokes a user error handler for every error regardless of
+        // error_reporting(), so it is the handler's own error_reporting() test - Magento's
+        // included - that decides whether the error is promoted, and PHPUnit runs tests with
+        // error_reporting() set to 245: E_WARNING, E_NOTICE and E_DEPRECATED are all excluded.
+        // Installing the handler alone therefore reproduced Magento's handler faithfully but
+        // Magento's ENVIRONMENT not at all, and every foreach()-over-a-scalar warning was
+        // handed straight back to PHP - which is precisely the "degrades to a skipped loop"
+        // reading that makes a live store's fatal invisible to a test.
+        $previousReporting = error_reporting(E_ALL);
+        set_error_handler(static function (int $severity, string $message, string $file = '', int $line = 0) {
+            // Exactly Magento\Framework\App\ErrorHandler::handler(): a suppressed or unreported
+            // error is handed back to PHP, everything else becomes an exception.
+            if ((error_reporting() & $severity) === 0) {
+                return false;
+            }
+
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            return $call();
+        } catch (\Throwable $escaped) {
+            $this->fail(sprintf(
+                'Validator::%s() let a malformed captured-address store escape as %s: "%s" (%s:%d). A store '
+                . 'this module cannot read may cost the shopper a BYPASS - the address is verified and billed '
+                . 'again - but never a fatal: this runs inside a checkout submission, over a bare session key '
+                . 'shared with every other module on the installation.',
+                $reader,
+                get_class($escaped),
+                $escaped->getMessage(),
+                $escaped->getFile(),
+                $escaped->getLine()
+            ));
+        } finally {
+            restore_error_handler();
+            error_reporting($previousReporting);
+        }
+    }
+
+    /**
+     * What each reader answers for an address it ACCEPTS, whether it was bypassed or billed.
+     *
+     * The two shapes are deliberately different because the readers' contracts are: the
+     * single-address reader answers the ['error' => false] envelope its checkout callers read,
+     * the batch reader answers one boolean verdict per input key, under that key - the
+     * LOQ-16977 return shape. Note that the accepted verdict is IDENTICAL whether the address
+     * was bypassed or verified, which is precisely why every test here pairs it with
+     * billedStreets().
+     *
+     * @param string $reader self::READER_SINGLE or self::READER_BATCH.
+     * @return array
+     */
+    private function acceptedVerdict(string $reader): array
+    {
+        return $reader === self::READER_BATCH ? [0 => true] : ['error' => false];
+    }
+
+    /**
+     * Resolve a malformedStoreAndReaderProvider() placeholder into the value the test actually
+     * puts in the session attribute.
+     *
+     * @param mixed $malformed A provider value, possibly a placeholder.
+     * @param string $entry The entry Controller::storeCapturedAddress() wrote for the address
+     *                      under test.
+     * @return mixed
+     */
+    private function materialise($malformed, string $entry)
+    {
+        if ($malformed === self::THE_ENTRY_UNWRAPPED) {
+            return $entry;
+        }
+
+        if ($malformed === self::AN_OBJECT_AROUND_THE_ENTRY) {
+            return (object)['entry' => $entry];
+        }
+
+        return $malformed;
+    }
+
+    /**
+     * Cross a table of single-argument provider rows with the two readers of the store, naming
+     * each row after both.
+     *
+     * The cross product is built here rather than written out because the requirement is
+     * literally "every one of these values, through EVERY reader": the guards under test live
+     * in the shared matcher, and it was the existence of a second caller with its own truthiness
+     * check that decided where they had to go.
+     *
+     * @param array<string, array{0: mixed}> $rows
+     * @return array<string, array{0: mixed, 1: string}>
+     */
+    private static function crossWithReaders(array $rows): array
+    {
+        $crossed = [];
+        foreach ($rows as $name => $arguments) {
+            foreach ([self::READER_SINGLE, self::READER_BATCH] as $reader) {
+                $crossed[$name . ', read by ' . $reader . '()'] = [$arguments[0], $reader];
+            }
+        }
+
+        return $crossed;
+    }
+
+    /**
+     * The documented bound, read from the production constant so the tests cannot drift from
+     * it - and so removing the bound fails loudly instead of silently skipping these tests.
+     */
+    private function capturedLimit(): int
+    {
+        if (!defined(Controller::class . '::CAPTURED_ADDRESSES_LIMIT')) {
+            $this->fail(
+                'Controller::CAPTURED_ADDRESSES_LIMIT is not defined: the captured-address store must be '
+                . 'bounded, or one session can grow it without limit for as long as the shopper keeps picking '
+                . 'addresses from the lookup.'
+            );
+        }
+
+        return (int)constant(Controller::class . '::CAPTURED_ADDRESSES_LIMIT');
+    }
+
+    /**
+     * The single-address verdict cache's bound, the neighbour this store's bound must match.
+     */
+    private function verifyCacheLimit(): int
+    {
+        if (!defined(Validator::class . '::VERIFY_CACHE_LIMIT')) {
+            $this->fail(
+                'Validator::VERIFY_CACHE_LIMIT is not defined: the verdict cache consulted alongside this '
+                . 'store must be bounded too, and this store\'s bound is defined as being the same as it.'
+            );
+        }
+
+        return (int)constant(Validator::class . '::VERIFY_CACHE_LIMIT');
+    }
+
+    /**
+     * The BATCH verdict cache's bound - the one neighbour that is deliberately LARGER, so
+     * "consistent with its neighbours" cannot be satisfied by making all three equal.
+     */
+    private function batchCacheLimit(): int
+    {
+        if (!defined(Validator::class . '::BATCH_VERIFY_CACHE_LIMIT')) {
+            $this->fail(
+                'Validator::BATCH_VERIFY_CACHE_LIMIT is not defined: the batch verdict cache must be bounded '
+                . 'too, and this store\'s bound is defined by contrast with it.'
+            );
+        }
+
+        return (int)constant(Validator::class . '::BATCH_VERIFY_CACHE_LIMIT');
+    }
+
+    /**
+     * Every property an object holds, including private and inherited ones, by name.
+     *
+     * @param object $object
+     * @return array<string, mixed>
+     */
+    private function propertyValues(object $object): array
+    {
+        $values = [];
+        for ($class = new ReflectionClass($object); $class !== false; $class = $class->getParentClass()) {
+            foreach ($class->getProperties() as $property) {
+                $property->setAccessible(true);
+                if (!array_key_exists($property->getName(), $values) && $property->isInitialized($object)) {
+                    $values[$property->getName()] = $property->getValue($object);
+                }
+            }
+        }
+
+        return $values;
+    }
+}

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Helper;
+
+use Loqate\ApiIntegration\Helper\Data;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Helper\Context;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The config-reading seam every other class in this module depends on.
+ *
+ * WHY THIS FILE EXISTS. Every other test mocks Helper\Data wholesale, so nothing exercised
+ * these methods and nothing pinned the SCOPE they read at. That gap was not theoretical: the
+ * admin notice for the unverified-order combination was scope-blind precisely because
+ * getConfigValue() reads SCOPE_STORE with no store - which resolves to the default store in the
+ * admin area - and no test could tell the difference between naming a store and not naming one.
+ * The notice's own test stubs Data and models Magento's inheritance itself, so it asserts that
+ * model rather than this mechanism: deleting the $storeId argument from
+ * getConfigValueForStore() left that test green.
+ *
+ * These tests therefore assert the ARGUMENTS handed to ScopeConfigInterface, which is the only
+ * place the scope of a read is decided.
+ */
+class DataTest extends TestCase
+{
+    /** @var array<int, array{path: string, scope: string, scopeCode: mixed}> Every read, in order. */
+    private array $reads = [];
+
+    /**
+     * A store-scoped read must NAME the store, or it is not store-scoped.
+     *
+     * This is the assertion that would have failed the scope-blind read. Dropping the third
+     * argument, or passing the wrong scope type, is a silent revert of the fix that made the
+     * admin notice see per-store-view configuration.
+     */
+    public function testAStoreScopedReadNamesTheStoreItWasAskedFor(): void
+    {
+        $helper = $this->helper(['some/path' => 'value-for-store-7']);
+
+        $value = $helper->getConfigValueForStore('some/path', 7);
+
+        $this->assertSame('value-for-store-7', $value, 'The configured value must be returned unchanged.');
+        $this->assertSame(
+            [['path' => 'some/path', 'scope' => ScopeInterface::SCOPE_STORE, 'scopeCode' => 7]],
+            $this->reads,
+            'A store-scoped read must pass SCOPE_STORE *and* the store id. Without the id, Magento '
+            . 'resolves the current store - the default store in the admin area - so a per-store-view '
+            . 'override becomes invisible and any caller reasoning about another store is silently wrong.'
+        );
+    }
+
+    /**
+     * ...and the scope-less read must NOT name one, which is the contrast that gives the test
+     * above its meaning.
+     *
+     * getConfigValue() is deliberately current-scope: it is what the storefront paths want, and
+     * pinning it here stops the two methods being quietly collapsed into one.
+     */
+    public function testTheCurrentScopeReadDoesNotNameAStore(): void
+    {
+        $helper = $this->helper(['some/path' => 'value']);
+
+        $helper->getConfigValue('some/path');
+
+        $this->assertSame(
+            [['path' => 'some/path', 'scope' => ScopeInterface::SCOPE_STORE, 'scopeCode' => null]],
+            $this->reads,
+            'getConfigValue() must read SCOPE_STORE with NO store code, so Magento resolves the current '
+            . 'store. If a store code appears here, the two read methods have become the same method and '
+            . 'one of the two call sites is now wrong.'
+        );
+    }
+
+    /**
+     * A store id of 0 must still be passed, not treated as "no store".
+     *
+     * 0 is the admin store, a real store id. A truthiness guard would silently downgrade this to
+     * a current-scope read - the exact bug this method exists to avoid - and 0 is the value a
+     * failed store lookup produces, so it is the one most likely to arrive.
+     */
+    public function testAStoreIdOfZeroIsStillNamed(): void
+    {
+        $helper = $this->helper(['some/path' => 'admin-value']);
+
+        $helper->getConfigValueForStore('some/path', 0);
+
+        $this->assertSame(
+            [['path' => 'some/path', 'scope' => ScopeInterface::SCOPE_STORE, 'scopeCode' => 0]],
+            $this->reads,
+            'Store 0 is the admin store, not the absence of a store: it must be passed through.'
+        );
+    }
+
+    /**
+     * Helper under test, over a scope config that records every read.
+     *
+     * @param array<string, mixed> $values Config values keyed by path.
+     * @return Data
+     */
+    private function helper(array $values): Data
+    {
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnCallback(
+            function ($path, $scope = null, $scopeCode = null) use ($values) {
+                $this->reads[] = ['path' => $path, 'scope' => $scope, 'scopeCode' => $scopeCode];
+
+                return $values[$path] ?? null;
+            }
+        );
+
+        return new Data(new Context($scopeConfig), $this->createMock(StoreManagerInterface::class));
+    }
+}

--- a/Test/Unit/Helper/ShopperScopedAddressStoresTest.php
+++ b/Test/Unit/Helper/ShopperScopedAddressStoresTest.php
@@ -5,7 +5,7 @@ namespace Loqate\ApiIntegration\Test\Unit\Helper;
 use Loqate\ApiConnector\Client\Verify;
 use Loqate\ApiIntegration\Helper\Controller;
 use Loqate\ApiIntegration\Helper\Data;
-use Loqate\ApiIntegration\Helper\ShopperScopedSession;
+use Loqate\ApiIntegration\Helper\ShopperScopedAddressStores;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
 use Magento\Customer\Model\Session;
@@ -23,7 +23,7 @@ use ReflectionProperty;
 use stdClass;
 
 /**
- * Unit tests for Helper\ShopperScopedSession: the one seam through which this module
+ * Unit tests for Helper\ShopperScopedAddressStores: the one seam through which this module
  * reaches the three session attributes that can make an address SKIP a billable Loqate
  * verify, and the guard that keeps them belonging to ONE shopper (LOQ-16978).
  *
@@ -90,7 +90,7 @@ use stdClass;
  * testOnTheAdminhtmlPathTheBatchCacheIsOwnedByTheGuestAndTheFlushIsANoOp(), which pins that
  * ACCEPTED LIMIT as documented behaviour so it cannot change silently in either direction.
  */
-class ShopperScopedSessionTest extends TestCase
+class ShopperScopedAddressStoresTest extends TestCase
 {
     /** Any non-empty key lets both helpers build their API connectors. */
     private const API_KEY = 'TEST-API-KEY-0000';
@@ -114,7 +114,7 @@ class ShopperScopedSessionTest extends TestCase
     private const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
 
     /**
-     * The second identity source ShopperScopedSession deliberately does NOT read.
+     * The second identity source ShopperScopedAddressStores deliberately does NOT read.
      *
      * Held as a STRING and never imported: this class is a backend one, it is not among the
      * handful stubbed under Test/stubs, and the harness runs without Magento installed - so a
@@ -133,7 +133,7 @@ class ShopperScopedSessionTest extends TestCase
     ];
 
     /**
-     * Build a ShopperScopedSession over a customer session double whose data persists and
+     * Build a ShopperScopedAddressStores over a customer session double whose data persists and
      * whose logged-in identity can be changed between calls, exactly as a login or a logout
      * changes it between two requests.
      *
@@ -143,7 +143,7 @@ class ShopperScopedSessionTest extends TestCase
      *
      * @param array<string, mixed> $data Session attributes present before the first access.
      * @param int|string|null $customerId Logged-in customer, null for a guest.
-     * @return array{guard: ShopperScopedSession, session: ArrayObject, identity: ArrayObject,
+     * @return array{guard: ShopperScopedAddressStores, session: ArrayObject, identity: ArrayObject,
      *     writes: ArrayObject}
      */
     private function createGuard(array $data = [], $customerId = null): array
@@ -155,7 +155,7 @@ class ShopperScopedSessionTest extends TestCase
         $sessionMock = $this->createSessionDouble($sessionStore, $identity, $writes);
 
         return [
-            'guard' => new ShopperScopedSession($sessionMock),
+            'guard' => new ShopperScopedAddressStores($sessionMock),
             'session' => $sessionStore,
             'identity' => $identity,
             'writes' => $writes,
@@ -349,7 +349,7 @@ class ShopperScopedSessionTest extends TestCase
      * that grant a verify bypass, reached through the names Controller and Validator publish.
      *
      * This is the one thing the behavioural tests cannot see. Reading or writing an attribute
-     * through ShopperScopedSession does NOT enrol it in the flush - only this list does - so
+     * through ShopperScopedAddressStores does NOT enrol it in the flush - only this list does - so
      * a fourth store could be added, reached through the guard, and still be inherited by the
      * next shopper with every other test in this file green.
      *
@@ -388,16 +388,16 @@ class ShopperScopedSessionTest extends TestCase
                 Validator::VERIFY_CACHE_SESSION_KEY,
                 Validator::BATCH_VERIFY_CACHE_SESSION_KEY,
             ],
-            'The three attribute NAMES are unchanged by the constants moving onto ShopperScopedSession. They '
+            'The three attribute NAMES are unchanged by the constants moving onto ShopperScopedAddressStores. They '
             . 'are the keys of live customer sessions: renaming one silently empties that store for every '
             . 'shopper mid-checkout at deploy time, which re-bills every address they have already had '
             . 'verified.'
         );
         $this->assertSame(
             [
-                ShopperScopedSession::CAPTURED_ADDRESSES_SESSION_KEY,
-                ShopperScopedSession::VERIFY_CACHE_SESSION_KEY,
-                ShopperScopedSession::BATCH_VERIFY_CACHE_SESSION_KEY,
+                ShopperScopedAddressStores::CAPTURED_ADDRESSES_SESSION_KEY,
+                ShopperScopedAddressStores::VERIFY_CACHE_SESSION_KEY,
+                ShopperScopedAddressStores::BATCH_VERIFY_CACHE_SESSION_KEY,
             ],
             [
                 Controller::CAPTURED_ADDRESSES_SESSION_KEY,
@@ -878,8 +878,8 @@ class ShopperScopedSessionTest extends TestCase
     public function testAnUnenrolledAttributeIsRejectedByBothGetDataAndSetData(string $key): void
     {
         $calls = [
-            'getData()' => static fn (ShopperScopedSession $guard) => $guard->getData($key),
-            'setData()' => static fn (ShopperScopedSession $guard) => $guard->setData($key, 'a new value'),
+            'getData()' => static fn (ShopperScopedAddressStores $guard) => $guard->getData($key),
+            'setData()' => static fn (ShopperScopedAddressStores $guard) => $guard->setData($key, 'a new value'),
         ];
 
         foreach ($calls as $label => $call) {
@@ -937,7 +937,7 @@ class ShopperScopedSessionTest extends TestCase
      * Attributes that must NOT be reachable through the guard.
      *
      * The first four are the module's real un-enrolled session attributes, named in the
-     * ShopperScopedSession class docblock as deliberately out of scope for LOQ-16978. They
+     * ShopperScopedAddressStores class docblock as deliberately out of scope for LOQ-16978. They
      * are the ones a future edit is most likely to route through this class by analogy, which
      * is exactly the mistake the throw exists to catch: they would gain the guard's
      * appearance without ever being added to the flush.
@@ -1172,7 +1172,7 @@ class ShopperScopedSessionTest extends TestCase
      * whichever admin submitted first.
      *
      * THIS IS NOT A FAILING TEST AND IT IS NOT A WORKAROUND. It is the documented limit on
-     * ShopperScopedSession, asserted so it cannot change in either direction unnoticed - if
+     * ShopperScopedAddressStores, asserted so it cannot change in either direction unnoticed - if
      * someone injects the backend auth session and closes it, this test fails and says so; if
      * someone assumes it is already closed, this test is the counter-example. It is
      * deliberately accepted upstream: the admin panel is a trusted, authenticated, non-shared
@@ -1206,7 +1206,7 @@ class ShopperScopedSessionTest extends TestCase
             $this->ownerConstant('GUEST_OWNER_ID'),
             $shopper['session'][$this->ownerKey()] ?? null,
             'On the adminhtml path the customer session carries no customer id, so the batch cache is owned '
-            . 'by the GUEST. This is the documented ACCEPTED LIMIT on ShopperScopedSession: the guard scopes '
+            . 'by the GUEST. This is the documented ACCEPTED LIMIT on ShopperScopedAddressStores: the guard scopes '
             . 'by customer identity only, and there is no customer identity here to scope by.'
         );
 
@@ -1226,7 +1226,7 @@ class ShopperScopedSessionTest extends TestCase
             . 'view and AQI threshold and only passes are stored, so it is the same verdict the second admin '
             . 'would have earned. Accepted upstream (the admin panel is trusted, authenticated and not '
             . 'shared); if this assertion ever fails because the backend auth session was injected, that is an '
-            . 'improvement - update this test and the ACCEPTED LIMITS note on ShopperScopedSession together.'
+            . 'improvement - update this test and the ACCEPTED LIMITS note on ShopperScopedAddressStores together.'
         );
 
         // The structural half of the same limit, and the reason the behavioural half above
@@ -1241,10 +1241,10 @@ class ShopperScopedSessionTest extends TestCase
             1,
             $identitySources,
             sprintf(
-                'ShopperScopedSession must read exactly ONE identity source. Holding a %s alongside the '
+                'ShopperScopedAddressStores must read exactly ONE identity source. Holding a %s alongside the '
                 . 'customer session would mean the admin-swap limit asserted above has been closed, which is '
                 . 'an improvement but makes the assertion above wrong: change both together, and the ACCEPTED '
-                . 'LIMITS note on ShopperScopedSession with them. Note that this counts SESSIONS only - the '
+                . 'LIMITS note on ShopperScopedAddressStores with them. Note that this counts SESSIONS only - the '
                 . 'guard is free to acquire other collaborators (a logger is the standing candidate, named on '
                 . 'assertEnrolled()) without touching what it can see about identity. Found: %s.',
                 self::BACKEND_AUTH_SESSION,
@@ -1317,7 +1317,7 @@ class ShopperScopedSessionTest extends TestCase
      * quietly bypassed: neither helper may keep a reference to the raw customer session.
      *
      * Both are handed a Magento\Customer\Model\Session by DI and wrap it in a
-     * ShopperScopedSession. If either also retained the raw object, a future edit could read
+     * ShopperScopedAddressStores. If either also retained the raw object, a future edit could read
      * or write any of the three attributes directly - no flush, no marker, and every
      * behavioural test in this file still green, because they only exercise the paths that DO
      * go through the guard.
@@ -1333,7 +1333,7 @@ class ShopperScopedSessionTest extends TestCase
                     $value,
                     sprintf(
                         '%s::$%s holds the raw customer session. The captured-address store and both verdict '
-                        . 'caches must be reachable only through ShopperScopedSession, or one direct '
+                        . 'caches must be reachable only through ShopperScopedAddressStores, or one direct '
                         . 'getData() re-opens LOQ-16978 with the whole suite green.',
                         $label,
                         $name
@@ -1341,11 +1341,11 @@ class ShopperScopedSessionTest extends TestCase
                 );
             }
 
-            $guards = array_filter($held, static fn ($value): bool => $value instanceof ShopperScopedSession);
+            $guards = array_filter($held, static fn ($value): bool => $value instanceof ShopperScopedAddressStores);
             $this->assertCount(
                 1,
                 $guards,
-                sprintf('%s must hold exactly one ShopperScopedSession to reach its session stores.', $label)
+                sprintf('%s must hold exactly one ShopperScopedAddressStores to reach its session stores.', $label)
             );
         }
     }
@@ -1519,7 +1519,7 @@ class ShopperScopedSessionTest extends TestCase
         $keys = self::readManagedKeys();
         if ($keys === []) {
             $this->fail(
-                'ShopperScopedSession::SHOPPER_SCOPED_SESSION_KEYS is missing or empty: that list IS the '
+                'ShopperScopedAddressStores::SHOPPER_SCOPED_SESSION_KEYS is missing or empty: that list IS the '
                 . 'flush, so an empty one means no store is ever cleared when the shopper changes.'
             );
         }
@@ -1534,7 +1534,7 @@ class ShopperScopedSessionTest extends TestCase
      */
     private static function readManagedKeys(): array
     {
-        $reflection = new ReflectionClass(ShopperScopedSession::class);
+        $reflection = new ReflectionClass(ShopperScopedAddressStores::class);
         if (!$reflection->hasConstant('SHOPPER_SCOPED_SESSION_KEYS')) {
             return [];
         }
@@ -1551,7 +1551,7 @@ class ShopperScopedSessionTest extends TestCase
         $key = self::readOwnerKey();
         if ($key === '') {
             $this->fail(
-                'ShopperScopedSession::SESSION_OWNER_KEY is not defined: the identity the shopper-scoped '
+                'ShopperScopedAddressStores::SESSION_OWNER_KEY is not defined: the identity the shopper-scoped '
                 . 'stores belong to has to be recorded somewhere, or no identity change can be detected.'
             );
         }
@@ -1564,7 +1564,7 @@ class ShopperScopedSessionTest extends TestCase
      */
     private static function readOwnerKey(): string
     {
-        $reflection = new ReflectionClass(ShopperScopedSession::class);
+        $reflection = new ReflectionClass(ShopperScopedAddressStores::class);
 
         return $reflection->hasConstant('SESSION_OWNER_KEY')
             ? (string)$reflection->getConstant('SESSION_OWNER_KEY')
@@ -1584,10 +1584,10 @@ class ShopperScopedSessionTest extends TestCase
      */
     private function ownerConstant(string $name): int
     {
-        $reflection = new ReflectionClass(ShopperScopedSession::class);
+        $reflection = new ReflectionClass(ShopperScopedAddressStores::class);
         if (!$reflection->hasConstant($name)) {
             $this->fail(sprintf(
-                'ShopperScopedSession::%s is not defined. The guard needs three DISJOINT owner classes - a '
+                'ShopperScopedAddressStores::%s is not defined. The guard needs three DISJOINT owner classes - a '
                 . 'positive customer id, the guest, and "the session answered an id we cannot read" - or two '
                 . 'different identities compare equal and the stores are not flushed between them.',
                 $name

--- a/Test/Unit/Helper/ShopperScopedSessionTest.php
+++ b/Test/Unit/Helper/ShopperScopedSessionTest.php
@@ -1,0 +1,1620 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Helper;
+
+use Loqate\ApiConnector\Client\Verify;
+use Loqate\ApiIntegration\Helper\Controller;
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\ShopperScopedSession;
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Logger\Logger;
+use Magento\Customer\Model\Session;
+use Magento\Directory\Model\RegionFactory;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use ArrayObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+use stdClass;
+
+/**
+ * Unit tests for Helper\ShopperScopedSession: the one seam through which this module
+ * reaches the three session attributes that can make an address SKIP a billable Loqate
+ * verify, and the guard that keeps them belonging to ONE shopper (LOQ-16978).
+ *
+ * THE DEFECT. All three stores - Controller::CAPTURED_ADDRESSES_SESSION_KEY (the Capture
+ * bypass), Validator::VERIFY_CACHE_SESSION_KEY and
+ * Validator::BATCH_VERIFY_CACHE_SESSION_KEY (the LOQ-16969/LOQ-16976 verdict caches) -
+ * live in the customer session, and a PHP session OUTLIVES a login: Magento calls
+ * session_regenerate_id() on login and on logout, which changes the session ID while
+ * PRESERVING every value in $_SESSION. Nothing in Magento clears a third-party session
+ * attribute on an identity change. So on a shared browser - a family device, a public
+ * terminal, a click-and-collect kiosk - shopper B could inherit shopper A's bypasses and
+ * check out an address that was never verified against B's own submission. Every entry in
+ * these stores is a licence to skip a verification, which is why they share a lifetime and
+ * are flushed TOGETHER: flushing two of the three still leaves the third granting B a
+ * bypass A earned.
+ *
+ * WHAT IS PINNED HERE, and in which direction:
+ *  - the flush fires on EVERY identity change, in all three directions a browser can take
+ *    it - guest to logged in, one customer straight to another, logged in back to guest -
+ *    see testEveryIdentityChangeFlushesEveryShopperScopedStore(), and it fires whichever of
+ *    the stores is touched first, see
+ *    testTouchingAnyOneStoreAfterAnIdentityChangeFlushesAllOfThem();
+ *  - it does NOT fire for the same shopper, which is just as load-bearing: a guard that
+ *    flushed on every request would silently undo LOQ-16969 and LOQ-16976 and re-bill every
+ *    checkout, and it would do so with the whole suite green, because "cache never hits" is
+ *    invisible to a test that only checks for over-sharing. Hence
+ *    testTheSameShopperKeepsItsOwnStoresAndIsNotWrittenTo(),
+ *    testANumericStringCustomerIdIsTheSameShopperAsTheIntegerId() (the '7' versus 7 case:
+ *    Magento hands back either depending on how the id reached the session, and a typed
+ *    comparison would flush on every single request) and
+ *    testAGuestSessionIsNotFlushedOnEveryRequest();
+ *  - LEGACY data, written before the marker existed, is ADOPTED rather than thrown away,
+ *    see testLegacyDataWithNoOwnerMarkerIsAdopted(). Anything already in the session was by
+ *    definition written in THIS session, so it belongs to whoever is at this browser now,
+ *    and flushing it at deploy time would cost every live shopper their bypasses for
+ *    nothing. An UNREADABLE marker is the opposite case and is answered the opposite way,
+ *    see testAnUnreadableOwnerMarkerIsTreatedAsAnIdentityChange();
+ *  - an unreadable IDENTITY is a third owner of its own and is never folded onto the guest,
+ *    see testACustomerIdThatCannotBeReadIsItsOwnOwnerAndNeverTheGuest(). That is a
+ *    REGRESSION test, not a completeness one: mapping an unreadable customer id onto the
+ *    guest id made "a customer whose id we cannot read" and "nobody is logged in" compare
+ *    EQUAL, so a logout out of that state did not flush and the guest that followed
+ *    inherited all three bypass stores - the exact hand-off this class exists to stop;
+ *  - the ENROLMENT assertion: an attribute missing from the flush list is refused by both
+ *    getData() and setData() rather than quietly reached through the guard without ever
+ *    being flushed, see testAnUnenrolledAttributeIsRejectedByBothGetDataAndSetData() and
+ *    its mirror testEveryEnrolledAttributeIsAcceptedByBothGetDataAndSetData().
+ *
+ * The end of the chain - that the two helpers really do reach those attributes only through
+ * this class - is asserted behaviourally for all three stores
+ * (testACapturedAddressBypassDoesNotSurviveALogin(), testACachedVerdictDoesNotSurviveALogin(),
+ * testABatchVerdictDoesNotSurviveALogin()) and structurally
+ * (testNeitherHelperKeepsAReferenceToTheRawCustomerSession()), because a single raw
+ * $session->getData() left anywhere in Controller or Validator re-opens the defect while
+ * every test in this file still passes.
+ *
+ * ONE STORE IS ONLY NOMINALLY COVERED IN PRODUCTION, and that is pinned here rather than
+ * left to the class docblock: the BATCH verdict cache is written exclusively from adminhtml,
+ * where the customer session carries no customer id, so its owner is permanently the guest
+ * and the flush is a no-op on that path. The guard machinery works for it - proved by
+ * testABatchVerdictDoesNotSurviveALogin(), which drives a real customer identity change
+ * through verifyMultipleAddresses() - but on the path that actually writes it there is no
+ * identity to change. See
+ * testOnTheAdminhtmlPathTheBatchCacheIsOwnedByTheGuestAndTheFlushIsANoOp(), which pins that
+ * ACCEPTED LIMIT as documented behaviour so it cannot change silently in either direction.
+ */
+class ShopperScopedSessionTest extends TestCase
+{
+    /** Any non-empty key lets both helpers build their API connectors. */
+    private const API_KEY = 'TEST-API-KEY-0000';
+
+    /** AVC strictly better than the baked-in default threshold "P40-U00-P0-95" => accepted. */
+    private const PASSING_AVC = 'V55-I22-P9-99';
+
+    /**
+     * Address quality index the BATCH path is judged against, and the value the stub
+     * connector answers with, so checkQualityIndex()'s 'A' <= 'A' passes.
+     */
+    private const PASSING_AQI = 'A';
+
+    /** Session attribute the captured-address store lives under. */
+    private const CAPTURED_ADDRESSES_SESSION_KEY = 'captured_addresses';
+
+    /** Session attribute the single-address verdict cache lives under. */
+    private const VERIFY_CACHE_SESSION_KEY = 'loqate_verified_addresses';
+
+    /** Session attribute the batch verdict cache lives under. */
+    private const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
+
+    /**
+     * The second identity source ShopperScopedSession deliberately does NOT read.
+     *
+     * Held as a STRING and never imported: this class is a backend one, it is not among the
+     * handful stubbed under Test/stubs, and the harness runs without Magento installed - so a
+     * `use` statement or an `instanceof` on it would be a fatal here rather than an assertion.
+     * See isSessionCollaborator() for how it is matched.
+     */
+    private const BACKEND_AUTH_SESSION = 'Magento\Backend\Model\Auth\Session';
+
+    /** A Magento-shaped address as it arrives from checkout. */
+    private const ADDRESS = [
+        'street' => ['1 High St', 'Flat 2'],
+        'city' => 'London',
+        'region' => 'Greater London',
+        'postcode' => 'SW1A 1AA',
+        'country_id' => 'GB',
+    ];
+
+    /**
+     * Build a ShopperScopedSession over a customer session double whose data persists and
+     * whose logged-in identity can be changed between calls, exactly as a login or a logout
+     * changes it between two requests.
+     *
+     * Every setData() is recorded as well as applied, so a test can assert not only what the
+     * session ENDS UP holding but that the hot path (same shopper) writes NOTHING at all -
+     * which is what makes running the check on every single access affordable.
+     *
+     * @param array<string, mixed> $data Session attributes present before the first access.
+     * @param int|string|null $customerId Logged-in customer, null for a guest.
+     * @return array{guard: ShopperScopedSession, session: ArrayObject, identity: ArrayObject,
+     *     writes: ArrayObject}
+     */
+    private function createGuard(array $data = [], $customerId = null): array
+    {
+        $sessionStore = new ArrayObject($data);
+        $identity = new ArrayObject(['customerId' => $customerId]);
+        $writes = new ArrayObject();
+
+        $sessionMock = $this->createSessionDouble($sessionStore, $identity, $writes);
+
+        return [
+            'guard' => new ShopperScopedSession($sessionMock),
+            'session' => $sessionStore,
+            'identity' => $identity,
+            'writes' => $writes,
+        ];
+    }
+
+    /**
+     * A Magento\Customer\Model\Session double that actually stores what it is given.
+     *
+     * The shared Test/stubs Session is a no-op (getData() returns null, setData() stores
+     * nothing), so nothing under test could ever be observed. getData()/setData() have to be
+     * *added* to the double when the real Magento Session is present, because it does not
+     * declare them - SessionManager __call-forwards them to Session\Storage - while the stub
+     * does declare them and PHPUnit refuses to "add" an existing method; hence the
+     * method_exists() filter, which keeps this double working on both sides.
+     *
+     * @param ArrayObject $sessionStore Backing store for the session attributes.
+     * @param ArrayObject $identity Holds 'customerId', read LIVE so a test can log in mid-test.
+     * @param ArrayObject|null $writes Records every setData() call, in order.
+     * @return Session&MockObject
+     */
+    private function createSessionDouble(
+        ArrayObject $sessionStore,
+        ArrayObject $identity,
+        ?ArrayObject $writes = null
+    ) {
+        $sessionBuilder = $this->getMockBuilder(Session::class)->disableOriginalConstructor();
+        $undeclared = array_values(array_filter(
+            ['getData', 'setData'],
+            static fn (string $method): bool => !method_exists(Session::class, $method)
+        ));
+        if ($undeclared) {
+            $sessionBuilder->addMethods($undeclared);
+        }
+        $sessionMock = $sessionBuilder->getMock();
+        $sessionMock->method('getData')->willReturnCallback(
+            static function ($key = '', $clear = false) use ($sessionStore) {
+                return $sessionStore[$key] ?? null;
+            }
+        );
+        $sessionMock->method('setData')->willReturnCallback(
+            static function ($key, $value = null) use ($sessionStore, $sessionMock, $writes) {
+                if ($writes !== null) {
+                    $writes[] = ['key' => $key, 'value' => $value];
+                }
+                $sessionStore[$key] = $value;
+
+                return $sessionMock;
+            }
+        );
+        $sessionMock->method('getCustomerId')->willReturnCallback(
+            static fn () => $identity['customerId']
+        );
+
+        return $sessionMock;
+    }
+
+    /**
+     * THE guarantee, in all three directions a shared browser can take an identity: every
+     * shopper-scoped store is cleared and the new owner is recorded.
+     *
+     * All three transitions matter and none of them subsumes another. Guest to logged in is
+     * the family-device case (a guest browses, then someone signs in). Customer A to
+     * customer B is one login straight after another, which fires no logout in between on
+     * some flows. Logged in to guest is the LOGOUT, and it is the one an "only track logged-in
+     * customers" implementation misses: without a value standing for "guest", logging out
+     * looks identical to a session that was never marked, so A's bypasses would be left
+     * sitting in front of whoever uses the browser next.
+     *
+     * @param int|string|null $before Logged-in identity that wrote the stores.
+     * @param int|string|null $after Logged-in identity making the next request.
+     * @param int $expectedOwner Owner id that must be recorded after the change.
+     */
+    #[DataProvider('identityChangeProvider')]
+    public function testEveryIdentityChangeFlushesEveryShopperScopedStore(
+        $before,
+        $after,
+        int $expectedOwner
+    ): void {
+        $harness = $this->createGuard($this->seededStores(), $before);
+
+        // First request: the stores belong to $before, so nothing is flushed and the marker
+        // records that identity.
+        $harness['guard']->getData(self::CAPTURED_ADDRESSES_SESSION_KEY);
+        $this->assertSame(
+            $this->seededStores(),
+            $this->managedAttributes($harness),
+            'The stores must survive a request made by the shopper they belong to.'
+        );
+
+        // ...and then the identity changes, as a login, a logout or a second login does.
+        $harness['identity']['customerId'] = $after;
+        $read = $harness['guard']->getData(self::CAPTURED_ADDRESSES_SESSION_KEY);
+
+        $this->assertNull(
+            $read,
+            'The very access that detects the identity change must already answer with the flushed value: a '
+            . 'store cleared only on the NEXT request still grants this request its bypass.'
+        );
+        foreach ($this->managedKeys() as $key) {
+            $this->assertNull(
+                $harness['session'][$key] ?? null,
+                sprintf(
+                    'Session attribute "%s" survived an identity change. All three stores are verify '
+                    . 'bypasses, so they must be flushed TOGETHER: leaving any one of them lets the new '
+                    . 'shopper check out an address that was only ever verified for the previous one.',
+                    $key
+                )
+            );
+        }
+        $this->assertSame(
+            $expectedOwner,
+            $harness['session'][$this->ownerKey()] ?? null,
+            'The new identity must be recorded as the owner, or the stores it now writes are flushed again '
+            . 'on the next access - the caches would never hit and every address would be re-billed.'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: int|string|null, 1: int|string|null, 2: int}>
+     */
+    public static function identityChangeProvider(): array
+    {
+        return [
+            'a guest logs in' => [null, 7, 7],
+            'one customer logs in straight after another' => [7, 8, 8],
+            'a customer logs out' => [7, null, 0],
+            // Magento hands back an int or a numeric string depending on how the id reached
+            // the session, so a genuine change has to be detected across both shapes too.
+            'a customer logs out, having arrived as a numeric string' => ['7', null, 0],
+            'a guest logs in and the id arrives as a numeric string' => [null, '8', 8],
+        ];
+    }
+
+    /**
+     * The flush must not depend on which store the request happens to touch first.
+     *
+     * Checkout reaches these attributes in different orders on different paths -
+     * verifyAddress() reads the captured-address store before the verdict cache,
+     * verifyMultipleAddresses() reads the captured store and then the BATCH cache, and a
+     * Capture retrieve writes the captured store without reading either cache. A guard
+     * wired into only one of those entry points would leave the other two stores intact on
+     * exactly the requests that do not go through it.
+     *
+     * Driven from the production list of managed keys, so a fourth store added to it is
+     * covered by this test automatically.
+     *
+     * @param string $touched Managed session key the request reads first.
+     */
+    #[DataProvider('managedStoreProvider')]
+    public function testTouchingAnyOneStoreAfterAnIdentityChangeFlushesAllOfThem(string $touched): void
+    {
+        $harness = $this->createGuard(
+            array_merge($this->seededStores(), [$this->ownerKey() => 7]),
+            8
+        );
+
+        $harness['guard']->getData($touched);
+
+        foreach ($this->managedKeys() as $key) {
+            $this->assertNull(
+                $harness['session'][$key] ?? null,
+                sprintf(
+                    'Reading "%s" after an identity change must flush "%s" as well: the three stores are one '
+                    . 'shopper\'s data and have one lifetime.',
+                    $touched,
+                    $key
+                )
+            );
+        }
+    }
+
+    /**
+     * One case per managed store, taken from the production constant so a store added to the
+     * flush list is exercised without anyone remembering to extend this file.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function managedStoreProvider(): array
+    {
+        $cases = [];
+        foreach (self::readManagedKeys() as $key) {
+            $cases[$key] = [$key];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * The coverage gate on the flush list itself: it must name exactly the three attributes
+     * that grant a verify bypass, reached through the names Controller and Validator publish.
+     *
+     * This is the one thing the behavioural tests cannot see. Reading or writing an attribute
+     * through ShopperScopedSession does NOT enrol it in the flush - only this list does - so
+     * a fourth store could be added, reached through the guard, and still be inherited by the
+     * next shopper with every other test in this file green.
+     *
+     * The literals are asserted alongside the list because the attribute names MOVED onto
+     * this class in the LOQ-16978 review (Controller::CAPTURED_ADDRESSES_SESSION_KEY and
+     * Validator's two are now aliases of the constants here, to break a circular dependency:
+     * the flush list pointed at those classes while both of them construct this one). Two
+     * things have to survive that move and neither is visible from the list alone - the
+     * aliases must still resolve, because every other reference in the module and in three
+     * other test files goes through them, and the VALUES must be unchanged, or every live
+     * session loses its stores at deploy time and every shopper mid-checkout is re-billed.
+     */
+    public function testTheFlushListNamesExactlyTheStoresThatGrantAVerifyBypass(): void
+    {
+        $managed = $this->managedKeys();
+
+        $this->assertEqualsCanonicalizing(
+            [
+                Controller::CAPTURED_ADDRESSES_SESSION_KEY,
+                Validator::VERIFY_CACHE_SESSION_KEY,
+                Validator::BATCH_VERIFY_CACHE_SESSION_KEY,
+            ],
+            $managed,
+            'Every session attribute that can make an address skip the billable Loqate verify must be in the '
+            . 'flush list: the Capture bypass and BOTH verdict caches. One left out is one bypass a shopper '
+            . 'can inherit from whoever used the browser before them.'
+        );
+        $this->assertSame(
+            [
+                self::CAPTURED_ADDRESSES_SESSION_KEY,
+                self::VERIFY_CACHE_SESSION_KEY,
+                self::BATCH_VERIFY_CACHE_SESSION_KEY,
+            ],
+            [
+                Controller::CAPTURED_ADDRESSES_SESSION_KEY,
+                Validator::VERIFY_CACHE_SESSION_KEY,
+                Validator::BATCH_VERIFY_CACHE_SESSION_KEY,
+            ],
+            'The three attribute NAMES are unchanged by the constants moving onto ShopperScopedSession. They '
+            . 'are the keys of live customer sessions: renaming one silently empties that store for every '
+            . 'shopper mid-checkout at deploy time, which re-bills every address they have already had '
+            . 'verified.'
+        );
+        $this->assertSame(
+            [
+                ShopperScopedSession::CAPTURED_ADDRESSES_SESSION_KEY,
+                ShopperScopedSession::VERIFY_CACHE_SESSION_KEY,
+                ShopperScopedSession::BATCH_VERIFY_CACHE_SESSION_KEY,
+            ],
+            [
+                Controller::CAPTURED_ADDRESSES_SESSION_KEY,
+                Validator::VERIFY_CACHE_SESSION_KEY,
+                Validator::BATCH_VERIFY_CACHE_SESSION_KEY,
+            ],
+            'Controller and Validator must keep publishing these names as ALIASES of the constants on the '
+            . 'guard. The guard owns them because the guard is what enforces their lifetime, but every other '
+            . 'reference in the module still goes through the old names - and an alias that drifts from what '
+            . 'it aliases is two attributes with one meaning, of which only one is in the flush list.'
+        );
+        $this->assertSame(
+            count($managed),
+            count(array_unique($managed)),
+            'No attribute may be listed twice: the list is iterated to flush, so a duplicate is dead weight.'
+        );
+        $this->assertNotContains(
+            $this->ownerKey(),
+            $managed,
+            'The owner marker must NOT be one of the flushed attributes: flushing it would erase the identity '
+            . 'just recorded, so the very next access would flush the stores all over again and no verdict '
+            . 'could ever be cached.'
+        );
+    }
+
+    /**
+     * The marker is a bare key in the customer session, shared with Magento core and every
+     * other module on the installation, so it has to be namespaced. A collision would be read
+     * as an identity change (or worse, as a match) on every request.
+     */
+    public function testTheOwnerMarkerIsNamespacedToThisModule(): void
+    {
+        $marker = $this->ownerKey();
+
+        $this->assertNotSame('', $marker, 'The ownership marker must be a non-empty session attribute name.');
+        $this->assertStringStartsWith(
+            'loqate_',
+            $marker,
+            'The ownership marker shares the customer session with Magento core and every other module, so '
+            . 'its name must be namespaced to this one.'
+        );
+    }
+
+    /**
+     * The over-flushing guard, and the reason it matters as much as the flush itself: for the
+     * SAME shopper the stores must survive untouched, and the check must write NOTHING.
+     *
+     * A guard that flushed whenever it was unsure would silently undo LOQ-16969 and
+     * LOQ-16976 - every checkout would be re-billed - and would do it with the rest of the
+     * suite green, because "the cache never hits" looks exactly like "the cache is safe" to a
+     * test that only asserts nothing is over-shared. The write assertion is the second half:
+     * this check runs on EVERY access to any of the three stores, so the matching case has to
+     * be reads only - the owner marker and the customer id, two of them - and not a rewrite of
+     * four attributes per lookup.
+     */
+    public function testTheSameShopperKeepsItsOwnStoresAndIsNotWrittenTo(): void
+    {
+        $harness = $this->createGuard(
+            array_merge($this->seededStores(), [$this->ownerKey() => 7]),
+            7
+        );
+
+        $read = $harness['guard']->getData(self::VERIFY_CACHE_SESSION_KEY);
+
+        $this->assertSame(
+            ['cached' => 'verdict'],
+            $read,
+            'The shopper who owns the stores must be handed their contents back unchanged.'
+        );
+        $this->assertSame(
+            $this->seededStores(),
+            $this->managedAttributes($harness),
+            'None of the stores may be flushed while the same shopper is making the requests.'
+        );
+        $this->assertSame(
+            [],
+            iterator_to_array($harness['writes']),
+            'The matching case must write nothing at all: this check runs on every single access to every '
+            . 'store, so it has to cost the two session reads it already makes - the owner marker and the '
+            . 'customer id - and no writes.'
+        );
+    }
+
+    /**
+     * The '7' versus 7 case, pinned as behaviour because it decides whether the caches work
+     * at all.
+     *
+     * Magento\Customer\Model\Session::getCustomerId() answers an int or a numeric string
+     * depending on how the id reached the session (a fresh login versus a session restored
+     * from storage), so the SAME shopper can present both shapes across two requests. A
+     * typed comparison would read that as an identity change, flush the stores on the second
+     * request, and re-bill every address in the checkout - while every test asserting that
+     * data is not over-shared stayed green. The ids are therefore normalised to int before
+     * they are compared, and both orders are asserted here because a normalisation applied
+     * to only one side of the comparison passes one direction and fails the other.
+     *
+     * @param int|string $before Identity that wrote the stores.
+     * @param int|string $after Identity on the next request - the same shopper, differently typed.
+     */
+    #[DataProvider('sameShopperDifferentTypeProvider')]
+    public function testANumericStringCustomerIdIsTheSameShopperAsTheIntegerId($before, $after): void
+    {
+        $harness = $this->createGuard($this->seededStores(), $before);
+
+        $harness['guard']->getData(self::VERIFY_CACHE_SESSION_KEY);
+        $harness['identity']['customerId'] = $after;
+        $read = $harness['guard']->getData(self::VERIFY_CACHE_SESSION_KEY);
+
+        $this->assertSame(
+            ['cached' => 'verdict'],
+            $read,
+            sprintf(
+                'Customer id %s and %s are the same shopper: the ids must be normalised before they are '
+                . 'compared, or the type Magento happens to hand back decides whether a shopper keeps their '
+                . 'own caches - and every address in the checkout is billed again.',
+                var_export($before, true),
+                var_export($after, true)
+            )
+        );
+        $this->assertSame(
+            $this->seededStores(),
+            $this->managedAttributes($harness),
+            'No store may be flushed when only the TYPE of the customer id changed.'
+        );
+        $this->assertSame(
+            7,
+            $harness['session'][$this->ownerKey()] ?? null,
+            'The marker must hold the normalised int form, so the comparison is decided by the id and never '
+            . 'by its type.'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: int|string, 1: int|string}>
+     */
+    public static function sameShopperDifferentTypeProvider(): array
+    {
+        return [
+            'string then int' => ['7', 7],
+            'int then string' => [7, '7'],
+            'string throughout' => ['7', '7'],
+        ];
+    }
+
+    /**
+     * A guest browsing the site is an identity too, and one that must not flush on every
+     * request: a guest checkout is exactly where the verify caches earn their keep, since
+     * the same address is replayed across three to five call paths in one checkout.
+     */
+    public function testAGuestSessionIsNotFlushedOnEveryRequest(): void
+    {
+        $harness = $this->createGuard([], null);
+
+        // First access marks the session as the guest's.
+        $harness['guard']->setData(self::VERIFY_CACHE_SESSION_KEY, ['cached' => 'verdict']);
+
+        $this->assertSame(
+            0,
+            $harness['session'][$this->ownerKey()] ?? null,
+            'A guest must be recorded with a real owner id, not left unmarked: an unmarked session is '
+            . 'indistinguishable from legacy data, so a later logout could not be detected as a change.'
+        );
+
+        // Two more requests by the same guest.
+        $harness['guard']->getData(self::VERIFY_CACHE_SESSION_KEY);
+        $read = $harness['guard']->getData(self::VERIFY_CACHE_SESSION_KEY);
+
+        $this->assertSame(
+            ['cached' => 'verdict'],
+            $read,
+            'A guest must keep their own verdict cache for the whole session: this is the shopper the cache '
+            . 'was written for, and re-flushing it would re-bill every address in a guest checkout.'
+        );
+    }
+
+    /**
+     * A write made on the very request that detects an identity change must survive it.
+     *
+     * The ownership check runs BEFORE the write for exactly this reason: were it to run
+     * afterwards - or were the flush deferred - the first verdict the new shopper earned
+     * would be wiped a moment after it was stored, and their first address would be verified
+     * twice over.
+     */
+    public function testAValueWrittenOnTheRequestThatFlushesTheStoresSurvives(): void
+    {
+        $harness = $this->createGuard(
+            array_merge($this->seededStores(), [$this->ownerKey() => 7]),
+            8
+        );
+
+        $harness['guard']->setData(self::VERIFY_CACHE_SESSION_KEY, ['fresh' => 'verdict']);
+
+        $this->assertSame(
+            ['fresh' => 'verdict'],
+            $harness['session'][self::VERIFY_CACHE_SESSION_KEY] ?? null,
+            'The new shopper\'s own write must land in the freshly flushed store, not be wiped by the flush '
+            . 'it triggered.'
+        );
+        $this->assertNull(
+            $harness['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] ?? null,
+            'The stores the write did not touch must still have been flushed.'
+        );
+        $this->assertSame(
+            ['fresh' => 'verdict'],
+            $harness['guard']->getData(self::VERIFY_CACHE_SESSION_KEY),
+            'Reading it straight back must return it: the flush must not fire a second time for the shopper '
+            . 'who has just been recorded as the owner.'
+        );
+    }
+
+    /**
+     * Data written BEFORE this guard existed carries no owner marker, and must be ADOPTED
+     * rather than thrown away.
+     *
+     * It is safe: anything in the session was by definition written during THIS session, so
+     * it belongs to whoever is at this browser now, and any identity change from here on is
+     * caught normally - which the second half of this test asserts, so "adopt" can never
+     * quietly become "never check again". Flushing instead would buy nothing and would cost
+     * every live shopper their bypasses at deploy time.
+     *
+     * @param int|string|null $customerId Identity of whoever is at the browser on the first access.
+     * @param int $expectedOwner Owner id that must be recorded for them.
+     */
+    #[DataProvider('legacyAdoptionProvider')]
+    public function testLegacyDataWithNoOwnerMarkerIsAdopted($customerId, int $expectedOwner): void
+    {
+        $harness = $this->createGuard($this->seededStores(), $customerId);
+
+        $read = $harness['guard']->getData(self::CAPTURED_ADDRESSES_SESSION_KEY);
+
+        $this->assertSame(
+            ['captured'],
+            $read,
+            'Data written before the marker existed must be adopted, not discarded: it was written in this '
+            . 'same session, so it belongs to whoever is at this browser.'
+        );
+        $this->assertSame(
+            $this->seededStores(),
+            $this->managedAttributes($harness),
+            'Adoption must leave all three stores intact.'
+        );
+        $this->assertSame(
+            $expectedOwner,
+            $harness['session'][$this->ownerKey()] ?? null,
+            'Adoption must RECORD the adopting identity, or the data stays unmarked and a later login could '
+            . 'not be told apart from this first access.'
+        );
+
+        // Adoption happens once. The next identity change is an ordinary one.
+        $harness['identity']['customerId'] = 99;
+        $harness['guard']->getData(self::CAPTURED_ADDRESSES_SESSION_KEY);
+
+        $this->assertSame(
+            [null, null, null],
+            array_values($this->managedAttributes($harness)),
+            'Adopted data must still be flushed when the shopper changes: adoption applies to the FIRST '
+            . 'access only, and must not become a permanent exemption from the check.'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: int|string|null, 1: int}>
+     */
+    public static function legacyAdoptionProvider(): array
+    {
+        return [
+            'adopted by a guest' => [null, 0],
+            'adopted by a logged-in customer' => [7, 7],
+            'adopted by a logged-in customer whose id arrives as a string' => ['7', 7],
+        ];
+    }
+
+    /**
+     * The mirror image of adoption, answered the opposite way: a marker that is PRESENT but
+     * cannot be read as a customer id is treated as an identity change and the stores are
+     * flushed.
+     *
+     * That asymmetry is deliberate. An ABSENT marker means "nobody has claimed this data
+     * yet"; an unreadable one means the marker was written and is now something we do not
+     * understand - a corrupted session payload, another module writing to the key - and it
+     * cannot be shown to belong to this shopper. Flushing costs at most a few re-verified
+     * addresses; trusting it risks handing one shopper another's bypasses.
+     *
+     * @param mixed $marker Value found in the owner attribute.
+     */
+    #[DataProvider('unreadableOwnerMarkerProvider')]
+    public function testAnUnreadableOwnerMarkerIsTreatedAsAnIdentityChange($marker): void
+    {
+        $harness = $this->createGuard(
+            array_merge($this->seededStores(), [$this->ownerKey() => $marker]),
+            7
+        );
+
+        $harness['guard']->getData(self::CAPTURED_ADDRESSES_SESSION_KEY);
+
+        $this->assertSame(
+            [null, null, null],
+            array_values($this->managedAttributes($harness)),
+            'An owner marker that cannot be read as a customer id cannot be shown to belong to this shopper, '
+            . 'so the stores must be flushed rather than trusted.'
+        );
+        $this->assertSame(
+            7,
+            $harness['session'][$this->ownerKey()] ?? null,
+            'The unreadable marker must be replaced by the current identity, or every request repeats the '
+            . 'flush and nothing can ever be cached.'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unreadableOwnerMarkerProvider(): array
+    {
+        return [
+            'a non-numeric string' => ['not-a-customer'],
+            'an empty string' => [''],
+            'a boolean' => [true],
+            'an array' => [[7]],
+            'an object' => [new stdClass()],
+        ];
+    }
+
+    /**
+     * THE REGRESSION TEST for the LOQ-16978 review defect: a customer id that cannot be read
+     * is its OWN owner, and must never be recorded as the guest.
+     *
+     * THE BUG. resolveOwnerId() used to answer `is_numeric($id) ? (int)$id : GUEST_OWNER_ID`,
+     * so "the session answered a customer id we cannot understand" and "nobody is logged in"
+     * produced the SAME owner, 0. Two genuinely different identities therefore compared equal
+     * and no flush fired between them. The logout direction is the damaging one: a shopper
+     * whose id could not be read earns bypasses in all three stores, logs out, and the guest
+     * at the browser next inherits every one of them - precisely the shared-browser hand-off
+     * this class exists to stop. The login direction is the same defect seen from the other
+     * side.
+     *
+     * WHY BOTH ORDERINGS. They fail for different reasons and neither implies the other: a
+     * fix applied to only one side of the comparison - or a sentinel that happened to equal
+     * the guest id in one direction only - passes one and fails the other. Under the old
+     * logic BOTH of these cases see owner 0 on both requests and flush nothing, so both fail.
+     *
+     * The owner assertion is the load-bearing half. A guard that flushed on some unrelated
+     * grounds would satisfy the flush assertions while leaving the two identities recorded
+     * identically, so the NEXT transition out of the unreadable state would still be missed.
+     *
+     * @param int|string|null $before Identity that wrote the stores.
+     * @param int|string|null $after Identity making the next request.
+     * @param string $expectedOwner 'guest' or 'unreadable' - resolved from the production
+     *                              constants, because the point is which SENTINEL is
+     *                              recorded, not which literal integer it happens to be.
+     */
+    #[DataProvider('unreadableIdentityChangeProvider')]
+    public function testACustomerIdThatCannotBeReadIsItsOwnOwnerAndNeverTheGuest(
+        $before,
+        $after,
+        string $expectedOwner
+    ): void {
+        $harness = $this->createGuard($this->seededStores(), $before);
+
+        // First request: whatever $before is, it adopts the stores and is recorded.
+        $harness['guard']->getData(self::CAPTURED_ADDRESSES_SESSION_KEY);
+        $this->assertSame(
+            $this->seededStores(),
+            $this->managedAttributes($harness),
+            'The stores must survive the first request, or the flush asserted below could be the adoption '
+            . 'branch rather than the identity change.'
+        );
+
+        // ...and then the identity changes between an unreadable id and a guest.
+        $harness['identity']['customerId'] = $after;
+        $read = $harness['guard']->getData(self::CAPTURED_ADDRESSES_SESSION_KEY);
+
+        $this->assertNull(
+            $read,
+            'The access that detects the change must already answer with the flushed value: a store cleared '
+            . 'only on the NEXT request still grants THIS request its bypass.'
+        );
+        foreach ($this->managedKeys() as $key) {
+            $this->assertNull(
+                $harness['session'][$key] ?? null,
+                sprintf(
+                    'Session attribute "%s" survived the move between a guest and a customer whose id could '
+                    . 'not be read. Those are two different identities, so all three bypass stores must be '
+                    . 'flushed; folding the unreadable id onto the guest id makes them compare equal and hands '
+                    . 'one shopper\'s bypasses to the next person at the browser.',
+                    $key
+                )
+            );
+        }
+        $this->assertSame(
+            $this->ownerConstant($expectedOwner === 'guest' ? 'GUEST_OWNER_ID' : 'UNREADABLE_OWNER_ID'),
+            $harness['session'][$this->ownerKey()] ?? null,
+            'An unreadable customer id must be recorded under its own sentinel, never under the guest id. '
+            . 'Recording both as the guest is what made the two states indistinguishable in the first place, '
+            . 'so a test that only checked the flush would pass again the moment the sentinel was removed.'
+        );
+    }
+
+    /**
+     * Both directions between a guest and a customer whose id cannot be read.
+     *
+     * 'not-a-customer' stands for anything getCustomerId() can answer that is neither null
+     * nor numeric. It cannot arrive through Magento's own API - the id is an int, a numeric
+     * string or null - so reaching it needs another module writing to the customer session's
+     * 'customer_id'. That is exactly why it must not be answered by guessing "guest": an
+     * identity this class cannot read is one it must not claim to recognise.
+     *
+     * @return array<string, array{0: int|string|null, 1: int|string|null, 2: string}>
+     */
+    public static function unreadableIdentityChangeProvider(): array
+    {
+        return [
+            'a customer whose id cannot be read logs out' => ['not-a-customer', null, 'guest'],
+            'a guest acquires a customer id that cannot be read' => [null, 'not-a-customer', 'unreadable'],
+        ];
+    }
+
+    /**
+     * The three owner classes have to stay DISJOINT, which is the property the sentinel's
+     * value is chosen for rather than an incidental fact about it.
+     *
+     * Customer ids are positive auto-increment values, the guest is 0, so the unreadable
+     * sentinel has to be negative. Asserted structurally because the behavioural test above
+     * can only see the two identities it drives: a sentinel changed to 0 fails that test, but
+     * one changed to a positive number would pass it while silently colliding with a real
+     * customer id - handing shopper #1's bypasses to any session with an unreadable id.
+     */
+    public function testTheUnreadableOwnerSentinelCannotCollideWithAGuestOrACustomer(): void
+    {
+        $guest = $this->ownerConstant('GUEST_OWNER_ID');
+        $unreadable = $this->ownerConstant('UNREADABLE_OWNER_ID');
+
+        $this->assertSame(
+            0,
+            $guest,
+            'The guest owner must be 0: customer ids are positive auto-increment values, so 0 is the one '
+            . 'value that can stand for "not logged in" without ever colliding with one.'
+        );
+        $this->assertNotSame(
+            $guest,
+            $unreadable,
+            'The unreadable-id sentinel must not equal the guest id. That collision IS the defect: it made a '
+            . 'logout out of an unreadable identity look like no change at all, so the stores were not '
+            . 'flushed and the guest inherited all three bypasses.'
+        );
+        $this->assertLessThan(
+            0,
+            $unreadable,
+            'The unreadable-id sentinel must be negative. Customer ids are positive and the guest is 0, so '
+            . 'only a negative value is guaranteed not to collide with either; a positive sentinel would '
+            . 'share an owner with a real customer account.'
+        );
+    }
+
+    /**
+     * The ENROLMENT assertion, in the direction that rejects: an attribute that is not in
+     * SHOPPER_SCOPED_SESSION_KEYS may not be reached through this class at all - not for
+     * reading and not for writing.
+     *
+     * WHY THIS IS WORTH A TEST. Reading a new attribute through the guard LOOKS protected -
+     * the call site is identical to the three that are - while the attribute is never
+     * actually flushed, which silently keeps the defect LOQ-16978 exists to close. The throw
+     * is what makes "reachable through this class" and "flushed by this class" the same set;
+     * without it they drift apart at the first new call site and every test in this file
+     * stays green.
+     *
+     * Both directions are asserted because only setData() is enrolled-checked by the writer
+     * and only getData() by the reader: a check added to one and forgotten on the other
+     * leaves half the hole open.
+     *
+     * The "nothing was written" assertion pins the ORDERING inside the guard. assertEnrolled()
+     * runs BEFORE enforceOwnership(), so a rejected call must not have written the owner
+     * marker either - a rejected access must leave the session exactly as it found it.
+     *
+     * @param string $key Attribute that is not enrolled in the flush.
+     */
+    #[DataProvider('unenrolledSessionKeyProvider')]
+    public function testAnUnenrolledAttributeIsRejectedByBothGetDataAndSetData(string $key): void
+    {
+        $calls = [
+            'getData()' => static fn (ShopperScopedSession $guard) => $guard->getData($key),
+            'setData()' => static fn (ShopperScopedSession $guard) => $guard->setData($key, 'a new value'),
+        ];
+
+        foreach ($calls as $label => $call) {
+            $harness = $this->createGuard([$key => 'pre-existing'], 7);
+
+            $thrown = null;
+            try {
+                $call($harness['guard']);
+            } catch (\InvalidArgumentException $e) {
+                $thrown = $e;
+            }
+
+            $this->assertInstanceOf(
+                \InvalidArgumentException::class,
+                $thrown,
+                sprintf(
+                    '%s must refuse the unenrolled attribute "%s". Letting it through gives that attribute '
+                    . 'the guard\'s appearance without its protection: the ownership check runs, but the '
+                    . 'attribute is never in the flush, so it is inherited by the next shopper anyway.',
+                    $label,
+                    $key
+                )
+            );
+            $this->assertStringContainsString(
+                $key,
+                $thrown->getMessage(),
+                'The message must name the offending attribute, or the developer who trips this has to go '
+                . 'looking for which call site it was.'
+            );
+            $this->assertStringContainsString(
+                'SHOPPER_SCOPED_SESSION_KEYS',
+                $thrown->getMessage(),
+                'The message must name the fix - the list to add the attribute to - because this throw is '
+                . 'only ever reached by a programming error, and the message is the instruction.'
+            );
+            $this->assertSame(
+                'pre-existing',
+                $harness['session'][$key] ?? null,
+                sprintf('A refused %s must leave the attribute itself untouched.', $label)
+            );
+            $this->assertSame(
+                [],
+                iterator_to_array($harness['writes']),
+                sprintf(
+                    'A refused %s must write NOTHING at all, not even the owner marker: the enrolment check '
+                    . 'runs before the ownership check precisely so a rejected access leaves the session '
+                    . 'exactly as it found it.',
+                    $label
+                )
+            );
+        }
+    }
+
+    /**
+     * Attributes that must NOT be reachable through the guard.
+     *
+     * The first four are the module's real un-enrolled session attributes, named in the
+     * ShopperScopedSession class docblock as deliberately out of scope for LOQ-16978. They
+     * are the ones a future edit is most likely to route through this class by analogy, which
+     * is exactly the mistake the throw exists to catch: they would gain the guard's
+     * appearance without ever being added to the flush.
+     *
+     * The owner marker is included because it is the one attribute this class writes itself
+     * and must never expose - flushing it would erase the identity just recorded - and the
+     * last two cover a near-miss typo and the empty key.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function unenrolledSessionKeyProvider(): array
+    {
+        return [
+            // Plugin\AbstractPlugin::shouldVerify() - unbounded lists of verified emails and
+            // phone numbers, bypasses of the same kind but out of scope for this ticket.
+            'the email bypass list' => ['loqate_email'],
+            'the phone bypass list' => ['loqate_phone'],
+            // Plugin\Frontend\AccountManagement / CheckoutShippingInformation.
+            'the pending email address' => ['loqate_email_to_validate'],
+            // Plugin\Frontend\CheckoutBillingAddress, read by PlaceOrder/PlaceOrderGuest.
+            'the billing error gate' => ['loqate_billing_errors'],
+            'the ownership marker itself' => [self::readOwnerKey()],
+            'a near miss of an enrolled name' => ['captured_address'],
+            'the empty key' => [''],
+        ];
+    }
+
+    /**
+     * The mirror of the rejection, and the half that stops the assertion being tightened into
+     * a wall: every attribute that IS enrolled must go through untouched, in both directions.
+     *
+     * Driven from the production flush list, so a fourth store added to it is exercised here
+     * automatically - and a store added to the list but somehow unreachable through the guard
+     * is reported as a failure rather than as silence.
+     *
+     * @param string $key A managed session key.
+     */
+    #[DataProvider('managedStoreProvider')]
+    public function testEveryEnrolledAttributeIsAcceptedByBothGetDataAndSetData(string $key): void
+    {
+        $harness = $this->createGuard([$key => 'already here'], 7);
+
+        $this->assertSame(
+            'already here',
+            $harness['guard']->getData($key),
+            sprintf('"%s" is in the flush list, so reading it through the guard must be allowed.', $key)
+        );
+
+        $harness['guard']->setData($key, 'written through the guard');
+
+        $this->assertSame(
+            'written through the guard',
+            $harness['session'][$key] ?? null,
+            sprintf('"%s" is in the flush list, so writing it through the guard must be allowed.', $key)
+        );
+    }
+
+    /**
+     * End to end on the Capture bypass, which is the oldest and widest of the three stores:
+     * an address shopper A picked from the Loqate lookup must not let shopper B check the
+     * same address out unverified.
+     *
+     * Asserted through Validator::verifyAddress() rather than on the attribute, because that
+     * is where the bypass is actually granted: this fails if the store is reached anywhere
+     * without the guard, however correct the guard itself is.
+     */
+    public function testACapturedAddressBypassDoesNotSurviveALogin(): void
+    {
+        $shopper = $this->createShopper([
+            self::CAPTURED_ADDRESSES_SESSION_KEY => [json_encode([
+                'Address1' => '1 High St',
+                'Address2' => 'Flat 2',
+                'Country' => 'GB',
+                'PostalCode' => 'SW1A 1AA',
+                'Address3' => 'London',
+                'Address4' => 'Greater London',
+            ])],
+        ]);
+
+        // The guest who captured it gets the bypass.
+        $asGuest = $shopper['validator']->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(['error' => false], $asGuest);
+        $this->assertSame(
+            0,
+            $this->apiCallCount($shopper),
+            'The shopper who captured the address must skip the billable verify: that is what the store is '
+            . 'for, and this test would prove nothing if it did not hold first.'
+        );
+
+        // Somebody signs in on the same browser.
+        $shopper['identity']['customerId'] = 7;
+        $asCustomer = $shopper['validator']->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'A shopper who logs in must NOT inherit the previous user\'s captured-address bypass: the address '
+            . 'has to be verified against Loqate for them, or an address nobody verified for this account '
+            . 'reaches checkout unchecked.'
+        );
+        $this->assertSame(['error' => false], $asCustomer, 'The fresh verification stands on its own verdict.');
+    }
+
+    /**
+     * The same guarantee for the verdict cache (LOQ-16969), which unlike the captured-address
+     * store also covers TYPED addresses - so it is the store most likely to hold an entry for
+     * whatever the next person at the browser types.
+     */
+    public function testACachedVerdictDoesNotSurviveALogin(): void
+    {
+        $shopper = $this->createShopper();
+
+        $shopper['validator']->verifyAddress(self::ADDRESS);
+        $shopper['validator']->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'The cache must work for the shopper who earned the verdict, or the flush below would be '
+            . 'indistinguishable from a cache that never hits.'
+        );
+
+        $shopper['identity']['customerId'] = 7;
+        $shopper['validator']->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'A shopper who logs in must not be served a verdict cached for whoever used the browser before '
+            . 'them: the address must be verified again for the new identity.'
+        );
+
+        // ...and the new shopper's own cache works normally from here on, which is what rules
+        // out a guard that simply flushes on every request.
+        $shopper['validator']->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'Once the new shopper is recorded as the owner, their own verdicts must be cached as usual - a '
+            . 'guard that kept flushing would re-bill every call path of every checkout.'
+        );
+    }
+
+    /**
+     * The third store, driven end to end through the method that actually reads and writes
+     * it: a BATCH verdict (LOQ-16976) must not be replayed for a different shopper.
+     *
+     * The batch cache was previously covered only at the guard level - "the attribute named
+     * BATCH_VERIFY_CACHE_SESSION_KEY is in the flush list and is set to null" - which proves
+     * the list, not the wiring. verifyMultipleAddresses() reaches the attribute through its
+     * own key builder (buildBatchVerifySignature(), county INCLUDED) and its own accessors
+     * (getCachedBatchVerifyResult()/storeBatchVerifyResult()), none of which the single-address
+     * tests exercise; either of those reading the raw session would leave this store shared
+     * with every other test in this file green.
+     *
+     * The cache-hit assertion before the identity change is what makes the third assertion
+     * mean anything: without it, "billed again after the login" is indistinguishable from a
+     * cache that never hits at all.
+     *
+     * NOTE the ACCEPTED LIMIT this does NOT contradict, pinned separately in
+     * testOnTheAdminhtmlPathTheBatchCacheIsOwnedByTheGuestAndTheFlushIsANoOp(): the guard
+     * machinery below works, but in production this store is only ever written from
+     * adminhtml, where there is no customer identity to change.
+     */
+    public function testABatchVerdictDoesNotSurviveALogin(): void
+    {
+        $shopper = $this->createShopper();
+        $batch = [0 => self::ADDRESS];
+
+        $first = $shopper['validator']->verifyMultipleAddresses($batch);
+
+        $this->assertSame(
+            [0 => true],
+            $first,
+            'The address must pass on its own AQI first, or this test is measuring a rejection rather than a '
+            . 'cached verdict.'
+        );
+        $this->assertSame(1, $this->apiCallCount($shopper), 'The first batch must be billed.');
+
+        $shopper['validator']->verifyMultipleAddresses($batch);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'The batch verdict must be cached for the shopper who earned it, or the flush asserted below is '
+            . 'indistinguishable from a cache that never hits.'
+        );
+
+        $shopper['identity']['customerId'] = 7;
+        $afterLogin = $shopper['validator']->verifyMultipleAddresses($batch);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'A shopper who logs in must not be handed a BATCH verdict cached for whoever used the browser '
+            . 'before them: like the other two stores, this one is a licence to skip a billable verify, and '
+            . 'it must be re-earned by the new identity.'
+        );
+        $this->assertSame([0 => true], $afterLogin, 'The fresh batch stands on its own verdict.');
+
+        $shopper['validator']->verifyMultipleAddresses($batch);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'Once the new shopper owns the stores their own batch verdicts must cache as usual - a guard that '
+            . 'kept flushing would re-bill every admin order re-submission LOQ-16976 exists to de-duplicate.'
+        );
+    }
+
+    /**
+     * THE ACCEPTED LIMIT, pinned as documented behaviour rather than left implicit: on the
+     * only path that writes the batch cache in production, the flush is a NO-OP.
+     *
+     * Both writers of Validator::BATCH_VERIFY_CACHE_SESSION_KEY are adminhtml plugins -
+     * Plugin\Admin\OrderSave and Plugin\Admin\ValidateImportAddress - and there the customer
+     * session normally holds no customer id at all. So the owner recorded for that store is
+     * permanently the guest, and an ADMIN USER swap inside one browser session changes
+     * nothing the guard can see.
+     *
+     * WHAT THE CONSEQUENCE ACTUALLY IS: BILLING, NOT EXPOSURE. It is worth being precise,
+     * because "one admin is served another admin's verdict" reads like a data leak and is not
+     * one. The batch cache key already namespaces every entry by store view and by the
+     * configured AQI threshold, and storeBatchVerifyResult() stores PASSES ONLY - so the
+     * verdict the second admin is handed is the SAME verdict their own submission would have
+     * earned, for the same address, under the same configuration. Nothing about the first
+     * admin's data is disclosed by it: the second admin had to submit that address themselves
+     * to reach the entry at all. What is genuinely shared is the BILLABLE CALL - the second
+     * submission does not pay for a Cleansing request, so the one call is attributed to
+     * whichever admin submitted first.
+     *
+     * THIS IS NOT A FAILING TEST AND IT IS NOT A WORKAROUND. It is the documented limit on
+     * ShopperScopedSession, asserted so it cannot change in either direction unnoticed - if
+     * someone injects the backend auth session and closes it, this test fails and says so; if
+     * someone assumes it is already closed, this test is the counter-example. It is
+     * deliberately accepted upstream: the admin panel is a trusted, authenticated, non-shared
+     * surface, the shared verdict is one the second admin would have earned anyway, and
+     * injecting Magento\Backend\Model\Auth\Session would drag a backend dependency into a
+     * helper constructed on every frontend checkout request. The SHOPPER-facing risk the
+     * ticket exists to close - where the two identities are strangers and the shared bypass
+     * decides whether an address is checked at all - is fully covered by the tests above.
+     */
+    public function testOnTheAdminhtmlPathTheBatchCacheIsOwnedByTheGuestAndTheFlushIsANoOp(): void
+    {
+        // Exactly the adminhtml situation: a customer session with no customer id, for the
+        // whole of the session, whichever admin user is driving it.
+        $shopper = $this->createShopper();
+        $batch = [0 => self::ADDRESS];
+
+        $shopper['validator']->verifyMultipleAddresses($batch);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'The first admin submission must be billed.'
+        );
+        $this->assertNotSame(
+            [],
+            $shopper['session'][self::BATCH_VERIFY_CACHE_SESSION_KEY] ?? [],
+            'The passing verdict must actually have been cached, or the limitation below would be nothing '
+            . 'more than an empty store.'
+        );
+        $this->assertSame(
+            $this->ownerConstant('GUEST_OWNER_ID'),
+            $shopper['session'][$this->ownerKey()] ?? null,
+            'On the adminhtml path the customer session carries no customer id, so the batch cache is owned '
+            . 'by the GUEST. This is the documented ACCEPTED LIMIT on ShopperScopedSession: the guard scopes '
+            . 'by customer identity only, and there is no customer identity here to scope by.'
+        );
+
+        // A different admin user now drives the same browser session. Nothing about the
+        // customer session changes, because the admin identity lives in a different session
+        // object (Magento\Backend\Model\Auth\Session) that this guard deliberately does not
+        // read - so there is nothing for it to detect.
+        $shopper['validator']->verifyMultipleAddresses($batch);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'DOCUMENTED LIMIT, asserted so it cannot drift: an admin-user swap inside one browser session '
+            . 'does NOT flush the batch verdict cache, because the guard tracks the CUSTOMER id and adminhtml '
+            . 'has none, so the second admin\'s identical submission replays the cached PASS instead of being '
+            . 'billed. The consequence is BILLING ATTRIBUTION, not exposure - the entry is namespaced by store '
+            . 'view and AQI threshold and only passes are stored, so it is the same verdict the second admin '
+            . 'would have earned. Accepted upstream (the admin panel is trusted, authenticated and not '
+            . 'shared); if this assertion ever fails because the backend auth session was injected, that is an '
+            . 'improvement - update this test and the ACCEPTED LIMITS note on ShopperScopedSession together.'
+        );
+
+        // The structural half of the same limit, and the reason the behavioural half above
+        // cannot say more than it does: there is no admin identity in this class to change.
+        $harness = $this->createGuard();
+        $identitySources = array_filter(
+            $this->propertyValues($harness['guard']),
+            fn ($value): bool => $this->isSessionCollaborator($value)
+        );
+
+        $this->assertCount(
+            1,
+            $identitySources,
+            sprintf(
+                'ShopperScopedSession must read exactly ONE identity source. Holding a %s alongside the '
+                . 'customer session would mean the admin-swap limit asserted above has been closed, which is '
+                . 'an improvement but makes the assertion above wrong: change both together, and the ACCEPTED '
+                . 'LIMITS note on ShopperScopedSession with them. Note that this counts SESSIONS only - the '
+                . 'guard is free to acquire other collaborators (a logger is the standing candidate, named on '
+                . 'assertEnrolled()) without touching what it can see about identity. Found: %s.',
+                self::BACKEND_AUTH_SESSION,
+                $this->describeCollaborators($harness['guard'])
+            )
+        );
+        $this->assertInstanceOf(
+            Session::class,
+            reset($identitySources),
+            sprintf(
+                'The one session collaborator must be the CUSTOMER session, not %s: the customer identity is '
+                . 'the whole of what this guard can scope by, and swapping which session it reads would '
+                . 'silently change which identity change flushes the stores.',
+                self::BACKEND_AUTH_SESSION
+            )
+        );
+    }
+
+    /**
+     * Is this collaborator one of the two SESSION objects an identity could be read from?
+     *
+     * Narrower than "is an object" on purpose (LOQ-16978 review). The property being counted
+     * is "how many identities can this guard see", and counting every object answered a
+     * different question: a Logger - which assertEnrolled()'s own docblock names as the
+     * standing alternative to the throw, and which would therefore be a perfectly ordinary
+     * thing to add - would have failed a test whose message talks about session collaborators
+     * and admin-user swaps, sending the next reader to look for a hole that is not there.
+     *
+     * Matched with is_a() against the class-name STRING rather than with `instanceof`, because
+     * Magento\Backend\Model\Auth\Session need not be autoloadable in this harness (only a
+     * handful of Magento classes are stubbed under Test/stubs). is_a() on an object never
+     * triggers an autoload failure and simply answers false when the named class does not
+     * exist - and, unlike comparing get_class(), it still recognises a subclass or a PHPUnit
+     * mock of it, which is what a test double for it would be.
+     *
+     * @param mixed $value A property value held by the guard.
+     */
+    private function isSessionCollaborator($value): bool
+    {
+        return is_a($value, Session::class) || is_a($value, self::BACKEND_AUTH_SESSION);
+    }
+
+    /**
+     * The guard's object-valued properties rendered as "name: Class", for a failure message
+     * that says WHAT was found rather than only how many.
+     *
+     * Reports every object, not just the sessions, so that a count failure is readable
+     * whichever collaborator caused it.
+     *
+     * @param object $guard
+     */
+    private function describeCollaborators(object $guard): string
+    {
+        $described = [];
+        foreach ($this->propertyValues($guard) as $name => $value) {
+            if (is_object($value)) {
+                // A PHPUnit double's own class name is generated noise; the class it stands in
+                // for is what the reader needs.
+                $class = $value instanceof MockObject ? (get_parent_class($value) ?: get_class($value))
+                    : get_class($value);
+                $described[] = sprintf('$%s: %s', $name, $class);
+            }
+        }
+
+        return $described === [] ? '(no object-valued properties at all)' : implode(', ', $described);
+    }
+
+    /**
+     * The structural half of the same property, and the one that stops the whole scheme being
+     * quietly bypassed: neither helper may keep a reference to the raw customer session.
+     *
+     * Both are handed a Magento\Customer\Model\Session by DI and wrap it in a
+     * ShopperScopedSession. If either also retained the raw object, a future edit could read
+     * or write any of the three attributes directly - no flush, no marker, and every
+     * behavioural test in this file still green, because they only exercise the paths that DO
+     * go through the guard.
+     */
+    public function testNeitherHelperKeepsAReferenceToTheRawCustomerSession(): void
+    {
+        foreach ($this->helpersHoldingShopperScopedStores() as $label => $helper) {
+            $held = $this->propertyValues($helper);
+
+            foreach ($held as $name => $value) {
+                $this->assertNotInstanceOf(
+                    Session::class,
+                    $value,
+                    sprintf(
+                        '%s::$%s holds the raw customer session. The captured-address store and both verdict '
+                        . 'caches must be reachable only through ShopperScopedSession, or one direct '
+                        . 'getData() re-opens LOQ-16978 with the whole suite green.',
+                        $label,
+                        $name
+                    )
+                );
+            }
+
+            $guards = array_filter($held, static fn ($value): bool => $value instanceof ShopperScopedSession);
+            $this->assertCount(
+                1,
+                $guards,
+                sprintf('%s must hold exactly one ShopperScopedSession to reach its session stores.', $label)
+            );
+        }
+    }
+
+    /**
+     * One constructed instance of each class that reaches a shopper-scoped store, keyed by a
+     * readable label for the failure message.
+     *
+     * @return array<string, object>
+     */
+    private function helpersHoldingShopperScopedStores(): array
+    {
+        $sessionMock = $this->createSessionDouble(new ArrayObject(), new ArrayObject(['customerId' => null]));
+        $moduleList = $this->createMock(ModuleListInterface::class);
+        $moduleList->method('getOne')->willReturn(['setup_version' => '9.9.9']);
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturn(self::API_KEY);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $logger = $this->createMock(Logger::class);
+
+        return [
+            'Helper\Controller' => new Controller(
+                $this->createMock(ResultFactory::class),
+                $this->createMock(RequestInterface::class),
+                $logger,
+                $sessionMock,
+                $moduleList,
+                $helper,
+                $serializer
+            ),
+            'Helper\Validator' => new Validator(
+                $logger,
+                $sessionMock,
+                $this->createMock(RegionFactory::class),
+                $moduleList,
+                $helper,
+                $serializer
+            ),
+        ];
+    }
+
+    /**
+     * Build a Validator over a session double whose logged-in identity can be changed
+     * mid-test, with its billable connector mock intercepted.
+     *
+     * @param array<string, mixed> $data Session attributes present before the first request.
+     * @return array{validator: Validator, session: ArrayObject, identity: ArrayObject,
+     *     requests: ArrayObject}
+     */
+    private function createShopper(array $data = []): array
+    {
+        $sessionStore = new ArrayObject($data);
+        $identity = new ArrayObject(['customerId' => null]);
+        $requests = new ArrayObject();
+
+        $moduleList = $this->createMock(ModuleListInterface::class);
+        $moduleList->method('getOne')->willReturn(['setup_version' => '9.9.9']);
+
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturnCallback(
+            static function ($configPath) {
+                switch ($configPath) {
+                    case 'loqate_settings/settings/api_key':
+                        // Required twice over: both constructors only build their connector
+                        // when it is set, and every verify method short-circuits with
+                        // noKeyFound when it is not.
+                        return self::API_KEY;
+                    case 'loqate_settings/address_settings/address_quality_index':
+                        // The BATCH path judges an address against this, not against the
+                        // AVC thresholds. Left at '' the comparison 'A' <= '' is a STRING
+                        // comparison and fails, so every batch address would be rejected and
+                        // nothing would ever be cached - the batch tests would then pass for
+                        // the wrong reason.
+                        return self::PASSING_AQI;
+                    default:
+                        // What an untouched admin field leaves behind - in particular
+                        // show_advanced_avc_settings != 1, so checkAVCStatus() uses the
+                        // baked-in default thresholds.
+                        return '';
+                }
+            }
+        );
+        $helper->method('getCurrentStore')->willReturn(0);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
+        $serializer->method('unserialize')->willReturnCallback(static fn ($value) => json_decode($value, true));
+
+        $validator = new Validator(
+            $this->createMock(Logger::class),
+            $this->createSessionDouble($sessionStore, $identity),
+            $this->createMock(RegionFactory::class),
+            $moduleList,
+            $helper,
+            $serializer
+        );
+
+        // The connector is built inside the constructor (new Verify($apiKey)), so the only
+        // way to intercept the billable call is to swap the private property afterwards.
+        $connector = $this->createMock(Verify::class);
+        // One response record per address sent, which is what verifyMultipleAddresses()'
+        // row-count guard requires; each record carries both an AVC (read by the
+        // single-address path) and an AQI (read by the batch path).
+        $connector->method('verifyAddress')->willReturnCallback(
+            static function ($params) use ($requests) {
+                $requests[] = $params;
+
+                return array_map(
+                    static fn () => [['AVC' => self::PASSING_AVC, 'AQI' => self::PASSING_AQI]],
+                    array_values((array)($params['Addresses'] ?? [[]]))
+                );
+            }
+        );
+        $apiConnector = new ReflectionProperty(Validator::class, 'apiConnector');
+        $apiConnector->setAccessible(true);
+        $apiConnector->setValue($validator, $connector);
+
+        return [
+            'validator' => $validator,
+            'session' => $sessionStore,
+            'identity' => $identity,
+            'requests' => $requests,
+        ];
+    }
+
+    /** Number of billable Loqate Cleansing requests issued so far. */
+    private function apiCallCount(array $shopper): int
+    {
+        return count($shopper['requests']);
+    }
+
+    /**
+     * One recognisable value per shopper-scoped store, so a flush that misses one is reported
+     * as which store survived rather than as a bare count.
+     *
+     * @return array<string, mixed>
+     */
+    private function seededStores(): array
+    {
+        return [
+            self::CAPTURED_ADDRESSES_SESSION_KEY => ['captured'],
+            self::VERIFY_CACHE_SESSION_KEY => ['cached' => 'verdict'],
+            self::BATCH_VERIFY_CACHE_SESSION_KEY => ['cached' => 'batch verdict'],
+        ];
+    }
+
+    /**
+     * The current value of each shopper-scoped store, in the fixed order seededStores() uses,
+     * so the two can be compared directly.
+     *
+     * @param array $harness Harness from createGuard().
+     * @return array<string, mixed>
+     */
+    private function managedAttributes(array $harness): array
+    {
+        $values = [];
+        foreach (array_keys($this->seededStores()) as $key) {
+            $values[$key] = $harness['session'][$key] ?? null;
+        }
+
+        return $values;
+    }
+
+    /**
+     * The production list of attributes the guard flushes together.
+     *
+     * @return string[]
+     */
+    private function managedKeys(): array
+    {
+        $keys = self::readManagedKeys();
+        if ($keys === []) {
+            $this->fail(
+                'ShopperScopedSession::SHOPPER_SCOPED_SESSION_KEYS is missing or empty: that list IS the '
+                . 'flush, so an empty one means no store is ever cleared when the shopper changes.'
+            );
+        }
+
+        return $keys;
+    }
+
+    /**
+     * managedKeys() for the static data providers, which cannot call assertions.
+     *
+     * @return string[]
+     */
+    private static function readManagedKeys(): array
+    {
+        $reflection = new ReflectionClass(ShopperScopedSession::class);
+        if (!$reflection->hasConstant('SHOPPER_SCOPED_SESSION_KEYS')) {
+            return [];
+        }
+
+        return array_values((array)$reflection->getConstant('SHOPPER_SCOPED_SESSION_KEYS'));
+    }
+
+    /**
+     * The session attribute the owning identity is recorded in, read from the production
+     * constant so these tests describe the real marker rather than a guess at it.
+     */
+    private function ownerKey(): string
+    {
+        $key = self::readOwnerKey();
+        if ($key === '') {
+            $this->fail(
+                'ShopperScopedSession::SESSION_OWNER_KEY is not defined: the identity the shopper-scoped '
+                . 'stores belong to has to be recorded somewhere, or no identity change can be detected.'
+            );
+        }
+
+        return $key;
+    }
+
+    /**
+     * ownerKey() for the static data providers, which cannot call assertions.
+     */
+    private static function readOwnerKey(): string
+    {
+        $reflection = new ReflectionClass(ShopperScopedSession::class);
+
+        return $reflection->hasConstant('SESSION_OWNER_KEY')
+            ? (string)$reflection->getConstant('SESSION_OWNER_KEY')
+            : '';
+    }
+
+    /**
+     * One of the reserved owner ids, read from the production constant.
+     *
+     * Read rather than hard-coded so these tests pin WHICH SENTINEL is recorded - the guest
+     * or the unreadable one - rather than which integer it currently happens to be; the
+     * integers themselves are pinned once, in
+     * testTheUnreadableOwnerSentinelCannotCollideWithAGuestOrACustomer(), where the disjointness
+     * they are chosen for is the actual subject.
+     *
+     * @param string $name 'GUEST_OWNER_ID' or 'UNREADABLE_OWNER_ID'.
+     */
+    private function ownerConstant(string $name): int
+    {
+        $reflection = new ReflectionClass(ShopperScopedSession::class);
+        if (!$reflection->hasConstant($name)) {
+            $this->fail(sprintf(
+                'ShopperScopedSession::%s is not defined. The guard needs three DISJOINT owner classes - a '
+                . 'positive customer id, the guest, and "the session answered an id we cannot read" - or two '
+                . 'different identities compare equal and the stores are not flushed between them.',
+                $name
+            ));
+        }
+
+        return (int)$reflection->getConstant($name);
+    }
+
+    /**
+     * Every property an object holds, including private and inherited ones, by name.
+     *
+     * @param object $object
+     * @return array<string, mixed>
+     */
+    private function propertyValues(object $object): array
+    {
+        $values = [];
+        for ($class = new ReflectionClass($object); $class !== false; $class = $class->getParentClass()) {
+            foreach ($class->getProperties() as $property) {
+                $property->setAccessible(true);
+                if (!array_key_exists($property->getName(), $values) && $property->isInitialized($object)) {
+                    $values[$property->getName()] = $property->getValue($object);
+                }
+            }
+        }
+
+        return $values;
+    }
+}

--- a/Test/Unit/Helper/ShopperScopedSessionTest.php
+++ b/Test/Unit/Helper/ShopperScopedSessionTest.php
@@ -1090,7 +1090,7 @@ class ShopperScopedSessionTest extends TestCase
      * The batch cache was previously covered only at the guard level - "the attribute named
      * BATCH_VERIFY_CACHE_SESSION_KEY is in the flush list and is set to null" - which proves
      * the list, not the wiring. verifyMultipleAddresses() reaches the attribute through its
-     * own key builder (buildBatchVerifySignature(), county INCLUDED) and its own accessors
+     * own cache key (namespaced by the resolved AQI threshold) and its own accessors
      * (getCachedBatchVerifyResult()/storeBatchVerifyResult()), none of which the single-address
      * tests exercise; either of those reading the raw session would leave this store shared
      * with every other test in this file green.

--- a/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
@@ -1,0 +1,2480 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Helper;
+
+use Loqate\ApiConnector\Client\Verify;
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Logger\Logger;
+use Magento\Customer\Model\Session;
+use Magento\Directory\Model\RegionFactory;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use ArrayObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * Unit tests for the BATCH verify path: Validator::verifyMultipleAddresses().
+ *
+ * Two tickets meet in this one method, and both are covered here because neither can be
+ * asserted without the other:
+ *
+ * LOQ-16977 - INDEX MAPPING. The method must return one verdict per input address, under
+ * the input's OWN KEY and in the input's OWN ORDER. Both halves were broken. The keys were
+ * recovered afterwards with array_search(false, $addressesToCheck) over an array whose
+ * values were all truthy, so the search always returned false, which coerces to the array
+ * key 0: every response row overwrote $result[0], the captured addresses' own verdicts were
+ * never merged in at all, and a mixed batch came back as a single entry. That matters to
+ * two callers - Plugin\Admin\OrderSave.php:51-57 reports the key to the admin
+ * ("The provided address is invalid: #billing_address"), and
+ * Plugin\Admin\ValidateImportAddress.php:94 array_merge()s the per-chunk arrays and derives
+ * the import row number from the merged $index + 1. The ORDER half is what the import
+ * depends on: array_merge() renumbers integer keys BY INSERTION ORDER, not by key value, so
+ * a chunk returned as [1, 3, 0, 2, 4] - precisely what filling cache hits during the first
+ * pass and API verdicts afterwards produces - silently mis-attributes EVERY reported row
+ * number. The result array is therefore pre-seeded with one slot per address before any
+ * verdict is filled in; see testCacheHitsAndMissesStillReturnRowsInAscendingInputOrder().
+ *
+ * LOQ-16976 - BILLING. The Cleansing API is billable PER ADDRESS, not per request, so the
+ * verdict cache is consulted per address BEFORE the address is added to the payload: only
+ * misses are sent, and the tests here count "addresses billed" as
+ * count($payload['Addresses']) summed over every invocation, not merely the number of
+ * requests. Its design deliberately differs from verifyAddress()' cache in three ways, each
+ * pinned below:
+ *  - a PHYSICALLY SEPARATE session attribute (BATCH_VERIFY_CACHE_SESSION_KEY) with a
+ *    different stored shape ({"valid":true} versus {"error":false}), because these verdicts
+ *    come from the address quality index (checkQualityIndex()) and the other cache's from
+ *    the AVC thresholds - one must never answer the other's lookup, see
+ *    testTheTwoVerdictCachesAreInvisibleToEachOtherInBothDirections();
+ *  - only PASSING verdicts are stored, see testAFailingVerdictIsNeverCached();
+ *  - a single STRICT key with the county INCLUDED, not the asymmetric strict/lossy pair,
+ *    which is safe precisely because no failure is ever cached, see
+ *    testChangingOnlyTheCountyCostsASecondBillableAddressOnTheBatchPathOnly().
+ * Entries are namespaced per store view and per resolved AQI threshold - NOT per resolved
+ * AVC comparer string - see testChangingTheQualityIndexThresholdInvalidatesCachedVerdicts()
+ * and testEditingTheAvcThresholdsInvalidatesNoBatchVerdict().
+ *
+ * POSITIONAL ATTRIBUTION is the precondition both tickets rest on, and it is the third thing
+ * pinned here, because the connector makes it unverifiable per row:
+ * Verify::verifyAddress() (vendor/lqt/api-connector/src/Client/Verify.php:50-52) ends in
+ * array_column($response, 'Matches'), which SILENTLY DROPS every record with no 'Matches' key
+ * and REINDEXES the survivors into a clean 0..N-1 list. A three-address batch whose middle
+ * record came back as an error envelope therefore arrives as a TWO-element list in which
+ * position 1 holds ADDRESS 3's verdict, indistinguishable from a truncated response. So the
+ * row count is checked BEFORE any verdict is read or cached, and a mismatch fails the whole
+ * batch with a log line rather than mis-numbering it:
+ *  - the mid-list gap, and the wrong PASS that must never reach the cache, see
+ *    testAMidListGapIsRejectedAndCachesNoVerdictAgainstTheWrongAddress();
+ *  - the whole-response faults array_column() flattens to the same empty list, which used to
+ *    produce zero verdicts, zero log lines and a fully unverified import, see
+ *    testAnUnattributableWholeResponseIsRejectedWithADiagnostic();
+ *  - and the accepted cost, a truncated response failing an import that could have been
+ *    partly reported, see testATruncatedResponseIsRejectedRatherThanReportingTheRowsItHolds().
+ *
+ * READABLE VERDICTS is the fourth property pinned here, on the AQI side of the same method.
+ * checkQualityIndex() (Helper/Validator.php:841-843) FAILS CLOSED on an AQI it cannot read,
+ * mirroring verifyAddress()'s AVC guard (Helper/Validator.php:377). Under PHP 8's <= rules null,
+ * '', false and 0 all compare as BETTER than any letter threshold, so an unreadable AQI used to
+ * be answered VALID - including Loqate's own "no match for this address" ("Matches":[]), which
+ * the row-count guard above cannot see, because array_column() preserves the row count for it.
+ * Three tests hold this line, and the third is as load-bearing as the first two:
+ *  - a row with no readable AQI in it at all, in every shape that survives the connector, see
+ *    testARowWithNoReadableQualityIndexFailsClosedAndIsNeverCached();
+ *  - an AQI that is PRESENT but unreadable ('', false, 0), see
+ *    testAPresentButUnreadableQualityIndexFailsClosedAndIsNeverCached();
+ *  - the OVER-REJECTION guard: a legitimate grade must still PASS and still be CACHED, so
+ *    "fail closed" can never be widened into "reject everything" with the suite still green, see
+ *    testALegitimateQualityIndexStillPassesAndIsStillCached().
+ *
+ * Each shopper gets its own session double AND its own connector mock (see createShopper()),
+ * so a store moved into a static property, Registry or CacheInterface shows up as a missing
+ * billable call on the second shopper's own connector.
+ */
+class ValidatorBatchVerifyCacheTest extends TestCase
+{
+    /** Any non-empty key makes the batch path reach the billable call. */
+    private const API_KEY = 'TEST-API-KEY-0000';
+
+    /**
+     * Configured address quality index threshold. checkQualityIndex() compares the
+     * response's AQI against it with <=, as plain strings, so 'A' and 'B' pass a 'C'
+     * threshold and 'E' does not.
+     */
+    private const AQI_THRESHOLD = 'C';
+
+    /** AQI better than self::AQI_THRESHOLD => the address passes. */
+    private const PASSING_AQI = 'A';
+
+    /** AQI poorer than self::AQI_THRESHOLD => the address fails. */
+    private const FAILING_AQI = 'E';
+
+    /**
+     * AVC strictly better than the baked-in default threshold "P40-U00-P0-95", so
+     * verifyAddress() accepts. Only the cross-cache tests need it: the batch path reads
+     * the AQI and ignores the AVC entirely.
+     */
+    private const PASSING_AVC = 'V55-I22-P9-99';
+
+    /** Session data key the SINGLE-address verdict cache must live under. */
+    private const VERIFY_CACHE_SESSION_KEY = 'loqate_verified_addresses';
+
+    /** Session data key the BATCH verdict cache must live under. */
+    private const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
+
+    /** Config path of the threshold batch verdicts are judged against. */
+    private const AQI_CONFIG_PATH = 'loqate_settings/address_settings/address_quality_index';
+
+    /** A Magento-shaped address as it arrives from admin order create or an import row. */
+    private const ADDRESS = [
+        'street' => ['1 High St', 'Flat 2'],
+        'city' => 'London',
+        'region' => 'Greater London',
+        'postcode' => 'SW1A 1AA',
+        'country_id' => 'GB',
+    ];
+
+    /** @var Validator The Validator under test (the "primary" admin/import session). */
+    private $validator;
+
+    /** @var Verify|MockObject The billable API client of the primary session. */
+    private $apiConnector;
+
+    /** @var ArrayObject Payloads of every primary apiConnector->verifyAddress() call, in order. */
+    private $apiRequests;
+
+    /** @var ArrayObject Backing store for the primary customer session, so data actually persists. */
+    private $sessionStore;
+
+    /** @var array The primary harness, as returned by createShopper(). */
+    private $shopper;
+
+    /**
+     * What the API answers per address, keyed by the address's first street line:
+     * 'pass' (AQI better than the threshold), 'fail' (poorer), one of the
+     * self::UNREADABLE_ROW_SHAPES tokens (a row with no readable AQI in it at all), or one of
+     * the self::UNREADABLE_AQI_VALUES tokens (a row whose AQI is PRESENT but unreadable).
+     * Anything absent from this map answers 'pass'.
+     *
+     * Shared by every shopper, because it models the API's opinion of an address, which
+     * is not per session.
+     *
+     * @var array<string, string>
+     */
+    private $apiVerdicts = [];
+
+    /**
+     * When set, EVERY connector call returns the transport-failure envelope with this
+     * message instead of verdicts, which is what makes verifyMultipleAddresses() return
+     * false.
+     *
+     * @var string|null
+     */
+    private $apiFailureMessage = null;
+
+    protected function setUp(): void
+    {
+        $this->apiVerdicts = [];
+        $this->apiFailureMessage = null;
+
+        $this->shopper = $this->createShopper();
+        $this->validator = $this->shopper['validator'];
+        $this->apiConnector = $this->shopper['connector'];
+        $this->apiRequests = $this->shopper['requests'];
+        $this->sessionStore = $this->shopper['session'];
+    }
+
+    /**
+     * Build one independent "shopper": a Validator wired to its own customer session
+     * double, its own billable connector mock and its own live store configuration.
+     *
+     * Modelled on ValidatorVerifyCacheTest::createShopper() and kept deliberately
+     * similar, since the two caches have to be compared against each other here. The
+     * connector is stubbed once, at construction: it answers from $this->apiVerdicts,
+     * one response row per address in the payload IN PAYLOAD ORDER, so a test never has
+     * to know how many addresses a batch will actually send - which is the very thing
+     * most of these tests are asserting.
+     *
+     * Pass an existing $session to model the same admin/import session on a later
+     * request, a $storeId to model a request handled by a different store view off the
+     * same session, and a $config ArrayObject (built with self::configWith()) to model
+     * store configuration read LIVE, so a test can change a value between two batches
+     * the way a merchant saving the admin form does.
+     *
+     * Pass a $respond callback to answer a payload with something other than one row per
+     * address - the malformed responses the positional attribution has to survive.
+     *
+     * @param ArrayObject|null $session Session backing store to reuse, or null for a new session.
+     * @param int $storeId Store view the request is being handled by (Data::getCurrentStore()).
+     * @param ArrayObject|null $config Live store configuration, config path => value.
+     * @param callable|null $respond Replacement connector response builder, given the payload.
+     * @return array{validator: Validator, connector: Verify&MockObject, requests: ArrayObject,
+     *     session: ArrayObject, config: ArrayObject, events: ArrayObject}
+     */
+    private function createShopper(
+        ?ArrayObject $session = null,
+        int $storeId = 0,
+        ?ArrayObject $config = null,
+        ?callable $respond = null
+    ): array {
+        $sessionStore = $session ?? new ArrayObject();
+        $requests = new ArrayObject();
+        $configStore = $config ?? new ArrayObject(self::configWith([]));
+
+        // One ordered timeline of everything the Validator emitted: every log record AND
+        // every billable request, so a test can assert both WHAT was logged (never an
+        // address) and WHEN (a miss must be logged before the request it accounts for).
+        $events = new ArrayObject();
+
+        $logger = $this->createMock(Logger::class);
+        $recordLog = static function (string $level) use ($events): callable {
+            return static function ($message, array $context = []) use ($events, $level) {
+                $events[] = ['type' => $level, 'message' => (string)$message, 'context' => $context];
+            };
+        };
+        $logger->method('debug')->willReturnCallback($recordLog('debug'));
+        $logger->method('info')->willReturnCallback($recordLog('info'));
+
+        // The shared Test/stubs Session is a no-op (getData() returns null, setData()
+        // stores nothing), so no cache could ever survive between calls. This mock retains
+        // data in $sessionStore, which also lets the tests read the two cache attributes
+        // directly - and, because the store is per shopper, assert nothing crosses between
+        // shoppers. getData()/setData() have to be *added* when the real
+        // Magento\Customer\Model\Session is present, because it does not declare them
+        // (SessionManager __call-forwards them to Session\Storage); the Test/stubs Session
+        // does declare them, and PHPUnit refuses to "add" an existing method - hence the
+        // method_exists() filter, which keeps this double working on both sides.
+        $sessionBuilder = $this->getMockBuilder(Session::class)->disableOriginalConstructor();
+        $undeclared = array_values(array_filter(
+            ['getData', 'setData'],
+            static fn (string $method): bool => !method_exists(Session::class, $method)
+        ));
+        if ($undeclared) {
+            $sessionBuilder->addMethods($undeclared);
+        }
+        $sessionMock = $sessionBuilder->getMock();
+        $sessionMock->method('getData')->willReturnCallback(
+            static function ($key = '', $clear = false) use ($sessionStore) {
+                return $sessionStore[$key] ?? null;
+            }
+        );
+        $sessionMock->method('setData')->willReturnCallback(
+            static function ($key, $value = null) use ($sessionStore, $sessionMock) {
+                $sessionStore[$key] = $value;
+
+                return $sessionMock;
+            }
+        );
+
+        // No test here uses region_id, but parseAddress() resolves one through
+        // RegionFactory, so the factory must not return null if a fixture ever grows one.
+        $regionFactory = $this->createMock(RegionFactory::class);
+        $regionFactory->method('create')->willReturnCallback(
+            static function () {
+                return new class {
+                    public function load($regionId)
+                    {
+                        return $this;
+                    }
+
+                    public function getName()
+                    {
+                        return '';
+                    }
+                };
+            }
+        );
+
+        // The constructor reads the module's setup_version to build the source string.
+        $moduleList = $this->createMock(ModuleListInterface::class);
+        $moduleList->method('getOne')->willReturn(['setup_version' => '9.9.9']);
+
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturnCallback(
+            static function ($configPath) use ($configStore) {
+                // A non-empty API key is required twice: the constructor only builds the
+                // connector when it is set, and verifyMultipleAddresses() short-circuits
+                // with noKeyFound when it is not.
+                if ($configPath === 'loqate_settings/settings/api_key') {
+                    return self::API_KEY;
+                }
+
+                // Anything not explicitly configured reads as empty, which is what the
+                // admin form leaves behind for an untouched field.
+                return $configStore[$configPath] ?? '';
+            }
+        );
+        // Verdicts are namespaced per STORE VIEW, because the AQI threshold behind them is
+        // read at SCOPE_STORE. Stubbed explicitly per shopper: getCurrentStore() is
+        // declared int, so an unstubbed mock would auto-return 0 for EVERY shopper,
+        // collapsing them into one namespace and making the scoping test below pass for
+        // the wrong reason.
+        $helper->method('getCurrentStore')->willReturn($storeId);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('serialize')->willReturnCallback(
+            static fn ($value) => json_encode($value)
+        );
+        $serializer->method('unserialize')->willReturnCallback(
+            static fn ($value) => json_decode($value, true)
+        );
+
+        $validator = new Validator(
+            $logger,
+            $sessionMock,
+            $regionFactory,
+            $moduleList,
+            $helper,
+            $serializer
+        );
+
+        // The connector is built inside the constructor (new Verify($apiKey)), so the only
+        // way to intercept the billable call is to swap the private property afterwards.
+        $connector = $this->createMock(Verify::class);
+        $connector->method('verifyAddress')->willReturnCallback(
+            function ($payload) use ($requests, $events, $respond) {
+                $requests[] = $payload;
+                $events[] = ['type' => 'api', 'message' => '', 'context' => []];
+
+                if ($this->apiFailureMessage !== null) {
+                    return ['error' => true, 'message' => $this->apiFailureMessage];
+                }
+
+                if ($respond !== null) {
+                    return $respond($payload);
+                }
+
+                // One row per address SENT, in the order they were sent: that positional
+                // correspondence is what the production code attributes verdicts by, and
+                // it is exactly how the Cleansing API answers a batch.
+                $rows = [];
+                foreach ((array)($payload['Addresses'] ?? []) as $address) {
+                    $rows[] = $this->responseRowFor((array)$address);
+                }
+
+                return $rows;
+            }
+        );
+        $reflection = new ReflectionProperty(Validator::class, 'apiConnector');
+        $reflection->setAccessible(true);
+        $reflection->setValue($validator, $connector);
+
+        return [
+            'validator' => $validator,
+            'connector' => $connector,
+            'requests' => $requests,
+            'session' => $sessionStore,
+            'config' => $configStore,
+            'events' => $events,
+        ];
+    }
+
+    /**
+     * THE index-mapping guarantee (LOQ-16977), on the batch shape that broke it: some
+     * addresses answered from the captured-address store, some sent to the API, and a
+     * string-keyed input - exactly what Plugin\Admin\OrderSave.php hands in.
+     *
+     * Every input key must come back carrying ITS OWN verdict, in the input's order, and
+     * the API must have been asked about the two uncaptured addresses only, in input
+     * order. The pre-fix code returned a single entry keyed 0 (array_search(false, ...)
+     * over all-truthy values returns false, which coerces to key 0), so both the admin
+     * message and any row attribution named the wrong address.
+     */
+    public function testAMixedCapturedAndVerifiedBatchReturnsEveryVerdictUnderItsOwnInputKey(): void
+    {
+        $captured = $this->distinctAddress(1);
+        $typed = $this->distinctAddress(2);
+        $capturedToo = $this->distinctAddress(3);
+        $typedAndFailing = $this->distinctAddress(4);
+        $this->apiVerdicts[$typedAndFailing['street'][0]] = 'fail';
+
+        $this->sessionStore['captured_addresses'] = [
+            self::capturedEntry($captured),
+            self::capturedEntry($capturedToo),
+        ];
+
+        $result = $this->validator->verifyMultipleAddresses([
+            'a' => $captured,
+            'b' => $typed,
+            'c' => $capturedToo,
+            'd' => $typedAndFailing,
+        ]);
+
+        $this->assertSame(
+            ['a', 'b', 'c', 'd'],
+            array_keys($result),
+            'Every input address must be answered under its OWN key, and in the input\'s order: '
+            . 'Plugin\Admin\OrderSave reports that key straight to the admin, and '
+            . 'Plugin\Admin\ValidateImportAddress derives the import row number from it.'
+        );
+        $this->assertSame(
+            ['a' => true, 'b' => true, 'c' => true, 'd' => false],
+            $result,
+            'Each key must carry the verdict of the address that came in under it - including the '
+            . 'captured addresses, whose verdicts were never merged into the result at all before.'
+        );
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount(),
+            'The two uncaptured addresses must be verified in a single batch request.'
+        );
+        $this->assertSame(
+            [$typed['street'][0], $typedAndFailing['street'][0]],
+            array_column($this->apiRequests[0]['Addresses'], 'Address1'),
+            'Only the addresses that were NOT already captured may be sent, and they must be sent in '
+            . 'input order: the response rows are attributed back positionally.'
+        );
+        $this->assertSame(
+            2,
+            $this->addressesBilled(),
+            'The Cleansing API is billable per ADDRESS, so a four-address batch with two captured '
+            . 'addresses must bill exactly two.'
+        );
+    }
+
+    /**
+     * The half of the mapping that is easiest to lose silently: a FAILING verdict.
+     *
+     * false is what every caller acts on, and the result array is filtered on the way out
+     * (rows Loqate did not answer are dropped), so a filter written as array_filter($result)
+     * would discard exactly the verdicts that matter and report a batch of invalid addresses
+     * as entirely clean. Asserted with the failure in the LAST position of a mixed batch,
+     * which is where the pre-fix single-slot bug hid it.
+     */
+    public function testAFailingVerdictSurvivesTheResultFilterUnderItsOwnKey(): void
+    {
+        $good = $this->distinctAddress(1);
+        $bad = $this->distinctAddress(2);
+        $this->apiVerdicts[$bad['street'][0]] = 'fail';
+
+        $result = $this->validator->verifyMultipleAddresses([
+            'shipping_address' => $good,
+            'billing_address' => $bad,
+        ], false);
+
+        $this->assertSame(
+            ['shipping_address' => true, 'billing_address' => false],
+            $result,
+            'A false verdict is the whole point of the call and must never be filtered out of the '
+            . 'result: dropping it reports an invalid address as valid.'
+        );
+        $this->assertArrayHasKey(
+            'billing_address',
+            $result,
+            'The failing address must keep its own key, or the admin is told the wrong address is invalid.'
+        );
+    }
+
+    /**
+     * The no-captured path, which admin import uses (verifyMultipleAddresses($batch, false)):
+     * a plain list must still come back as keys 0..N-1 in input order, with each row's own
+     * verdict. This is the shape ValidateImportAddress's row arithmetic is built on.
+     */
+    public function testAPlainListWithoutTheCapturedCheckIsAnsweredUnderKeysZeroToNMinusOne(): void
+    {
+        $rows = [];
+        for ($i = 0; $i < 4; $i++) {
+            $rows[] = $this->distinctAddress($i);
+        }
+        $this->apiVerdicts[$rows[2]['street'][0]] = 'fail';
+
+        $result = $this->validator->verifyMultipleAddresses($rows, false);
+
+        $this->assertSame([0, 1, 2, 3], array_keys($result), 'A plain list must be answered 0..N-1.');
+        $this->assertSame([true, true, false, true], array_values($result), 'Row 2 is the invalid one.');
+        $this->assertSame(
+            1,
+            $this->apiCallCount(),
+            'Nothing is cached or captured yet, so the whole list must go out in one request.'
+        );
+        $this->assertSame(4, $this->addressesBilled(), 'All four addresses are billed.');
+    }
+
+    /**
+     * THE return-ORDER regression, and the property the customer import actually depends on.
+     *
+     * Plugin\Admin\ValidateImportAddress.php:94 array_merge()s the per-chunk result arrays
+     * and reports ($index + 1) of the MERGED array as the import row number. array_merge()
+     * renumbers integer keys BY INSERTION ORDER, not by key value, so a chunk that came back
+     * as [1, 3, 0, 2, 4] - which is exactly what filling cache hits during the first pass
+     * and API verdicts afterwards produces - would renumber to 0..4 in that order and
+     * mis-attribute EVERY row number the merchant is shown. Pre-seeding one slot per address
+     * before any verdict is filled in is what prevents it.
+     *
+     * Both halves are asserted: the per-chunk key order, and then the array_merge() of two
+     * chunks - because the merge is the actual operation the import performs, and asserting
+     * only the single-chunk keys would leave the property that breaks the import untested.
+     */
+    public function testCacheHitsAndMissesStillReturnRowsInAscendingInputOrder(): void
+    {
+        // Ten import rows; the two that will be reported invalid are rows 1 and 8 (import
+        // rows #2 and #9), and both are deliberately CACHE MISSES, so their verdicts are
+        // the ones filled in last and are therefore the ones a lost ordering misplaces.
+        $rows = [];
+        for ($i = 0; $i < 10; $i++) {
+            $rows[$i] = $this->distinctAddress($i);
+        }
+        $this->apiVerdicts[$rows[1]['street'][0]] = 'fail';
+        $this->apiVerdicts[$rows[8]['street'][0]] = 'fail';
+
+        // Warm the cache with the rows that must come back as HITS: 0, 2 and 4 in the first
+        // chunk and 5, 7 and 9 in the second, leaving 1, 3, 6 and 8 to be verified live.
+        $this->validator->verifyMultipleAddresses(
+            [$rows[0], $rows[2], $rows[4], $rows[5], $rows[7], $rows[9]],
+            false
+        );
+        $this->assertSame(1, $this->apiCallCount(), 'The warm-up must be one request.');
+        $this->assertSame(6, $this->addressesBilled(), 'The warm-up bills its six addresses.');
+
+        $firstChunk = $this->validator->verifyMultipleAddresses(array_slice($rows, 0, 5), false);
+        $secondChunk = $this->validator->verifyMultipleAddresses(array_slice($rows, 5, 5), false);
+
+        $this->assertSame(
+            [0, 1, 2, 3, 4],
+            array_keys($firstChunk),
+            'A chunk whose rows 0, 2 and 4 are cache hits and rows 1 and 3 are misses must still be '
+            . 'returned in ASCENDING INPUT ORDER. Without pre-seeded slots this came back as '
+            . '[1, 3, 0, 2, 4] - hits filled during the first pass, API verdicts afterwards.'
+        );
+        $this->assertSame([0, 1, 2, 3, 4], array_keys($secondChunk), 'The same holds for every chunk.');
+
+        // ...and the operation the import really performs.
+        $merged = array_merge($firstChunk, $secondChunk);
+
+        $this->assertSame(
+            range(0, 9),
+            array_keys($merged),
+            'array_merge() of the per-chunk results must yield ascending 0..9: it renumbers by '
+            . 'INSERTION order, so any chunk that is not itself in input order silently shifts '
+            . 'every import row number that follows it.'
+        );
+        $this->assertSame(
+            [true, false, true, true, true, true, true, true, false, true],
+            array_values($merged),
+            'Each merged position must still carry the verdict of the row that occupied it.'
+        );
+
+        // The arithmetic ValidateImportAddress.php:107-117 performs on that merged array.
+        $reportedRows = [];
+        foreach ($merged as $index => $validAddress) {
+            if (!$validAddress) {
+                $reportedRows[] = $index + 1;
+            }
+        }
+        $this->assertSame(
+            [2, 9],
+            $reportedRows,
+            'The merchant must be told rows #2 and #9 are invalid - the rows that really are. This is '
+            . 'the property the whole ordering guarantee exists for: a mis-ordered chunk points them '
+            . 'at rows they would then "fix" while the genuinely bad ones import.'
+        );
+
+        $this->assertSame(
+            3,
+            $this->apiCallCount(),
+            'One warm-up request plus one per chunk: the cache hits must issue no request of their own.'
+        );
+        $this->assertSame(
+            10,
+            $this->addressesBilled(),
+            'Six warm-up addresses plus the four genuine misses. The six hits must cost nothing: the '
+            . 'API is billed per address, not per request.'
+        );
+    }
+
+    /**
+     * THE billing guarantee (LOQ-16976), on the case the merchant actually hits: an admin
+     * re-submitting the same order, or an import re-run after fixing an unrelated column.
+     *
+     * A five-address batch submitted twice must bill five addresses in total, and the second
+     * submission must issue NO request at all - not an empty 'Addresses' payload to a
+     * billable endpoint - while returning the identical verdicts.
+     */
+    public function testAnIdenticalBatchSubmittedTwiceBillsItsAddressesOnce(): void
+    {
+        // Every address passes: a rejection is deliberately never cached (see
+        // testAFailingVerdictIsNeverCached()), so a batch containing one could not make the
+        // "no second request at all" claim this test is about.
+        $batch = [];
+        for ($i = 0; $i < 5; $i++) {
+            $batch[] = $this->distinctAddress($i);
+        }
+
+        $first = $this->validator->verifyMultipleAddresses($batch, false);
+        $second = $this->validator->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount(),
+            'The second submission of an identical batch must short-circuit before the billable call: '
+            . 'every address it needs is already verified in this session.'
+        );
+        $this->assertSame(
+            5,
+            $this->addressesBilled(),
+            'Five addresses submitted twice must appear on the invoice five times, not ten.'
+        );
+        $this->assertSame(
+            [0, 1, 2, 3, 4],
+            array_keys($first),
+            'All five rows must be answered, under their own keys and in input order.'
+        );
+        $this->assertSame(
+            [true, true, true, true, true],
+            array_values($first),
+            'The live verdicts must be as the API answered them.'
+        );
+        $this->assertSame(
+            $first,
+            $second,
+            'The replayed batch must return the identical verdicts, keys and order.'
+        );
+    }
+
+    /**
+     * The partial case, which is what a re-run import or a corrected admin order looks like:
+     * three of the five addresses are already verified, so only the OTHER TWO may be sent -
+     * and they must be sent in input order, because response rows are attributed positionally.
+     */
+    public function testOnlyTheAddressesNotAlreadyVerifiedAreSentToTheApi(): void
+    {
+        $batch = [];
+        for ($i = 0; $i < 5; $i++) {
+            $batch[] = $this->distinctAddress($i);
+        }
+
+        // Rows 0, 1 and 4 verified by an earlier submission.
+        $this->validator->verifyMultipleAddresses([$batch[0], $batch[1], $batch[4]], false);
+        $this->assertSame(3, $this->addressesBilled(), 'The earlier submission bills its three addresses.');
+
+        $result = $this->validator->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(2, $this->apiCallCount(), 'The second submission must issue exactly one request.');
+        $sent = $this->apiRequests[1]['Addresses'];
+        $this->assertCount(
+            2,
+            $sent,
+            'Only the two addresses with no cached verdict may be added to the payload: the request is '
+            . 'billed per address it carries, so sending the cached three would bill them again.'
+        );
+        $this->assertSame(
+            [$batch[2]['street'][0], $batch[3]['street'][0]],
+            array_column($sent, 'Address1'),
+            'The two misses must be exactly rows 2 and 3, in input order.'
+        );
+        $this->assertSame(
+            5,
+            $this->addressesBilled(),
+            'Five distinct addresses across two submissions must cost five billed addresses.'
+        );
+        $this->assertSame([0, 1, 2, 3, 4], array_keys($result), 'All five rows must still be answered.');
+        $this->assertSame([true, true, true, true, true], array_values($result));
+    }
+
+    /**
+     * The two caches are SEPARATE STORES, asserted by reading the two session attributes.
+     *
+     * verifyAddress() judges an address against the AVC thresholds; verifyMultipleAddresses()
+     * judges it against the address quality index. The thresholds are different settings, so
+     * one verdict must never answer the other's lookup - a collision there would let an AVC
+     * verdict satisfy an AQI check, silently bypassing a threshold the merchant configured.
+     * The separation is therefore structural (two attributes, and two different stored value
+     * shapes) rather than a matter of prefixing one array carefully.
+     */
+    public function testEachVerifyPathWritesOnlyItsOwnSessionCache(): void
+    {
+        $this->validator->verifyAddress(self::ADDRESS);
+
+        $singleStore = $this->singleStore($this->shopper);
+        $this->assertCount(
+            1,
+            $singleStore,
+            'verifyAddress() must cache its verdict under "' . self::VERIFY_CACHE_SESSION_KEY . '".'
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($this->shopper),
+            'verifyAddress() must write NOTHING to the batch cache: its verdict comes from the AVC '
+            . 'thresholds and would be read there as an AQI verdict.'
+        );
+        $this->assertSame(
+            ['error' => false],
+            json_decode((string)reset($singleStore), true),
+            'The single-address cache stores an "error" flag.'
+        );
+
+        $batchOnly = $this->createShopper();
+        $batchOnly['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $batchStore = $this->batchStore($batchOnly);
+        $this->assertCount(
+            1,
+            $batchStore,
+            'verifyMultipleAddresses() must cache its verdict under "'
+            . self::BATCH_VERIFY_CACHE_SESSION_KEY . '".'
+        );
+        $this->assertSame(
+            [],
+            $this->singleStore($batchOnly),
+            'verifyMultipleAddresses() must write NOTHING to the single-address cache.'
+        );
+        $this->assertSame(
+            ['valid' => true],
+            json_decode((string)reset($batchStore), true),
+            'The batch cache stores a "valid" flag, not an "error" one: the differing shape is a second, '
+            . 'independent guard - an entry written by the other cache fails the shape check here and '
+            . 'degrades to a miss instead of being read as a verdict.'
+        );
+    }
+
+    /**
+     * ...and the behavioural consequence, in BOTH directions: for a textually identical
+     * address, a verdict earned by one method is invisible to the other, and costs a second
+     * billable call.
+     *
+     * That is a deliberate cost, not an oversight. The two verdicts answer different
+     * questions (AVC thresholds versus the AQI), so replaying one for the other would report
+     * a verdict the configuration never produced. Asserted both ways round, because either
+     * path can run first in a real Magento request.
+     */
+    public function testTheTwoVerdictCachesAreInvisibleToEachOtherInBothDirections(): void
+    {
+        // (1) Single first, then the batch path for the same address.
+        $singleFirst = $this->createShopper();
+        $singleFirst['validator']->verifyAddress(self::ADDRESS);
+        $this->assertSame(1, $this->shopperCallCount($singleFirst), 'The single verification is billed.');
+
+        $singleFirst['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(
+            2,
+            $this->shopperCallCount($singleFirst),
+            'The batch path must NOT be served the single-address cache\'s verdict: that verdict was '
+            . 'judged against the AVC thresholds, and this path judges the address quality index.'
+        );
+        $this->assertCount(1, $this->singleStore($singleFirst), 'One entry in the single-address cache...');
+        $this->assertCount(1, $this->batchStore($singleFirst), '...and one in the batch cache.');
+
+        // (2) The other way round.
+        $batchFirst = $this->createShopper();
+        $batchFirst['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+        $this->assertSame(1, $this->shopperCallCount($batchFirst), 'The batch verification is billed.');
+
+        $result = $batchFirst['validator']->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(
+            2,
+            $this->shopperCallCount($batchFirst),
+            'verifyAddress() must NOT be served the batch cache\'s verdict either: the separation has to '
+            . 'hold in both directions, or the reader that gets it wrong decides which threshold applies.'
+        );
+        $this->assertSame(['error' => false], $result, 'The live AVC verdict must be returned.');
+    }
+
+    /**
+     * A FAILING verdict is never cached, and that is load-bearing rather than tidiness.
+     *
+     * It is what makes the strict-only cache key safe: because no rejection is ever stored,
+     * an admin or an import can never be stranded on a replayed "invalid" that they cannot
+     * clear (the checkout dead-end the single-address cache needs its asymmetric key pair to
+     * avoid). The cost is stated and asserted here: a failing address is re-billed on every
+     * submission.
+     */
+    public function testAFailingVerdictIsNeverCached(): void
+    {
+        $good = $this->distinctAddress(1);
+        $bad = $this->distinctAddress(2);
+        $this->apiVerdicts[$bad['street'][0]] = 'fail';
+
+        $first = $this->validator->verifyMultipleAddresses([$good, $bad], false);
+
+        $this->assertSame([true, false], array_values($first), 'The second address must be rejected.');
+        $this->assertCount(
+            1,
+            $this->batchStore($this->shopper),
+            'Only the PASSING verdict may be cached: a stored rejection is what would force the cache '
+            . 'key to drop the county, widening the bypass for every address.'
+        );
+
+        $second = $this->validator->verifyMultipleAddresses([$good, $bad], false);
+
+        $this->assertSame(2, $this->apiCallCount(), 'The failing address must be sent again.');
+        $this->assertSame(
+            [$bad['street'][0]],
+            array_column($this->apiRequests[1]['Addresses'], 'Address1'),
+            'ONLY the failing address may be re-sent: the passing one is cached, so re-billing it too '
+            . 'would defeat the fix.'
+        );
+        $this->assertSame(
+            3,
+            $this->addressesBilled(),
+            'Two addresses submitted twice, one of them cacheable: three billed addresses.'
+        );
+        $this->assertSame([true, false], array_values($second), 'The verdicts must be unchanged.');
+    }
+
+    /**
+     * A response row with no readable AQI in it FAILS CLOSED and is never cached.
+     *
+     * Such a row is not a verdict, it is a fault or a non-answer: the connector collapses any
+     * per-record shape it does not recognise (a bad key, a changed schema, a PER-RECORD error
+     * envelope) into a row nothing can be read out of, and Loqate's own "no match for this
+     * address" arrives the same way, as "Matches":[]. Reporting either as "valid" is the
+     * maximally wrong answer, so checkQualityIndex()'s shape guard
+     * (Helper/Validator.php:841-843) rejects it, exactly as verifyAddress() already rejected an
+     * unreadable AVC (Helper/Validator.php:377): both verify paths now draw the "readable
+     * verdict" line in the same place. A TOP-LEVEL error envelope is NOT in this class - it makes
+     * HttpClient::searchForError() throw, Verify::verifyAddress() catches it into
+     * ['error' => true, ...], and the branch at Helper/Validator.php:616-623 answers it instead.
+     *
+     * EVERY shape asserted here survives the connector's array_column($response, 'Matches') with
+     * the ROW COUNT PRESERVED (see self::UNREADABLE_ROW_SHAPES), so the row-count guard
+     * (Helper/Validator.php:643-651) catches none of them and they all reach the attribution loop
+     * (Helper/Validator.php:703-711) as an AQI of null. This guard is the only thing between them
+     * and a PASS. That includes "Matches":null, which was missing from this taxonomy until the
+     * guard was written and is a survivor of array_column() just like [] is (verified on 8.3).
+     *
+     * Nothing may be cached either, and that is now ONE rule seen once rather than twice: the row
+     * is a FALSE verdict, and storeBatchVerifyResult() stores no failure - so the call site needs
+     * no separate readability test of its own.
+     *
+     * The sibling case, an AQI that is PRESENT but unreadable ('', false, 0), reaches the same
+     * guard by a different route and lives in
+     * testAPresentButUnreadableQualityIndexFailsClosedAndIsNeverCached(). The guard must NOT be
+     * widened past these shapes; testALegitimateQualityIndexStillPassesAndIsStillCached() is what
+     * stops that.
+     *
+     * @param string $token self::UNREADABLE_ROW_SHAPES token naming the row shape to answer with.
+     */
+    #[DataProvider('unreadableRowShapeProvider')]
+    public function testARowWithNoReadableQualityIndexFailsClosedAndIsNeverCached(string $token): void
+    {
+        $unreadable = $this->distinctAddress(1);
+        $this->apiVerdicts[$unreadable['street'][0]] = $token;
+
+        // Fixture-realism guard, ASSERTED rather than claimed in a comment: this shape really does
+        // reach the attribution loop, because the connector's array_column($response, 'Matches')
+        // keeps a record whose 'Matches' is [] or null instead of dropping it. Were that not so,
+        // the row count would differ and this test would silently be exercising the count guard
+        // (Helper/Validator.php:643-651) rather than the AQI shape guard it is written for.
+        $this->assertSame(
+            [self::UNREADABLE_ROW_SHAPES[$token]],
+            array_column([['Matches' => self::UNREADABLE_ROW_SHAPES[$token]]], 'Matches'),
+            'This row shape must survive the connector\'s array_column() with the count preserved, or the '
+            . 'test is not reaching the guard it claims to test.'
+        );
+
+        $first = $this->validator->verifyMultipleAddresses([$unreadable], false);
+
+        $this->assertSame(
+            [0 => false],
+            $first,
+            'An AQI the module could not read is NOT a verdict, so it must fail CLOSED. Answering true - '
+            . 'which is what null <= any letter threshold used to produce - let ONE malformed or '
+            . 'match-less response row PASS an address: admin order create went straight through '
+            . '(Plugin\Admin\OrderSave.php:50-58 sees true and raises no error) and the import row was '
+            . 'accepted unverified. For the "Matches":[] shape that meant reporting Loqate\'s own "no '
+            . 'match for this address" as VALID.'
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($this->shopper),
+            'A row we cannot read an AQI out of is a fault, not a verdict, so nothing may be cached: '
+            . 'otherwise a single connector fault decides that address for the rest of the session. The '
+            . 'rejection is not cached either - storeBatchVerifyResult() stores no failure - so the next '
+            . 'submission asks the API again instead of being stranded on an unreadable response.'
+        );
+
+        $second = $this->validator->verifyMultipleAddresses([$unreadable], false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'The next submission must retry the API rather than replay the unreadable response: the '
+            . 'accepted cost of caching nothing is that the address is billed again.'
+        );
+        $this->assertSame(
+            [0 => false],
+            $second,
+            'And it must fail closed again: a fault that repeats is still not a verdict.'
+        );
+        $this->assertSame([], $this->batchStore($this->shopper), 'Still nothing cached after the retry.');
+    }
+
+    /**
+     * The response-row shapes that carry no readable AQI, one data set each.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function unreadableRowShapeProvider(): array
+    {
+        $cases = [];
+        foreach (array_keys(self::UNREADABLE_ROW_SHAPES) as $token) {
+            $cases['response row is a ' . $token] = [$token];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * The batch cache key is STRICT - county INCLUDED - and this is where that differs
+     * observably from the single-address cache, whose SUCCESS key deliberately drops the
+     * county so capture.js rewriting "Meath" to "Co. Meath" cannot re-bill an address.
+     *
+     * Both designs are asserted here, side by side and on the same address, because the
+     * difference is intentional and each half is only defensible in the light of the other:
+     * the batch path can afford a strict key precisely because it never caches a rejection,
+     * so it has no dead-end to avoid, and an AQI plausibly depends on the county - a
+     * county-blind success cache here would be a WIDER bypass than the one the single-address
+     * cache already accepts. The stated cost: one extra billed address per county rewrite.
+     */
+    public function testChangingOnlyTheCountyCostsASecondBillableAddressOnTheBatchPathOnly(): void
+    {
+        $address = self::ADDRESS;
+        $countyRewritten = array_merge($address, ['region' => 'Co. London']);
+
+        $this->validator->verifyMultipleAddresses([$address], false);
+        $this->validator->verifyMultipleAddresses([$countyRewritten], false);
+
+        $this->assertSame(
+            2,
+            $this->addressesBilled(),
+            'The batch cache key includes the county, so rewriting it is a MISS and the address is '
+            . 'verified again. That is the accepted cost of a strict key on a path that never caches '
+            . 'a rejection and therefore needs no county-blind escape hatch.'
+        );
+        $this->assertCount(
+            2,
+            $this->batchStore($this->shopper),
+            'The two county spellings must occupy their own cache entries.'
+        );
+
+        // The single-address cache, same address, same rewrite: no second call, because its
+        // SUCCESS key drops the county. Two designs, deliberately different.
+        $single = $this->createShopper();
+        $single['validator']->verifyAddress($address);
+        $single['validator']->verifyAddress($countyRewritten);
+
+        $this->assertSame(
+            1,
+            $this->shopperCallCount($single),
+            'The single-address cache must still absorb a county rewrite: that is the LOQ-16969 fix, and '
+            . 'the two caches really do key differently - they are not interchangeable.'
+        );
+    }
+
+    /**
+     * The batch cache must be bounded, and must evict the OLDEST entry first.
+     *
+     * Unbounded is not an option: the addresses go into the customer session, which is
+     * serialised on every request, and an import can present thousands of rows. Bounded but
+     * newest-first would be worse than useless, because the entry most likely to be needed
+     * again is the one just written.
+     */
+    public function testTheBatchCacheIsBoundedAndEvictsTheOldestVerdictFirst(): void
+    {
+        $limit = $this->batchCacheLimit();
+
+        // One batch of limit + 5 distinct addresses: they are cached in the order the
+        // response rows are processed, which is the order they were sent.
+        $batch = [];
+        for ($i = 1; $i <= $limit + 5; $i++) {
+            $batch[] = $this->distinctAddress($i);
+        }
+        $this->validator->verifyMultipleAddresses($batch, false);
+
+        $store = $this->batchStore($this->shopper);
+        $this->assertCount(
+            $limit,
+            $store,
+            'Once more than BATCH_VERIFY_CACHE_LIMIT addresses have been verified the cache must hold '
+            . 'exactly BATCH_VERIFY_CACHE_LIMIT entries: no more (the session payload must stay '
+            . 'bounded) and no fewer (a cache that under-fills re-bills addresses it had room to keep).'
+        );
+
+        $callsAfterFill = $this->apiCallCount();
+        $billedAfterFill = $this->addressesBilled();
+
+        // The newest address must have survived...
+        $this->validator->verifyMultipleAddresses([$batch[$limit + 4]], false);
+        $this->assertSame(
+            $billedAfterFill,
+            $this->addressesBilled(),
+            'The most recently verified address must survive eviction: it is the likeliest to be asked '
+            . 'about again.'
+        );
+        $this->assertSame($callsAfterFill, $this->apiCallCount(), 'An all-hit batch must issue no request.');
+
+        // ...while the oldest five have been evicted and must be verified again.
+        $this->validator->verifyMultipleAddresses([$batch[0]], false);
+        $this->assertSame(
+            $billedAfterFill + 1,
+            $this->addressesBilled(),
+            'The oldest entries must be the ones evicted once the cache is full.'
+        );
+        $this->assertCount(
+            $limit,
+            $this->batchStore($this->shopper),
+            'Re-verifying an evicted address must not push the cache past its limit.'
+        );
+    }
+
+    /**
+     * The bound must be a bound, not a cliff: every one of the BATCH_VERIFY_CACHE_LIMIT
+     * verdicts the cache claims to hold has to be genuinely replayable.
+     *
+     * Asserted by filling the cache to exactly the limit and then re-submitting the whole
+     * batch with no further BILLED ADDRESS, which is what distinguishes a real FIFO cache of
+     * LIMIT entries from one that keeps only the newest verdict (or one whose effective limit
+     * is far smaller than advertised) - both of which satisfy a bare "count <= limit"
+     * assertion. It also pins the property the limit was chosen for: two full import chunks
+     * of 100 rows must fit at once, or a re-run import re-bills rows the cache had room for.
+     */
+    public function testEveryVerdictUpToTheBatchCacheLimitIsRetainedAndReplayable(): void
+    {
+        $limit = $this->batchCacheLimit();
+
+        $batch = [];
+        for ($i = 1; $i <= $limit; $i++) {
+            $batch[] = $this->distinctAddress($i);
+        }
+        $this->validator->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            $limit,
+            $this->addressesBilled(),
+            'Each of the ' . $limit . ' distinct addresses must be verified exactly once.'
+        );
+        $this->assertCount(
+            $limit,
+            $this->batchStore($this->shopper),
+            'A cache bounded to ' . $limit . ' entries must actually be able to hold ' . $limit . ' verdicts.'
+        );
+
+        // Re-submit the whole batch, and then every address individually, oldest first.
+        $replayed = $this->validator->verifyMultipleAddresses($batch, false);
+        for ($i = 1; $i <= $limit; $i++) {
+            $this->validator->verifyMultipleAddresses([$this->distinctAddress($i)], false);
+        }
+
+        $this->assertSame(
+            $limit,
+            $this->addressesBilled(),
+            'Every verdict up to the limit must still be cached: replaying all ' . $limit
+            . ' addresses must not cost a single further billed address.'
+        );
+        $this->assertSame(1, $this->apiCallCount(), 'And not a single further request either.');
+        $this->assertSame(
+            array_fill(0, $limit, true),
+            array_values($replayed),
+            'Every replayed verdict must come back intact, under its own key.'
+        );
+        $this->assertCount(
+            $limit,
+            $this->batchStore($this->shopper),
+            'Replaying cached verdicts must not grow the cache.'
+        );
+    }
+
+    /**
+     * The staleness the AQI fingerprint in the cache key exists to fix: a batch verdict is a
+     * function of the address AND of the quality threshold it was judged against, so once a
+     * merchant tightens or loosens that threshold, verdicts computed under the old one must
+     * not be replayed.
+     *
+     * The threshold is showInStore="1" and read at SCOPE_STORE, so the store view has to be
+     * part of the namespace too - one session can span store views (?___store=, a language
+     * switcher) - and that half is asserted here as well.
+     */
+    public function testChangingTheQualityIndexThresholdInvalidatesCachedVerdicts(): void
+    {
+        $config = new ArrayObject(self::configWith([]));
+        $shopper = $this->createShopper(null, 0, $config);
+
+        $shopper['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+        $this->assertSame(1, $this->shopperCallCount($shopper), 'The first submission must reach the API.');
+        $keyBefore = (string)array_key_first($this->batchStore($shopper));
+
+        // The merchant tightens the accepted quality. The address is unchanged.
+        $config[self::AQI_CONFIG_PATH] = 'B';
+
+        $shopper['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(
+            2,
+            $this->shopperCallCount($shopper),
+            'Changing the address quality index threshold must invalidate the cached verdicts: they were '
+            . 'judged against the old threshold, so replaying them reports a verdict the current '
+            . 'configuration never produced.'
+        );
+
+        $store = $this->batchStore($shopper);
+        $this->assertCount(2, $store, 'The two verdicts must be cached under their own threshold namespaces.');
+        $keyAfter = (string)array_keys($store)[1];
+        $this->assertNotSame(
+            self::fingerprintSegment($keyBefore),
+            self::fingerprintSegment($keyAfter),
+            'The threshold fingerprint segment of the key must change with the applied threshold.'
+        );
+        $this->assertSame(
+            self::signatureSegment($keyBefore),
+            self::signatureSegment($keyAfter),
+            'The threshold must NAMESPACE the key, not leak into the address signature: one address must '
+            . 'still project to one signature.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{12}$/',
+            self::fingerprintSegment($keyBefore),
+            'The fingerprint must be 12 hex characters: hex so it can never contain the "|" the signature '
+            . 'parts are joined with, and truncated so the session payload does not carry 64 characters '
+            . 'per entry.'
+        );
+    }
+
+    /**
+     * The other half of that contract, and the reason this cache fingerprints the AQI and NOT
+     * resolveComparerAvcString(): the AVC thresholds have no bearing whatsoever on a batch
+     * verdict, which comes from checkQualityIndex(). Editing them - all eight fields and the
+     * advanced-settings toggle - must therefore invalidate nothing.
+     *
+     * Fingerprinting the wrong threshold would be wrong in both directions at once: it would
+     * throw away every cached batch verdict on a change that could not affect one, and it
+     * would NOT invalidate them when the AQI itself changed, which is the change that
+     * actually matters (see the previous test).
+     */
+    public function testEditingTheAvcThresholdsInvalidatesNoBatchVerdict(): void
+    {
+        $base = 'loqate_settings/verify_threshold_settings/';
+        $config = new ArrayObject(self::configWith([
+            $base . 'show_advanced_avc_settings' => '1',
+            $base . 'avc_matchscore' => '90',
+        ]));
+        $shopper = $this->createShopper(null, 0, $config);
+
+        $shopper['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+        $this->assertSame(1, $this->shopperCallCount($shopper), 'The first submission must reach the API.');
+
+        // Every AVC threshold field the module has, plus the toggle that decides whether they
+        // apply at all.
+        foreach ([
+            'show_advanced_avc_settings' => '0',
+            'avc_verification_status' => 'U',
+            'avc_post_match_level' => '0',
+            'avc_pre_match_level' => '0',
+            'avc_parsing_status' => 'U',
+            'avc_lexicon_identification_match_level' => '0',
+            'avc_context_identification_match_level' => '0',
+            'avc_postcode_status' => 'P0',
+            'avc_matchscore' => '10',
+        ] as $field => $value) {
+            $config[$base . $field] = $value;
+        }
+
+        $result = $shopper['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(
+            1,
+            $this->shopperCallCount($shopper),
+            'The AVC thresholds do not enter a batch verdict at all - this path judges the address '
+            . 'quality index - so editing them must not invalidate a single cached verdict, let alone '
+            . 're-bill every address in an open import.'
+        );
+        $this->assertSame([0 => true], $result, 'The cached verdict must still be replayed.');
+        $this->assertCount(1, $this->batchStore($shopper), 'No second namespace may appear.');
+    }
+
+    /**
+     * Store-view namespacing, asserted the way the single-address cache's tests assert it:
+     * two store views in ONE session must never answer for each other, because the AQI
+     * threshold behind their verdicts is resolved at SCOPE_STORE - yet the namespace must be
+     * a NAMESPACE, so the same address still projects to the same signature under both.
+     */
+    public function testVerdictsAreNotReplayedAcrossStoreViewsInTheSameSession(): void
+    {
+        $sharedSession = new ArrayObject();
+        $storeOne = $this->createShopper($sharedSession, 1);
+        $storeTwo = $this->createShopper($sharedSession, 2);
+
+        $storeOne['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+        $storeTwo['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(1, $this->shopperCallCount($storeOne), 'Store view 1 must verify the address itself.');
+        $this->assertSame(
+            1,
+            $this->shopperCallCount($storeTwo),
+            'Store view 2 must not be served store view 1\'s verdict: the quality threshold behind it is '
+            . 'resolved at SCOPE_STORE and the two views can configure it differently.'
+        );
+
+        $keys = array_keys($this->batchStore($storeOne));
+        $this->assertCount(2, $keys, 'Both verdicts must coexist in the one session, namespaced per store view.');
+        $this->assertCount(
+            1,
+            array_unique(array_map(
+                static fn (string $key): string => self::signatureSegment($key),
+                $keys
+            )),
+            'One address must project to one signature: only the store view namespace may differ.'
+        );
+    }
+
+    /**
+     * The same session on a later request must still get the saving: the admin order-create
+     * screen and the import both build a fresh Validator per request, so the verdicts have to
+     * be read back out of the shared customer session rather than held in instance state.
+     *
+     * Pinned to the same NON-DEFAULT store view on both requests, so this asserts a genuine
+     * hit inside one namespace and not two shoppers collapsing into store view 0.
+     */
+    public function testALaterRequestInTheSameSessionAndStoreViewReplaysTheCachedVerdicts(): void
+    {
+        $sharedSession = new ArrayObject();
+        $firstRequest = $this->createShopper($sharedSession, 7);
+        $firstRequest['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+        $this->assertSame(1, $this->shopperCallCount($firstRequest), 'The first request must bill the address.');
+
+        // Same session and store view, brand new Validator, and the API now answers "fail"
+        // for this address - so a verdict of "valid" can only have come out of the session.
+        $laterRequest = $this->createShopper($sharedSession, 7);
+        $this->apiVerdicts[self::ADDRESS['street'][0]] = 'fail';
+
+        $result = $laterRequest['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(
+            0,
+            $this->shopperCallCount($laterRequest),
+            'A new Validator instance in the same session must replay the cached verdict, not re-bill it.'
+        );
+        $this->assertSame([0 => true], $result, 'The replayed verdict must be the one the earlier request wrote.');
+    }
+
+    /**
+     * A verdict is customer data, so it may live in the per-shopper customer session and
+     * nowhere with a longer lifetime. Two independent sessions verifying the same address
+     * must each be billed: a store "optimised" into a static property, Registry or
+     * CacheInterface would serve the first session's verdict to the second - suppressing a
+     * verification that never happened for it.
+     */
+    public function testTwoSeparateSessionsVerifyingTheSameBatchAreEachBilled(): void
+    {
+        $sessionA = $this->createShopper();
+        $sessionB = $this->createShopper();
+
+        $sessionA['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+        $sessionB['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(1, $this->shopperCallCount($sessionA), 'The first session verifies the address once.');
+        $this->assertSame(
+            1,
+            $this->shopperCallCount($sessionB),
+            'A second session must NOT be served the first one\'s cached verdict: the batch verdict cache '
+            . 'must be per customer session, never static/Registry/CacheInterface state.'
+        );
+        $this->assertCount(1, $this->batchStore($sessionA), 'Each session must hold its own verdict store.');
+        $this->assertCount(1, $this->batchStore($sessionB), 'Each session must hold its own verdict store.');
+    }
+
+    /**
+     * A transport failure is not a verdict. verifyMultipleAddresses() returns false, nothing
+     * is cached, the failure is reported AS ITSELF in the log, and the next attempt retries -
+     * so an import re-run after the outage is not stranded on a failure it can never clear.
+     *
+     * BOTH BATCH SIZES ARE EXERCISED, because the two ways the isset($response['error'])
+     * branch can be broken - deleting it, and demoting it below the row-count guard - are each
+     * INVISIBLE to one of them. The connector reports a transport failure as
+     * ['error' => true, 'message' => ...], a TWO-ELEMENT array, so its element count collides
+     * with the address count of precisely the batch Plugin\Admin\OrderSave.php:29-36 sends:
+     * billing plus shipping, TWO addresses.
+     *  - TWO addresses pins that the branch EXISTS. count($response) === 2 === count($sentItems),
+     *    so the row-count guard does NOT fire and cannot stand in for the branch. Delete the
+     *    branch and the envelope reaches the attribution loop, which reads
+     *    true[0]['AQI'] ?? null => null, and checkQualityIndex(null) FAIL-OPENS: both addresses
+     *    are reported VALID and the admin order is placed unverified during any Loqate outage,
+     *    with no diagnostic anywhere. A one-address batch hides that completely, because 2 !== 1
+     *    makes the guard fire and return false for entirely the wrong reason.
+     *  - ONE address pins its POSITION above the guard - which the note above the guard states
+     *    as established fact ("the branch directly above already returns for them and always
+     *    did"). Here the counts DO differ, so demoting the branch below the guard lets the
+     *    guard answer first and the outage is reported as "answered 2 rows for 1 addresses":
+     *    a false diagnostic that sends whoever reads it after a blocked import hunting a Loqate
+     *    schema change instead of a network fault. The two-address arm cannot see that
+     *    reordering at all - with the counts equal the guard is skipped either way.
+     * Hence both arms assert the LOGGED MESSAGE and not merely the false return: the demotion
+     * still returns false, and the log line is the only place it shows.
+     */
+    public function testATransportFailureIsReportedAsItselfOnAnySizedBatchNotCachedAndRetried(): void
+    {
+        $this->apiFailureMessage = 'cURL error 28: Operation timed out';
+        $batch = [$this->distinctAddress(1), $this->distinctAddress(2)];
+
+        $failed = $this->validator->verifyMultipleAddresses($batch, false);
+
+        $this->assertFalse(
+            $failed,
+            'A failed billable call must be reported as false, which is the shape '
+            . 'Plugin\Admin\ValidateImportAddress has to handle without merging it. Answering '
+            . '[true, true] here - which is what the error envelope becomes if it ever reaches the '
+            . 'attribution loop - places the admin order with both addresses unverified.'
+        );
+        $this->assertSame(
+            ['cURL error 28: Operation timed out'],
+            array_column($this->logRecords($this->shopper, 'info'), 'message'),
+            'A transport failure must be reported as itself, not as a row-count mismatch: the error envelope '
+            . 'is a 2-element array, so on a two-address batch the count guard would pass it through and '
+            . 'report BOTH addresses valid.'
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($this->shopper),
+            'Nothing may be written to the verdict cache while the API is failing.'
+        );
+
+        // A ONE-address batch during the same outage: the counts now differ (2 elements against
+        // 1 address), so this is the arm that pins the error branch's POSITION above the
+        // row-count guard. Its own shopper, so its log is read in isolation.
+        $oneAddress = $this->createShopper();
+        $this->assertFalse(
+            $oneAddress['validator']->verifyMultipleAddresses([self::ADDRESS], false),
+            'A transport failure fails the batch whatever its size.'
+        );
+        $this->assertSame(
+            ['cURL error 28: Operation timed out'],
+            array_column($this->logRecords($oneAddress, 'info'), 'message'),
+            'The transport error must be reported ahead of the row-count guard. Demoting it below the guard '
+            . 'leaves the outage logged as "answered 2 rows for 1 addresses" - the error envelope\'s own '
+            . 'element count read as a row count - which is a false diagnostic, and the return value is '
+            . 'false either way so nothing else here can catch it.'
+        );
+
+        $this->apiFailureMessage = null;
+        $recovered = $this->validator->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(2, $this->apiCallCount(), 'The retry must reach the API again.');
+        $this->assertSame(
+            [0 => true, 1 => true],
+            $recovered,
+            'The retry must return the live verdict, one per address, under the input\'s own keys.'
+        );
+        $this->assertCount(
+            2,
+            $this->batchStore($this->shopper),
+            'Once the retry succeeds its verdicts must be cached like any other, so the failure has not '
+            . 'poisoned the session into re-billing forever either.'
+        );
+    }
+
+    /**
+     * An empty batch must cost nothing at all: no request, and no empty 'Addresses' payload
+     * sent to a billable endpoint just to discard the answer.
+     */
+    public function testAnEmptyBatchIssuesNoRequest(): void
+    {
+        $result = $this->validator->verifyMultipleAddresses([], false);
+
+        $this->assertSame([], $result, 'There is nothing to report for an empty batch.');
+        $this->assertSame(0, $this->apiCallCount(), 'An empty batch must not reach the billable endpoint.');
+    }
+
+    /**
+     * The instrumentation that makes the saving auditable, and its PRIVACY rule.
+     *
+     * Misses map ONE-TO-ONE onto billed addresses, which is what lets the drop in the Loqate
+     * invoice be reconciled from the log without waiting for the invoice. And nothing that
+     * identifies anybody may appear on those lines: a log file outlives the session, is
+     * readable by anyone with server access and is shipped to aggregators, so the address and
+     * the raw signature are both forbidden. Asserted as a WHITELIST - every debug record must
+     * match one exact shape - because a blacklist only catches the leaks someone thought of.
+     */
+    public function testBatchCacheLoggingAccountsForEveryBilledAddressWithoutLeakingOne(): void
+    {
+        $batch = [$this->distinctAddress(1), $this->distinctAddress(2)];
+
+        $this->validator->verifyMultipleAddresses($batch, false);
+        $this->validator->verifyMultipleAddresses($batch, false);
+
+        $records = $this->batchCacheLogRecords($this->shopper);
+        $this->assertSame(
+            ['miss', 'miss', 'hit', 'hit'],
+            array_column($records, 'outcome'),
+            'Every cache lookup outcome must be logged exactly once, in order.'
+        );
+        $this->assertSame(
+            $this->addressesBilled(),
+            count(array_filter($records, static fn (array $r): bool => $r['outcome'] === 'miss')),
+            'Each miss must correspond to exactly one BILLED ADDRESS, or the log cannot be used to '
+            . 'reconcile the invoice.'
+        );
+        $this->assertSame(
+            ['log:miss', 'log:miss', 'api', 'log:hit', 'log:hit'],
+            $this->eventTimeline($this->shopper),
+            'The misses must be logged BEFORE the request they account for, and a fully cached batch must '
+            . 'issue no request at all.'
+        );
+        $this->assertSame(
+            $records[0]['token'],
+            $records[2]['token'],
+            'The miss and the later hit for one address must share a token, or the hits cannot be matched '
+            . 'against the requests they replaced.'
+        );
+        $this->assertNotSame($records[0]['token'], $records[1]['token'], 'Two addresses must not share a token.');
+
+        $forbidden = ['1 Test Street', '2 Test Street', 'London', 'Greater London', 'SW1A', 'GB'];
+        foreach (array_keys($this->batchStore($this->shopper)) as $key) {
+            // The namespaced key and the address signature inside it are PII too.
+            $forbidden[] = (string)$key;
+            $forbidden[] = self::signatureSegment((string)$key);
+        }
+
+        foreach ($this->logRecords($this->shopper) as $index => $record) {
+            $haystack = $record['message'] . ' ' . json_encode($record['context']);
+            foreach ($forbidden as $secret) {
+                $this->assertStringNotContainsStringIgnoringCase(
+                    $secret,
+                    $haystack,
+                    sprintf(
+                        'Log record #%d ("%s") contains "%s". The batch verify cache instrumentation must '
+                        . 'never write the address, any address field or the raw signature to the log: a '
+                        . 'log file outlives the session and is not the place for customer data.',
+                        $index,
+                        $record['message'],
+                        $secret
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Defensive-read contract: a batch cache store that is not an array at all (another
+     * module writing to the key, a half-migrated session payload) or an entry that cannot be
+     * read as a verdict must degrade to "not cached" - one extra billed address - and never
+     * throw in the middle of an import.
+     */
+    public function testAnUnreadableBatchCacheDegradesToOneExtraBilledAddress(): void
+    {
+        $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
+        $this->assertCount(1, $this->batchStore($this->shopper), 'The verdict must be cached normally first.');
+
+        $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = 'not-an-array';
+        $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(2, $this->apiCallCount(), 'An unreadable store must fall back to verifying, not throw.');
+        $this->assertCount(
+            1,
+            $this->batchStore($this->shopper),
+            'The corrupted store must be replaced by a fresh, usable one.'
+        );
+
+        // A single corrupted ENTRY, which is the reachable case: the key is present but its
+        // payload cannot be read, so the read misses and the verdict is rewritten in place.
+        $store = $this->batchStore($this->shopper);
+        $key = (string)array_key_first($store);
+        $store[$key] = '{not json';
+        $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
+
+        $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(3, $this->apiCallCount(), 'A corrupted entry must be re-verified, not throw.');
+        $this->assertSame(
+            ['valid' => true],
+            json_decode((string)($this->batchStore($this->shopper)[$key] ?? ''), true),
+            'The re-verified verdict must overwrite the corrupted entry with a usable one.'
+        );
+    }
+
+    /**
+     * An entry written by the SINGLE-address cache must not be readable as a batch verdict
+     * even if the two stores are ever conflated by a future change: the value shapes differ
+     * ("error" versus "valid"), so the shape check degrades it to a miss.
+     *
+     * This is the second, independent guard behind the separate session attribute, and it is
+     * the one that still holds after somebody "simplifies" the two stores into one.
+     */
+    public function testASingleAddressVerdictPlantedInTheBatchStoreIsNotReadAsAVerdict(): void
+    {
+        // Earn a real batch cache key, then overwrite its value with the other cache's shape.
+        $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
+        $store = $this->batchStore($this->shopper);
+        $key = (string)array_key_first($store);
+        $store[$key] = json_encode(['error' => false]);
+        $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
+
+        $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'A verdict in the single-address cache\'s shape must not satisfy a batch lookup: these '
+            . 'verdicts answer different questions - the AVC thresholds versus the address quality '
+            . 'index - so reading one as the other would apply a threshold the merchant did not choose.'
+        );
+    }
+
+    /**
+     * An address with nothing identifiable in it has an empty signature, which is the
+     * sentinel that keeps it out of the cache entirely: it must neither be written (poisoning
+     * the store under an empty key) nor be served another address's verdict.
+     */
+    public function testAnUnidentifiableAddressIsNeitherCachedNorServedACachedVerdict(): void
+    {
+        $result = $this->validator->verifyMultipleAddresses([[], [], self::ADDRESS], false);
+
+        $this->assertSame([0 => true, 1 => true, 2 => true], $result, 'All three rows must be answered.');
+        $this->assertSame(
+            3,
+            $this->addressesBilled(),
+            'Two unidentifiable addresses must both be sent - neither may satisfy the other, nor the real '
+            . 'address - so all three are billed.'
+        );
+        $this->assertCount(
+            1,
+            $this->batchStore($this->shopper),
+            'Only the identifiable address may be cached.'
+        );
+        $this->assertArrayNotHasKey(
+            '',
+            $this->batchStore($this->shopper),
+            'An empty signature must never be used as a cache key.'
+        );
+
+        // ...and the unidentifiable rows are still not cached on a second pass.
+        $this->validator->verifyMultipleAddresses([[], []], false);
+        $this->assertSame(5, $this->addressesBilled(), 'An unidentifiable address is billed every time.');
+    }
+
+    /**
+     * The same address appearing TWICE in one batch: both copies miss the cache in the first
+     * pass, so both are sent, and the second response row refreshes the entry the first one
+     * wrote. Both keys must still be answered, and the entry must not be duplicated.
+     *
+     * A realistic import shape (the same address on two customer rows), and the one place
+     * where storeBatchVerifyResult() writes to a key that is already present.
+     *
+     * The COST is asserted rather than glossed over: within ONE batch the cache cannot help,
+     * because it is only written once the response comes back, so the same address is billed once
+     * per OCCURRENCE. Collapsing in-batch duplicates into a single billable address is tracked as
+     * LOQ-17015, "the same address repeated within one batch is billed once per occurrence"; the
+     * assertion below is what will have to change when it is done, so the current cost is visible
+     * rather than rediscovered from an invoice.
+     */
+    public function testADuplicatedAddressInOneBatchIsAnsweredUnderBothKeys(): void
+    {
+        $result = $this->validator->verifyMultipleAddresses([self::ADDRESS, self::ADDRESS], false);
+
+        $this->assertSame([0 => true, 1 => true], $result, 'Both rows must be answered.');
+        $this->assertSame(
+            2,
+            $this->addressesBilled(),
+            'The deferred cost of LOQ-17015, pinned: both occurrences are sent in the one request, so the '
+            . 'same address is billed twice. Only a LATER batch is answered from the cache.'
+        );
+        $this->assertCount(
+            1,
+            $this->batchStore($this->shopper),
+            'The two identical rows describe one address, so they must share one cache entry.'
+        );
+
+        $replayed = $this->validator->verifyMultipleAddresses([self::ADDRESS, self::ADDRESS], false);
+
+        $this->assertSame(1, $this->apiCallCount(), 'The second submission must be answered entirely from cache.');
+        $this->assertSame([0 => true, 1 => true], $replayed, 'Both rows must be answered from the one entry.');
+    }
+
+    /**
+     * THE defect the row-count guard exists for, in the exact shape it reaches us in: a MID-LIST
+     * GAP, where the response is not merely short but SHIFTED.
+     *
+     * Verify::verifyAddress() ends in array_column($response, 'Matches'), which silently drops
+     * every record with no 'Matches' key and reindexes the survivors into a clean 0..N-1 list
+     * (verified on PHP 8.3). So a three-address batch whose MIDDLE record came back as an error
+     * envelope arrives here as a two-element list in which position 1 holds ADDRESS 3's verdict.
+     * Nothing in the response says so.
+     *
+     * Before the guard, address 2 was handed address 3's PASS and - far worse -
+     * storeBatchVerifyResult() persisted that pass against ADDRESS 2's SIGNATURE, so a "valid"
+     * that Loqate never gave for that address was replayed, without a request, for the rest of
+     * the session. That is the "wrong valid replayed" failure the strict cache key exists to
+     * prevent, arriving through the one door the single-address path does not have.
+     *
+     * All three halves are asserted: the batch is refused, the cache stays EMPTY, and address 2
+     * is genuinely still billable afterwards - which is the property the merchant experiences.
+     */
+    public function testAMidListGapIsRejectedAndCachesNoVerdictAgainstTheWrongAddress(): void
+    {
+        // First call: three addresses sent, two rows back - exactly what array_column() makes of
+        // a three-record response whose middle record has no 'Matches' key. Second call: the
+        // connector behaves, and REJECTS whatever it is asked about, so a verdict of true on the
+        // second pass could only have come out of the cache.
+        $call = 0;
+        $shopper = $this->createShopper(null, 0, null, function ($payload) use (&$call): array {
+            $call++;
+            if ($call === 1) {
+                $this->assertCount(
+                    3,
+                    (array)$payload['Addresses'],
+                    'Fixture guard: all three addresses must be sent, or this test is not exercising the '
+                    . 'mid-list gap at all.'
+                );
+
+                return [
+                    [['AQI' => self::PASSING_AQI]],
+                    [['AQI' => self::PASSING_AQI]],
+                ];
+            }
+
+            return array_map(
+                static fn (): array => [['AQI' => self::FAILING_AQI]],
+                (array)$payload['Addresses']
+            );
+        });
+
+        $addresses = [
+            $this->distinctAddress(1),
+            $this->distinctAddress(2),
+            $this->distinctAddress(3),
+        ];
+
+        $result = $shopper['validator']->verifyMultipleAddresses($addresses, false);
+
+        $this->assertFalse(
+            $result,
+            'Two rows for three addresses cannot be attributed to the addresses sent, so the whole batch '
+            . 'must be refused. Attributing them positionally hands address 2 address 3\'s verdict, and '
+            . 'the response gives no way to detect that.'
+        );
+        $this->assertCount(
+            0,
+            $this->batchStore($shopper),
+            'THIS IS THE DEFECT the guard exists for: with a mid-list gap, address 3\'s PASS was persisted '
+            . 'against ADDRESS 2\'s signature and replayed - with no request and no log line - for the rest '
+            . 'of the session. Nothing whatsoever may be cached from a response whose rows cannot be '
+            . 'attributed: not the rows before the gap either, because which rows those are is precisely '
+            . 'what is unknowable.'
+        );
+        $this->assertSame(
+            ['Loqate batch verify answered 2 rows for 3 addresses; verdicts not attributed.'],
+            array_column($this->logRecords($shopper, 'info'), 'message'),
+            'The refusal must leave exactly one diagnostic naming both counts, at INFO so it is actually '
+            . 'written (Logger/Handler.php pins the handler at INFO, so a DEBUG line would be dropped).'
+        );
+
+        // ...and the consequence for the merchant: address 2 is still unverified, so it must be
+        // sent again and must be answered by the API rather than from the cache.
+        $second = $shopper['validator']->verifyMultipleAddresses([$addresses[1]], false);
+
+        $this->assertSame(
+            2,
+            $this->shopperCallCount($shopper),
+            'Address 2 must be verified again: a rejected batch caches nothing, so nothing can be replayed.'
+        );
+        $this->assertSame(
+            [0 => false],
+            $second,
+            'And it must get the verdict the API actually gives it. Before the guard this answered true '
+            . 'from the cache, without a request - a rejection the merchant could never see.'
+        );
+    }
+
+    /**
+     * The whole-response faults that used to be COMPLETELY SILENT.
+     *
+     * array_column() flattens every body it cannot read as records to the same empty list, and
+     * none of these shapes sets $response['error'], so before the count guard they produced
+     * zero verdicts, zero log lines and an import that proceeded ENTIRELY UNVERIFIED with no
+     * diagnostic at all: verifyMultipleAddresses() returned [], which
+     * Plugin\Admin\ValidateImportAddress merges as "no rows to report" and
+     * Plugin\Admin\OrderSave iterates as "no address is invalid".
+     *
+     * Each shape must now return false - the value both callers fail closed on - and leave
+     * exactly one INFO record naming the two counts.
+     *
+     * @param mixed $response What the connector hands back for a two-address payload.
+     * @param int $answeredRows Row count the diagnostic must report.
+     */
+    #[DataProvider('unattributableResponseProvider')]
+    public function testAnUnattributableWholeResponseIsRejectedWithADiagnostic(
+        $response,
+        int $answeredRows
+    ): void {
+        $shopper = $this->createShopper(null, 0, null, static fn ($payload) => $response);
+
+        $result = $shopper['validator']->verifyMultipleAddresses(
+            [$this->distinctAddress(1), $this->distinctAddress(2)],
+            false
+        );
+
+        $this->assertFalse(
+            $result,
+            'A response that cannot be attributed to the addresses sent must be refused. Returning an '
+            . 'empty verdict array instead - which is what this used to do - is read by every caller as '
+            . '"nothing to report": the import proceeds with every row unverified and nobody is told.'
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($shopper),
+            'There is no verdict here to cache, so the cache must be untouched.'
+        );
+        $this->assertSame(
+            [sprintf(
+                'Loqate batch verify answered %d rows for 2 addresses; verdicts not attributed.',
+                $answeredRows
+            )],
+            array_column($this->logRecords($shopper, 'info'), 'message'),
+            'Exactly one diagnostic, naming what came back and what was asked, at INFO so it survives '
+            . 'the handler\'s level (Logger/Handler.php pins it at INFO). The absence of this line is '
+            . 'what made these faults undiagnosable: an unverified import looked exactly like a clean one.'
+        );
+    }
+
+    /**
+     * Response shapes that carry no attributable verdicts for a two-address batch.
+     *
+     * The first is what the connector's array_column() produces from ANY 200 body it cannot
+     * read as records - a {"error": "..."} envelope, a {} body, a changed schema - and also
+     * from a response every one of whose records lacks 'Matches'. The second is the raw
+     * {"Items": ...} shape: array_column() collapses it to the empty list too, and it is
+     * asserted in its own right because it is what the connector would hand straight through
+     * if that array_column() were ever removed, and it must be refused either way. The third
+     * pins the is_array() half of the guard, which count() alone would not cover.
+     */
+    public static function unattributableResponseProvider(): array
+    {
+        return [
+            'an empty list, what array_column() makes of any unreadable body' => [[], 0],
+            'a {"Items": ...} envelope' => [['Items' => [['AQI' => self::PASSING_AQI]]], 1],
+            'not an array at all' => [null, 0],
+        ];
+    }
+
+    /**
+     * One response row per address SENT is the contract positional attribution rests on. A
+     * response with MORE rows than addresses cannot be attributed either - there is no way to
+     * tell WHICH rows are the surplus ones - so the whole batch is refused rather than the
+     * surplus guessed at, and in particular no verdict is cached against a key a surplus row
+     * was never about.
+     */
+    public function testSurplusResponseRowsAreRejectedRatherThanMisattributed(): void
+    {
+        // Two rows for a one-address payload.
+        $shopper = $this->createShopper(null, 0, null, static fn ($payload): array => [
+            [['AQI' => self::PASSING_AQI]],
+            [['AQI' => self::FAILING_AQI]],
+        ]);
+
+        $result = $shopper['validator']->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertFalse(
+            $result,
+            'A row count that does not match the addresses sent must fail the batch, whichever direction '
+            . 'it is wrong in: the first row looks like the answer to the one address sent, but nothing '
+            . 'in a response with a spurious row establishes that it is.'
+        );
+        $this->assertCount(
+            0,
+            $this->batchStore($shopper),
+            'NOTHING may be cached from an unattributable response - not even the first row. A verdict '
+            . 'stored against the wrong signature is replayed for the whole session, and that is the one '
+            . 'failure this cache must never produce.'
+        );
+        $this->assertSame(
+            ['Loqate batch verify answered 2 rows for 1 addresses; verdicts not attributed.'],
+            array_column($this->logRecords($shopper, 'info'), 'message'),
+            'Exactly one diagnostic naming both counts, so an over-long response is as visible in the log '
+            . 'as a short one.'
+        );
+    }
+
+    /**
+     * A genuinely TRUNCATED response - Loqate answering fewer rows than it was sent, with no
+     * shift involved - fails the whole batch too, and that is the ACCEPTED COST of the count
+     * guard rather than a happy accident.
+     *
+     * The rejected alternative, which this test used to pin, was to report the rows that did
+     * come back. It is not available, because a truncated response is INDISTINGUISHABLE from a
+     * shifted one: array_column() reindexes the survivors of a dropped record into the same
+     * clean short list, so "the first N rows are the first N addresses" cannot be established
+     * from the response. Reporting anyway meant later import chunks were silently renumbered by
+     * ValidateImportAddress's array_merge(), and the trade is one-sided: a mis-numbered row
+     * sends the merchant to edit a VALID row while the genuinely bad one imports unnoticed,
+     * whereas a blocked import is loud, retryable and loses nothing.
+     */
+    public function testATruncatedResponseIsRejectedRatherThanReportingTheRowsItHolds(): void
+    {
+        // One row for a two-address payload.
+        $shopper = $this->createShopper(null, 0, null, static fn ($payload): array => [
+            [['AQI' => self::PASSING_AQI]],
+        ]);
+
+        $result = $shopper['validator']->verifyMultipleAddresses(
+            [$this->distinctAddress(1), $this->distinctAddress(2)],
+            false
+        );
+
+        $this->assertFalse(
+            $result,
+            'One row for two addresses must fail the whole batch. The alternative - answering row 0 and '
+            . 'leaving row 1 unreported - reads a truncated response as if it were known not to be a '
+            . 'shifted one, which the response does not say.'
+        );
+        $this->assertCount(
+            0,
+            $this->batchStore($shopper),
+            'The one row that did come back may not be cached either: whether it belongs to address 1 is '
+            . 'exactly what is unknown.'
+        );
+        $this->assertSame(
+            ['Loqate batch verify answered 1 rows for 2 addresses; verdicts not attributed.'],
+            array_column($this->logRecords($shopper, 'info'), 'message'),
+            'The blocked import must be explained in the log, or the merchant is told to "try again" with '
+            . 'nothing on the server saying why.'
+        );
+    }
+
+    /**
+     * An AQI that is PRESENT but not readable as a quality index FAILS CLOSED and is never
+     * cached - the second route into the same guard.
+     *
+     * The guard is a READABILITY test - is this a non-empty string (Helper/Validator.php:841-843)
+     * - and deliberately not a null check, and that difference is the whole point of this test:
+     * under PHP 8's <= rules '' <= 'A', false <= 'A' and 0 <= 'A' are ALL true, so every value
+     * here used to be answered VALID, and a guard written as "$qualityIndex !== null" would still
+     * answer valid AND cache it - storing a genuine-looking verdict nobody computed and replaying
+     * it, without a request, for the rest of the session.
+     * testARowWithNoReadableQualityIndexFailsClosedAndIsNeverCached() cannot catch that: its rows
+     * carry no 'AQI' at all, so they arrive as the null a null check already handles.
+     *
+     * The rejection is the correct answer, not a compromise: an unreadable AQI is not a verdict,
+     * so the batch path answers it the way verifyAddress() answers an unreadable AVC
+     * (Helper/Validator.php:377). Nothing being cached follows from the same rule - a false
+     * verdict is never stored - so a fault answers this one row and dies with the request, and the
+     * next identical batch asks the API again.
+     *
+     * Note the deliberate contrast with
+     * testALegitimateQualityIndexStillPassesAndIsStillCached(): the INT 0 here is rejected because
+     * it is not a string, while the STRING '0' passes there. The guard is on shape, not truthiness.
+     *
+     * @param string $token $apiVerdicts token naming the unreadable AQI value to answer with.
+     */
+    #[DataProvider('unreadableQualityIndexProvider')]
+    public function testAPresentButUnreadableQualityIndexFailsClosedAndIsNeverCached(string $token): void
+    {
+        $address = $this->distinctAddress(1);
+        $this->apiVerdicts[$address['street'][0]] = $token;
+
+        $first = $this->validator->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame(
+            [0 => false],
+            $first,
+            'An AQI that is present but unreadable must fail CLOSED. It used to answer "valid" - '
+            . '"" <= "C", false <= "C" and 0 <= "C" are all true under PHP 8 - so ONE malformed response '
+            . 'row made that address PASS: admin order create went through '
+            . '(Plugin\Admin\OrderSave.php:50-58 sees true and raises no error) and the import row was '
+            . 'accepted unverified, while verifyAddress() already failed CLOSED on the equivalent '
+            . 'unreadable AVC (Helper/Validator.php:377). The two paths must agree, and this is where the '
+            . 'AQI side is held.'
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($this->shopper),
+            'Nothing may be cached: a guard written as "$qualityIndex !== null" would answer TRUE for this '
+            . 'value and store it as a real PASS, so ONE malformed response would pass that address for '
+            . 'the whole session, with no request and no way to notice. The guard therefore asks whether '
+            . 'the AQI is READABLE, not whether it is null - and because the answer is false, '
+            . 'storeBatchVerifyResult()\'s never-cache-a-failure rule keeps it out of the store on its own.'
+        );
+
+        $second = $this->validator->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'The next submission must retry the API rather than replay a verdict read out of a value the '
+            . 'module could not interpret.'
+        );
+        $this->assertSame(
+            2,
+            $this->addressesBilled(),
+            'Re-billing the address is the accepted cost of caching no failure: an unreadable response '
+            . 'must never strand an address on a rejection it cannot clear.'
+        );
+        $this->assertSame([0 => false], $second, 'The verdict is unchanged on the retry.');
+        $this->assertSame(
+            [],
+            $this->batchStore($this->shopper),
+            'Still nothing cached after the retry: a fault that repeats is still not a verdict.'
+        );
+    }
+
+    /**
+     * The AQI values a response can carry that are not usable quality indexes. Each is a real
+     * JSON shape - "AQI":"" , "AQI":false and "AQI":0 - and each COMPARED as better than any
+     * letter threshold before the shape guard, which is what made them dangerous rather than
+     * merely odd.
+     */
+    public static function unreadableQualityIndexProvider(): array
+    {
+        $cases = [];
+        foreach (array_keys(self::UNREADABLE_AQI_VALUES) as $token) {
+            $cases['AQI is ' . $token] = [$token];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * THE OVER-REJECTION GUARD: a LEGITIMATE quality index must still PASS, and must still be
+     * CACHED.
+     *
+     * Fail-closed is only correct if it rejects EXACTLY the unreadable values. Without this test
+     * the guard at Helper/Validator.php:841-843 could be strengthened all the way to "reject
+     * everything" - a whitelist of today's grade letters, empty(), a falsy test, is_numeric() -
+     * with every other test in this class still green: the two fail-closed tests above would keep
+     * passing, and so would every cache test, because a rejection is never cached anyway. What
+     * such a change would break is real verdicts, in production, silently. This is the assertion
+     * that fails first instead.
+     *
+     * Three cases, deliberately not one:
+     *  - 'A' against a threshold of 'A': the EQUALITY case, and the shipped default
+     *    (etc/config.xml:20 sets address_quality_index to 'A' and the field is not exposed in
+     *    etc/adminhtml/system.xml, so this is what most merchants actually run);
+     *  - 'B' against a looser 'C' threshold, so this test does not accidentally prove only that
+     *    equality survives - a guard narrowed to "$qualityIndex === $threshold" would pass the
+     *    case above and fail this one;
+     *  - the STRING '0' against 'C', because the guard tests the value's SHAPE and NOT its
+     *    truthiness ON PURPOSE. '0' is a non-empty string, so it is readable and passes, while
+     *    empty() or a falsy test would reject it. This case exists to stop a future tidy-up from
+     *    replacing "!is_string($x) || $x === ''" with empty(): the two look equivalent, empty()
+     *    catches nothing extra (the empty string is already rejected) and it would start rejecting
+     *    a real value. Contrast the INT 0, which IS rejected, in
+     *    testAPresentButUnreadableQualityIndexFailsClosedAndIsNeverCached().
+     *
+     * @param string $threshold Configured address_quality_index the verdict is judged against.
+     * @param string $qualityIndex AQI the response carries for the address.
+     * @param string $why What this case protects, quoted into the failure message.
+     */
+    #[DataProvider('legitimateQualityIndexProvider')]
+    public function testALegitimateQualityIndexStillPassesAndIsStillCached(
+        string $threshold,
+        string $qualityIndex,
+        string $why
+    ): void {
+        $shopper = $this->createShopper(
+            null,
+            0,
+            new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => $threshold])),
+            static fn ($payload): array => array_map(
+                static fn (): array => [['AQI' => $qualityIndex, 'AVC' => self::PASSING_AVC]],
+                (array)$payload['Addresses']
+            )
+        );
+        $address = $this->distinctAddress(1);
+
+        $first = $shopper['validator']->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame(
+            [0 => true],
+            $first,
+            sprintf(
+                'A READABLE AQI that meets the configured threshold MUST still pass; this case pins that '
+                . '%s. The fail-closed guard (Helper/Validator.php:841-843) rejects only values whose '
+                . 'SHAPE is unreadable - no string, or the empty string - and widening it to empty(), to '
+                . 'a falsy test, to a whitelist of the grade letters Loqate uses today or to is_numeric() '
+                . 'would over-reject genuine verdicts and block valid addresses at admin order create and '
+                . 'on every import row. If this fails, the guard has stopped being fail-closed and started '
+                . 'being fail-shut, and no other test in this class would have noticed.',
+                $why
+            )
+        );
+        $this->assertCount(
+            1,
+            $this->batchStore($shopper),
+            'A readable verdict is a REAL verdict, so it must still be cached. Fail-closed must not spread '
+            . 'into "cache nothing": that would re-bill every address on every submission and undo '
+            . 'LOQ-16976.'
+        );
+
+        $replayed = $shopper['validator']->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame(
+            [0 => true],
+            $replayed,
+            'And the cached pass must be replayable, which is the property the billing fix is made of.'
+        );
+        $this->assertSame(
+            1,
+            $this->shopperCallCount($shopper),
+            'One billable request in total: the second submission must be answered entirely from the '
+            . 'cache.'
+        );
+    }
+
+    /**
+     * Legitimate (threshold, AQI) pairs that must keep passing the fail-closed guard, with what
+     * each one protects.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function legitimateQualityIndexProvider(): array
+    {
+        return [
+            "AQI 'A' at the shipped default threshold 'A'" => [
+                'A',
+                'A',
+                'the strongest grade, judged against the threshold etc/config.xml:20 ships - the equality '
+                . 'case, and the configuration most merchants run',
+            ],
+            "AQI 'B' under a looser 'C' threshold" => [
+                'C',
+                'B',
+                'a passing grade that is NOT equal to the threshold, so the guard cannot be narrowed to an '
+                . 'equality test and hide behind the default-threshold case',
+            ],
+            "the string '0' under a 'C' threshold" => [
+                'C',
+                '0',
+                'a non-empty string is READABLE whatever it spells: the guard is on shape, not truthiness, '
+                . 'so empty() or a falsy test would reject this legitimate value',
+            ],
+        ];
+    }
+
+    /**
+     * REFRESHING an entry while the cache is FULL must not cost an unrelated address its
+     * verdict. That is the whole job of the unset-then-append in storeBatchVerifyResult(), and
+     * nothing else in the suite can see it: with the cache below its limit the unset is
+     * invisible, because writing to an existing key overwrites it in place either way.
+     *
+     * At the limit it stops being invisible. Without the unset, the eviction loop sees a store
+     * that already contains the key it is about to write, counts it, and array_shift()s the
+     * OLDEST entry to make room the write did not need - so refreshing the NEWEST verdict
+     * silently destroys the oldest one, and the cache ends up one entry short of the bound it
+     * advertises.
+     *
+     * The refresh is reachable: it happens whenever a key is present but its payload is
+     * unreadable (a half-migrated session, another module writing to the attribute), and
+     * whenever the same address appears twice in one batch. This test uses the unreadable
+     * payload, because that is the case that arrives with the cache already full after an
+     * import.
+     */
+    public function testRefreshingAnEntryWhileTheCacheIsFullEvictsNoUnrelatedVerdict(): void
+    {
+        $limit = $this->batchCacheLimit();
+
+        // Fill the cache to EXACTLY the limit, in one batch, so the entries are in send order:
+        // $batch[0] is the oldest entry and $batch[$limit - 1] the newest.
+        $batch = [];
+        for ($i = 1; $i <= $limit; $i++) {
+            $batch[] = $this->distinctAddress($i);
+        }
+        $this->validator->verifyMultipleAddresses($batch, false);
+
+        $store = $this->batchStore($this->shopper);
+        $this->assertCount($limit, $store, 'Fixture guard: the cache must start exactly full.');
+        $keys = array_keys($store);
+
+        // Corrupt the payload of the NEWEST entry, so re-verifying that one address misses the
+        // cache and writes to a key that is already present - while the cache is full.
+        $store[$keys[$limit - 1]] = '{not json';
+        $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
+
+        $this->validator->verifyMultipleAddresses([$batch[$limit - 1]], false);
+
+        $this->assertSame(
+            $limit + 1,
+            $this->addressesBilled(),
+            'Fixture guard: the corrupted entry must genuinely have missed, or the refresh under test '
+            . 'never happened.'
+        );
+        $this->assertCount(
+            $limit,
+            $this->batchStore($this->shopper),
+            'Refreshing an existing entry needs no room, so the cache must still hold exactly ' . $limit
+            . ' verdicts. One fewer means the write evicted something it did not have to.'
+        );
+
+        // THE assertion: the entry at the far end of the FIFO queue - the one with nothing to do
+        // with the refresh - must still be replayable.
+        $replayed = $this->validator->verifyMultipleAddresses([$batch[0]], false);
+
+        $this->assertSame(
+            $limit + 1,
+            $this->addressesBilled(),
+            'The OLDEST verdict must survive a refresh of the newest one. Without the unset-then-append, '
+            . 'the eviction loop counts the key it is about to overwrite as if it needed room and shifts '
+            . 'this entry out - so a corrupted or repeated address quietly costs an unrelated, perfectly '
+            . 'good verdict, and every such write shrinks the cache by one.'
+        );
+        $this->assertSame([0 => true], $replayed, 'And it must replay as the verdict it was, not as a miss.');
+    }
+
+    /**
+     * The pre-existing captured-address bypass is free and must stay free: an address Loqate
+     * itself authored through the Capture lookup is not sent to the billable endpoint at all,
+     * and it writes nothing to the verdict cache because it never earned a verdict.
+     */
+    public function testACapturedAddressIsNotSentAndNotCached(): void
+    {
+        $this->sessionStore['captured_addresses'] = [self::capturedEntry(self::ADDRESS)];
+        // The API would REJECT it, so a verdict of true can only come from the bypass.
+        $this->apiVerdicts[self::ADDRESS['street'][0]] = 'fail';
+
+        $result = $this->validator->verifyMultipleAddresses([self::ADDRESS]);
+
+        $this->assertSame([0 => true], $result, 'A captured address must be accepted without verification.');
+        $this->assertSame(0, $this->apiCallCount(), 'A captured address must not reach the billable API at all.');
+        $this->assertSame(
+            [],
+            $this->batchStore($this->shopper),
+            'The captured bypass returns before the verdict cache, so it must write nothing to it.'
+        );
+    }
+
+    /**
+     * With no API key configured the method reports 'noKeyFound' and touches neither the API
+     * nor either cache. Callers must not merge this shape into row-indexed data - see
+     * ValidateImportAddressTest - so it is pinned here at the source.
+     */
+    public function testNoApiKeyReportsNoKeyFoundRatherThanRowIndexedVerdicts(): void
+    {
+        $keyless = $this->createKeylessValidator();
+
+        $result = $keyless->verifyMultipleAddresses([self::ADDRESS], false);
+
+        $this->assertSame(
+            ['noKeyFound' => true],
+            $result,
+            'With no API key there is nothing to validate, and that must be reported as its own shape '
+            . 'rather than as a row-indexed verdict array.'
+        );
+    }
+
+    /**
+     * AQI values that are PRESENT in the response but carry no readable verdict, keyed by the
+     * $apiVerdicts token that produces them.
+     *
+     * Every one of them compares as BETTER than any letter threshold under PHP 8's <= rules -
+     * '' <= 'C' (string comparison), false <= 'C' ('C' is truthy) and 0 <= 'C' (the int is
+     * cast to '0') are all true - so before the shape guard checkQualityIndex() answered "valid"
+     * for each. That is exactly why the guard has to test whether the AQI is READABLE rather than
+     * merely whether it is null: a "verdict" that is really a response the module could not read
+     * must be rejected, and must not be stored and replayed for the rest of the session. See
+     * testAPresentButUnreadableQualityIndexFailsClosedAndIsNeverCached().
+     *
+     * Note that the INT 0 belongs here while the STRING '0' does NOT: '0' is a readable
+     * non-empty string and still passes - see
+     * testALegitimateQualityIndexStillPassesAndIsStillCached().
+     *
+     * @var array<string, mixed>
+     */
+    private const UNREADABLE_AQI_VALUES = [
+        'empty-aqi' => '',
+        'false-aqi' => false,
+        'zero-aqi' => 0,
+    ];
+
+    /**
+     * Whole RESPONSE-ROW shapes that carry no readable AQI at all, keyed by the $apiVerdicts
+     * token that produces them. Each value is one element of the list the CONNECTOR emits - that
+     * is, one record's 'Matches' value after Verify::verifyAddress()'s
+     * array_column($response, 'Matches') (vendor/lqt/api-connector/src/Client/Verify.php:50-52).
+     *
+     * ALL THREE SURVIVE that array_column() with the row count PRESERVED, verified on PHP 8.3: it
+     * drops only records that lack the 'Matches' KEY, so a record whose 'Matches' is [] - or even
+     * null - still contributes an element. The row-count guard (Helper/Validator.php:643-651)
+     * therefore cannot see any of them; they reach the attribution loop
+     * (Helper/Validator.php:703-711), where $addressResponse[0]['AQI'] ?? null is null for every
+     * one, and only checkQualityIndex()'s shape guard (Helper/Validator.php:841-843) stands
+     * between them and a PASS. See
+     * testARowWithNoReadableQualityIndexFailsClosedAndIsNeverCached().
+     *
+     * @var array<string, mixed>
+     */
+    private const UNREADABLE_ROW_SHAPES = [
+        // "Matches":[{}] - a match object with no AQI field in it.
+        'match carrying no AQI' => [[]],
+        // "Matches":[] - Loqate saying "no match for this address", the case where answering
+        // "valid" is the maximally wrong answer.
+        'Matches list that is empty' => [],
+        // "Matches":null - a survivor of array_column() just like [] is, and the shape that was
+        // missing from this taxonomy until the fail-closed guard was written.
+        'Matches value that is null' => null,
+    ];
+
+    /**
+     * What the API answers for one parsed address, in the shape
+     * Validator::verifyMultipleAddresses() reads: $response[$n][0]['AQI'].
+     *
+     * The return type is deliberately left off rather than declared array: the connector's
+     * array_column($response, 'Matches') emits whatever each record's 'Matches' held, so a row
+     * can legitimately arrive as null or as [] - see self::UNREADABLE_ROW_SHAPES.
+     *
+     * @param array $address One entry of the payload's 'Addresses' list.
+     * @return mixed One response row.
+     */
+    private function responseRowFor(array $address)
+    {
+        $verdict = $this->apiVerdicts[(string)($address['Address1'] ?? '')] ?? 'pass';
+
+        if (array_key_exists($verdict, self::UNREADABLE_ROW_SHAPES)) {
+            // A row with no readable AQI in it at all, so the '??' in the production code
+            // supplies null. Kept distinct from the UNREADABLE_AQI_VALUES below because the two
+            // reach the production guard by different routes: a missing value versus a value
+            // that is really there.
+            return self::UNREADABLE_ROW_SHAPES[$verdict];
+        }
+
+        if (array_key_exists($verdict, self::UNREADABLE_AQI_VALUES)) {
+            // A row whose AQI is present but is not a usable quality index. Kept distinct from
+            // 'unreadable' above because the two reach the production guard by different
+            // routes: '??' on a missing key versus a value that is really there.
+            return [[
+                'AQI' => self::UNREADABLE_AQI_VALUES[$verdict],
+                'AVC' => self::PASSING_AVC,
+            ]];
+        }
+
+        return [[
+            'AQI' => $verdict === 'fail' ? self::FAILING_AQI : self::PASSING_AQI,
+            'AVC' => self::PASSING_AVC,
+        ]];
+    }
+
+    /** A unique, fully-formed address per index. */
+    private function distinctAddress(int $index): array
+    {
+        return [
+            'street' => [$index . ' Test Street'],
+            'city' => 'London',
+            'region' => 'Greater London',
+            'postcode' => 'SW1A ' . $index . 'AA',
+            'country_id' => 'GB',
+        ];
+    }
+
+    /**
+     * A captured-address store entry for a Magento-shaped address, as
+     * Helper\Controller::storeCapturedAddress() writes it: the ADDRESS_CAPTURE_MAPPING keys,
+     * serialised.
+     *
+     * @param array $address Magento-shaped address.
+     * @return string
+     */
+    private static function capturedEntry(array $address): string
+    {
+        return (string)json_encode([
+            'Address1' => $address['street'][0] ?? '',
+            'Address2' => $address['street'][1] ?? '',
+            'Address3' => $address['city'] ?? '',
+            'Address4' => $address['region'] ?? '',
+            'PostalCode' => $address['postcode'] ?? '',
+            'Country' => $address['country_id'] ?? '',
+        ]);
+    }
+
+    /**
+     * Store configuration for these tests: the AQI threshold every batch verdict is judged
+     * against, plus whatever else the test cares about.
+     *
+     * @param array<string, string> $overrides Config path => value.
+     * @return array<string, string>
+     */
+    private static function configWith(array $overrides): array
+    {
+        return array_merge([self::AQI_CONFIG_PATH => self::AQI_THRESHOLD], $overrides);
+    }
+
+    /** Number of billable Loqate Cleansing requests issued by the primary session. */
+    private function apiCallCount(): int
+    {
+        return count($this->apiRequests);
+    }
+
+    /** apiCallCount() for a specific shopper built by createShopper(). */
+    private function shopperCallCount(array $shopper): int
+    {
+        return count($shopper['requests']);
+    }
+
+    /**
+     * Number of ADDRESSES the primary session put on the invoice: the Cleansing API is
+     * billed per address, not per request, so this - and not the request count - is what the
+     * de-duplication has to reduce.
+     */
+    private function addressesBilled(): int
+    {
+        $billed = 0;
+        foreach ($this->apiRequests as $payload) {
+            $billed += count((array)($payload['Addresses'] ?? []));
+        }
+
+        return $billed;
+    }
+
+    /** The BATCH verdict cache as currently held in a shopper's session. */
+    private function batchStore(array $shopper): array
+    {
+        $store = $shopper['session'][self::BATCH_VERIFY_CACHE_SESSION_KEY] ?? [];
+
+        return is_array($store) ? $store : [];
+    }
+
+    /** The SINGLE-address verdict cache as currently held in a shopper's session. */
+    private function singleStore(array $shopper): array
+    {
+        $store = $shopper['session'][self::VERIFY_CACHE_SESSION_KEY] ?? [];
+
+        return is_array($store) ? $store : [];
+    }
+
+    private function batchCacheLimit(): int
+    {
+        if (!defined(Validator::class . '::BATCH_VERIFY_CACHE_LIMIT')) {
+            $this->fail(
+                'Validator::BATCH_VERIFY_CACHE_LIMIT is not defined: the batch verdict cache must be '
+                . 'bounded, or an import can inflate the customer session without limit.'
+            );
+        }
+
+        $limit = (int)constant(Validator::class . '::BATCH_VERIFY_CACHE_LIMIT');
+        $this->assertGreaterThanOrEqual(
+            100,
+            $limit,
+            'The batch cache must hold at least one full import chunk (Plugin\Admin\ValidateImportAddress '
+            . 'verifies in chunks of 100), or eviction discards a chunk\'s earliest rows before the chunk '
+            . 'has finished and a re-run re-bills them.'
+        );
+
+        return $limit;
+    }
+
+    /** A Validator with no API key configured, so every method short-circuits. */
+    private function createKeylessValidator(): Validator
+    {
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturn('');
+        $helper->method('getCurrentStore')->willReturn(0);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
+        $serializer->method('unserialize')->willReturnCallback(static fn ($value) => json_decode($value, true));
+
+        return new Validator(
+            $this->createMock(Logger::class),
+            $this->createMock(Session::class),
+            $this->createMock(RegionFactory::class),
+            $this->createMock(ModuleListInterface::class),
+            $helper,
+            $serializer
+        );
+    }
+
+    /** The AQI-threshold fingerprint segment of a namespaced cache key. */
+    private static function fingerprintSegment(string $key): string
+    {
+        return explode('|', $key)[1] ?? '';
+    }
+
+    /** The address signature part of a namespaced cache key (store view and fingerprint stripped). */
+    private static function signatureSegment(string $key): string
+    {
+        return implode('|', array_slice(explode('|', $key), 2));
+    }
+
+    /**
+     * The ONE line shape the batch cache instrumentation may write: an outcome, the (single)
+     * key family and a 12-hex hash - or "unkeyed". Anything else - an address, a signature, a
+     * store id - fails to match, which is what makes this a whitelist rather than a guess at
+     * what a leak would look like.
+     */
+    private const BATCH_CACHE_LOG_PATTERN =
+        '/^Loqate batch verify cache (hit|miss) \[family=strict, key=([0-9a-f]{12}|unkeyed)\]$/';
+
+    /**
+     * The batch cache-outcome debug records of a shopper, parsed, asserting on the way that
+     * each one matches the whitelisted shape and carries no log context.
+     *
+     * @param array $shopper Shopper harness from createShopper().
+     * @return array<int, array{outcome: string, token: string}>
+     */
+    private function batchCacheLogRecords(array $shopper): array
+    {
+        $parsed = [];
+        foreach ($this->logRecords($shopper, 'debug') as $index => $record) {
+            $this->assertMatchesRegularExpression(
+                self::BATCH_CACHE_LOG_PATTERN,
+                $record['message'],
+                sprintf(
+                    'Debug record #%d ("%s") is not one of the permitted batch cache-outcome lines. These '
+                    . 'records may contain the outcome, the key family and a truncated hash only - never '
+                    . 'the address and never the signature.',
+                    $index,
+                    $record['message']
+                )
+            );
+            $this->assertSame(
+                [],
+                $record['context'],
+                sprintf(
+                    'Debug record #%d carries a log context. The context is serialised into the log file '
+                    . 'like the message, so it must not become a side channel for customer data.',
+                    $index
+                )
+            );
+
+            preg_match(self::BATCH_CACHE_LOG_PATTERN, $record['message'], $matches);
+            $parsed[] = ['outcome' => $matches[1], 'token' => $matches[2]];
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Every log record the Validator emitted for a shopper, in order.
+     *
+     * @param array $shopper Shopper harness from createShopper().
+     * @param string|null $level Only records of this level ('debug', 'info'), or null for all.
+     * @return array<int, array{type: string, message: string, context: array}>
+     */
+    private function logRecords(array $shopper, ?string $level = null): array
+    {
+        return array_values(array_filter(
+            iterator_to_array($shopper['events']),
+            static fn (array $event): bool => $event['type'] !== 'api'
+                && ($level === null || $event['type'] === $level)
+        ));
+    }
+
+    /**
+     * The ordered timeline of what the Validator emitted, as compact tokens: 'log:hit',
+     * 'log:miss' and 'api' for a billable request. Lets the tests assert that the misses are
+     * logged BEFORE the request they account for, which is what makes the log usable to
+     * reconcile the Loqate invoice.
+     *
+     * @param array $shopper Shopper harness from createShopper().
+     * @return string[]
+     */
+    private function eventTimeline(array $shopper): array
+    {
+        $timeline = [];
+        foreach ($shopper['events'] as $event) {
+            if ($event['type'] === 'api') {
+                $timeline[] = 'api';
+                continue;
+            }
+
+            if ($event['type'] !== 'debug') {
+                continue;
+            }
+
+            $timeline[] = preg_match('/cache (hit|miss) /', $event['message'], $matches)
+                ? 'log:' . $matches[1]
+                : 'log:' . $event['message'];
+        }
+
+        return $timeline;
+    }
+}

--- a/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
@@ -45,9 +45,10 @@ use ReflectionProperty;
  * requests. Its design deliberately differs from verifyAddress()' cache in two ways, each
  * pinned below:
  *  - a PHYSICALLY SEPARATE session attribute (BATCH_VERIFY_CACHE_SESSION_KEY) with a
- *    different stored shape ({"valid":true} versus {"error":false}), because these verdicts
- *    come from the address quality index (checkQualityIndex()) and the other cache's from
- *    the AVC thresholds - one must never answer the other's lookup, see
+ *    different stored shape - the verdict field is "valid" here and "error" there, both
+ *    alongside the shared "schema" stamp - because these verdicts come from the address
+ *    quality index (checkQualityIndex()) and the other cache's from the AVC thresholds - one
+ *    must never answer the other's lookup, see
  *    testTheTwoVerdictCachesAreInvisibleToEachOtherInBothDirections();
  *  - only PASSING verdicts are stored, see testAFailingVerdictIsNeverCached().
  *
@@ -132,11 +133,18 @@ class ValidatorBatchVerifyCacheTest extends TestCase
     private const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
 
     /**
-     * Key-scheme version the SINGLE-address cache stamps into every verdict it writes.
+     * Key-scheme version BOTH verdict caches stamp into every verdict they write.
      *
-     * Mirrors Validator::VERIFY_KEY_SCHEMA_VERSION. Asserted here rather than ignored so
-     * that stamping the batch cache too - which would make the two payload shapes differ
-     * only by their verdict field name - cannot happen without this test noticing.
+     * Mirrors Validator::VERIFY_KEY_SCHEMA_VERSION deliberately rather than reading it by
+     * reflection: a bump to the production constant must FAIL here, because bumping it
+     * invalidates every verdict in a live session and that is a decision to make on purpose,
+     * not one to have absorbed silently by a test that follows along.
+     *
+     * The two payload shapes now differ only by their verdict field name - 'valid' for the
+     * batch cache, 'error' for the single-address one - which remains sufficient, and is pinned
+     * from both sides by the two "planted in the other store" tests. Those tests stamp their
+     * plants for that reason: unstamped, the stamp check rejects them first and the shape guard
+     * they exist to defend is never reached.
      */
     private const VERIFY_KEY_SCHEMA_VERSION = 1;
 
@@ -1560,10 +1568,17 @@ class ValidatorBatchVerifyCacheTest extends TestCase
     public function testASingleAddressVerdictPlantedInTheBatchStoreIsNotReadAsAVerdict(): void
     {
         // Earn a real batch cache key, then overwrite its value with the other cache's shape.
+        //
+        // The planted entry carries the CURRENT key-scheme stamp deliberately. Without it the
+        // stamp check rejects the entry first and this test passes whether or not the shape
+        // guard exists - which is exactly what happened when the batch cache gained a stamp:
+        // deleting the shape check left this test green, so the guard this test exists to
+        // defend was undefended. Stamping the plant leaves the shape as the ONLY thing that can
+        // reject it.
         $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
         $store = $this->batchStore($this->shopper);
         $key = (string)array_key_first($store);
-        $store[$key] = json_encode(['error' => false]);
+        $store[$key] = json_encode(['error' => false, 'schema' => self::VERIFY_KEY_SCHEMA_VERSION]);
         $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
 
         $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
@@ -2129,6 +2144,39 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             'And the LIVE verdict must be returned, so the stale entry can be seen not to have answered '
             . 'the lookup rather than merely to have agreed with it.'
         );
+    }
+
+    /**
+     * A batch verdict with NO stamp at all is discarded too, not treated as current.
+     *
+     * Separate from the wrong-stamp case because they fail differently in code: the wrong-stamp
+     * case is caught by any comparison, while an ABSENT stamp is caught only because the default
+     * supplied for a missing key cannot equal the current version. Relaxing that default -
+     * '?? null' to '?? self::VERIFY_KEY_SCHEMA_VERSION' - would silently admit every unstamped
+     * entry, which is precisely the set written by the deploy before the stamp existed.
+     */
+    public function testABatchVerdictWithNoKeySchemeStampIsDiscardedRatherThanReplayed(): void
+    {
+        $address = $this->distinctAddress(1);
+
+        $this->validator->verifyMultipleAddresses([$address], false);
+
+        $store = $this->batchStore($this->shopper);
+        $key = (string)array_key_first($store);
+        // Exactly what the deploy before the stamp wrote: a bare pass.
+        $store[$key] = json_encode(['valid' => true]);
+        $this->shopper['session'][self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
+
+        $verdicts = $this->validator->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'An UNSTAMPED batch verdict must be re-verified: it was written before the key scheme was '
+            . 'recorded, so nothing establishes that its key still names this address. Admitting it would '
+            . 'be a false ACCEPT, since this store holds nothing but passes.'
+        );
+        $this->assertSame([0 => true], $verdicts, 'And the live verdict must be the one returned.');
     }
 
     /**

--- a/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
@@ -42,17 +42,24 @@ use ReflectionProperty;
  * verdict cache is consulted per address BEFORE the address is added to the payload: only
  * misses are sent, and the tests here count "addresses billed" as
  * count($payload['Addresses']) summed over every invocation, not merely the number of
- * requests. Its design deliberately differs from verifyAddress()' cache in three ways, each
+ * requests. Its design deliberately differs from verifyAddress()' cache in two ways, each
  * pinned below:
  *  - a PHYSICALLY SEPARATE session attribute (BATCH_VERIFY_CACHE_SESSION_KEY) with a
  *    different stored shape ({"valid":true} versus {"error":false}), because these verdicts
  *    come from the address quality index (checkQualityIndex()) and the other cache's from
  *    the AVC thresholds - one must never answer the other's lookup, see
  *    testTheTwoVerdictCachesAreInvisibleToEachOtherInBothDirections();
- *  - only PASSING verdicts are stored, see testAFailingVerdictIsNeverCached();
- *  - a single STRICT key with the county INCLUDED, not the asymmetric strict/lossy pair,
- *    which is safe precisely because no failure is ever cached, see
- *    testChangingOnlyTheCountyCostsASecondBillableAddressOnTheBatchPathOnly().
+ *  - only PASSING verdicts are stored, see testAFailingVerdictIsNeverCached().
+ *
+ * THE KEY ITSELF IS THE SAME RULE AS THE SINGLE-ADDRESS ONE: an address shares a verdict
+ * with another submission only when the two ask Loqate about the same address, the
+ * region/county included, on the read as well as on the write. So a county variant nobody
+ * has had verified simply misses here and is billed - see
+ * testAnUnverifiedCountyVariantIsNeverServedACachedBatchPass() and
+ * testChangingOnlyTheCountyCostsASecondBillableAddress(), which are guards rather than red
+ * tests: they fail if anything ever teaches the key that two differently-spelt regions name
+ * one place, which on this path would let an import or an admin order pass an address on a
+ * verdict earned for a different one, and whose AQI plausibly depends on the county.
  * Entries are namespaced per store view and per resolved AQI threshold - NOT per resolved
  * AVC comparer string - see testChangingTheQualityIndexThresholdInvalidatesCachedVerdicts()
  * and testEditingTheAvcThresholdsInvalidatesNoBatchVerdict().
@@ -123,6 +130,15 @@ class ValidatorBatchVerifyCacheTest extends TestCase
 
     /** Session data key the BATCH verdict cache must live under. */
     private const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
+
+    /**
+     * Key-scheme version the SINGLE-address cache stamps into every verdict it writes.
+     *
+     * Mirrors Validator::VERIFY_KEY_SCHEMA_VERSION. Asserted here rather than ignored so
+     * that stamping the batch cache too - which would make the two payload shapes differ
+     * only by their verdict field name - cannot happen without this test noticing.
+     */
+    private const VERIFY_KEY_SCHEMA_VERSION = 1;
 
     /** Config path of the threshold batch verdicts are judged against. */
     private const AQI_CONFIG_PATH = 'loqate_settings/address_settings/address_quality_index';
@@ -701,9 +717,10 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             . 'thresholds and would be read there as an AQI verdict.'
         );
         $this->assertSame(
-            ['error' => false],
+            ['error' => false, 'schema' => self::VERIFY_KEY_SCHEMA_VERSION],
             json_decode((string)reset($singleStore), true),
-            'The single-address cache stores an "error" flag.'
+            'The single-address cache stores an "error" flag plus the key-scheme stamp it '
+            . 'requires to match on read.'
         );
 
         $batchOnly = $this->createShopper();
@@ -777,11 +794,10 @@ class ValidatorBatchVerifyCacheTest extends TestCase
     /**
      * A FAILING verdict is never cached, and that is load-bearing rather than tidiness.
      *
-     * It is what makes the strict-only cache key safe: because no rejection is ever stored,
-     * an admin or an import can never be stranded on a replayed "invalid" that they cannot
-     * clear (the checkout dead-end the single-address cache needs its asymmetric key pair to
-     * avoid). The cost is stated and asserted here: a failing address is re-billed on every
-     * submission.
+     * Because no rejection is ever stored, an admin or an import can never be stranded on a
+     * replayed "invalid" they cannot clear - the checkout dead-end the single-address cache
+     * has to avoid by keying rejections on the exact address Loqate judged. The cost is
+     * stated and asserted here: a failing address is re-billed on every submission.
      */
     public function testAFailingVerdictIsNeverCached(): void
     {
@@ -795,8 +811,8 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $this->assertCount(
             1,
             $this->batchStore($this->shopper),
-            'Only the PASSING verdict may be cached: a stored rejection is what would force the cache '
-            . 'key to drop the county, widening the bypass for every address.'
+            'Only the PASSING verdict may be cached: a stored rejection is what would make it possible for '
+            . 'an admin or an import to be stranded on an "invalid" they cannot clear.'
         );
 
         $second = $this->validator->verifyMultipleAddresses([$good, $bad], false);
@@ -920,21 +936,25 @@ class ValidatorBatchVerifyCacheTest extends TestCase
     }
 
     /**
-     * The batch cache key is STRICT - county INCLUDED - and this is where that differs
-     * observably from the single-address cache, whose SUCCESS key deliberately drops the
-     * county so capture.js rewriting "Meath" to "Co. Meath" cannot re-bill an address.
+     * The batch cache key carries the county as the address supplied it, so re-spelling the
+     * county of an address that has already passed costs one more billed address.
      *
-     * Both designs are asserted here, side by side and on the same address, because the
-     * difference is intentional and each half is only defensible in the light of the other:
-     * the batch path can afford a strict key precisely because it never caches a rejection,
-     * so it has no dead-end to avoid, and an AQI plausibly depends on the county - a
-     * county-blind success cache here would be a WIDER bypass than the one the single-address
-     * cache already accepts. The stated cost: one extra billed address per county rewrite.
+     * The accepted limit, stated and asserted rather than assumed: one extra billed address
+     * per rewrite, on a path (admin order create, import) where the county is largely
+     * re-derived from region_id and so churns far less than in checkout. The other direction
+     * is what may not be done - teaching the key that two spellings name one place buys that
+     * one address back only while the guess is right, and whenever it is wrong an import row
+     * or an admin order passes on a verdict Loqate gave a different address, on a path whose
+     * AQI plausibly depends on the county.
+     *
+     * The pair here is "Meath" and "Co. Meath" on an IE address because that is exactly the
+     * pair a label-collapsing rule merges, so this test is a tripwire for one being
+     * introduced.
      */
-    public function testChangingOnlyTheCountyCostsASecondBillableAddressOnTheBatchPathOnly(): void
+    public function testChangingOnlyTheCountyCostsASecondBillableAddress(): void
     {
-        $address = self::ADDRESS;
-        $countyRewritten = array_merge($address, ['region' => 'Co. London']);
+        $address = self::addressInCounty('IE', 'Meath');
+        $countyRewritten = self::addressInCounty('IE', 'Co. Meath');
 
         $this->validator->verifyMultipleAddresses([$address], false);
         $this->validator->verifyMultipleAddresses([$countyRewritten], false);
@@ -942,27 +962,67 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $this->assertSame(
             2,
             $this->addressesBilled(),
-            'The batch cache key includes the county, so rewriting it is a MISS and the address is '
-            . 'verified again. That is the accepted cost of a strict key on a path that never caches '
-            . 'a rejection and therefore needs no county-blind escape hatch.'
+            'The two submissions ask Loqate about different county text, so each must be verified and '
+            . 'billed in its own right: answering the second from the first pass would let an import row '
+            . 'or an admin order through on a verdict Loqate gave a different address.'
         );
         $this->assertCount(
             2,
             $this->batchStore($this->shopper),
             'The two county spellings must occupy their own cache entries.'
         );
+    }
 
-        // The single-address cache, same address, same rewrite: no second call, because its
-        // SUCCESS key drops the county. Two designs, deliberately different.
-        $single = $this->createShopper();
-        $single['validator']->verifyAddress($address);
-        $single['validator']->verifyAddress($countyRewritten);
+    /**
+     * A county variant nobody has had verified is never served an earlier pass: the county
+     * is in the key on the read as well as on the write, so it simply misses and is billed.
+     *
+     * Pinned as a real cache exchange rather than as a claim about a key: the identical
+     * submission is asserted to HIT first, so the misses that follow are the county's doing
+     * and not a cache that has stopped working. The variants are deliberately the ones a
+     * label-collapsing rule folds together ("Co. Meath" and "County Meath" with "Meath";
+     * "Dublin 1" with "Dublin") - if such a rule is ever introduced anywhere between the
+     * address and this key, those stop missing and this test fails.
+     */
+    public function testAnUnverifiedCountyVariantIsNeverServedACachedBatchPass(): void
+    {
+        $verified = self::addressInCounty('IE', 'Meath');
 
+        $this->validator->verifyMultipleAddresses([$verified], false);
+        $this->assertSame(1, $this->addressesBilled(), 'The first submission must be billed.');
+        $this->assertCount(1, $this->batchStore($this->shopper), 'Its passing verdict must be cached.');
+
+        $replayed = $this->validator->verifyMultipleAddresses([$verified], false);
         $this->assertSame(
             1,
-            $this->shopperCallCount($single),
-            'The single-address cache must still absorb a county rewrite: that is the LOQ-16969 fix, and '
-            . 'the two caches really do key differently - they are not interchangeable.'
+            $this->addressesBilled(),
+            'The IDENTICAL address must be served from the cache, or the misses asserted below would '
+            . 'prove nothing about the county.'
+        );
+        $this->assertSame([0 => true], $replayed, 'And it must be answered with its cached pass.');
+
+        $billed = 1;
+        foreach (['Co. Meath', 'County Meath', 'Kildare', 'Dublin', 'Dublin 1'] as $variant) {
+            $billed++;
+            $result = $this->validator->verifyMultipleAddresses([self::addressInCounty('IE', $variant)], false);
+
+            $this->assertSame(
+                $billed,
+                $this->addressesBilled(),
+                sprintf(
+                    'The county "%s" has never been verified on this path, so it must be BILLED, not '
+                    . 'answered from the pass earned by another county: an import row or an admin order '
+                    . 'would otherwise pass on a verdict Loqate gave a different address.',
+                    $variant
+                )
+            );
+            $this->assertSame([0 => true], $result, 'Each variant must carry its own live verdict.');
+        }
+
+        $this->assertCount(
+            6,
+            $this->batchStore($this->shopper),
+            'One cache entry per county actually verified: six counties, six entries.'
         );
     }
 
@@ -2241,6 +2301,29 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             'AQI' => $verdict === 'fail' ? self::FAILING_AQI : self::PASSING_AQI,
             'AVC' => self::PASSING_AVC,
         ]];
+    }
+
+    /**
+     * One fixed address in $countryId carrying $county, so a pair of these differs in the
+     * county alone and any extra billed address can only be the county's doing.
+     *
+     * Mirrors ValidatorVerifyCacheTest::addressInCounty(), because the two caches' county
+     * handling is compared against each other here and the comparison is only meaningful
+     * on the same address.
+     *
+     * @param string $countryId Magento country code.
+     * @param string $county Region/county name.
+     * @return array Magento-shaped address.
+     */
+    private static function addressInCounty(string $countryId, string $county): array
+    {
+        return [
+            'street' => ['12 Main Street'],
+            'city' => 'Navan',
+            'region' => $county,
+            'postcode' => 'C15 XXXX',
+            'country_id' => $countryId,
+        ];
     }
 
     /** A unique, fully-formed address per index. */

--- a/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
@@ -739,11 +739,13 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             'verifyMultipleAddresses() must write NOTHING to the single-address cache.'
         );
         $this->assertSame(
-            ['valid' => true],
+            ['valid' => true, 'schema' => self::VERIFY_KEY_SCHEMA_VERSION],
             json_decode((string)reset($batchStore), true),
-            'The batch cache stores a "valid" flag, not an "error" one: the differing shape is a second, '
-            . 'independent guard - an entry written by the other cache fails the shape check here and '
-            . 'degrades to a miss instead of being read as a verdict.'
+            'The batch cache stores a "valid" flag, not an "error" one: the differing VERDICT FIELD is a '
+            . 'second, independent guard - an entry written by the other cache fails the shape check here '
+            . 'and degrades to a miss instead of being read as a verdict. Both caches carry the same key-'
+            . 'scheme stamp, which is a guard against a different thing (a session outliving a deploy), so '
+            . 'sharing it does not weaken the shape guard: "valid" and "error" still differ.'
         );
     }
 
@@ -1539,9 +1541,11 @@ class ValidatorBatchVerifyCacheTest extends TestCase
 
         $this->assertSame(3, $this->apiCallCount(), 'A corrupted entry must be re-verified, not throw.');
         $this->assertSame(
-            ['valid' => true],
+            ['valid' => true, 'schema' => self::VERIFY_KEY_SCHEMA_VERSION],
             json_decode((string)($this->batchStore($this->shopper)[$key] ?? ''), true),
-            'The re-verified verdict must overwrite the corrupted entry with a usable one.'
+            'The re-verified verdict must overwrite the corrupted entry with a usable one - carrying the '
+            . 'key-scheme stamp, so recovering from corruption cannot quietly write an entry the next read '
+            . 'would discard as stale.'
         );
     }
 
@@ -2069,6 +2073,61 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             $this->shopperCallCount($shopper),
             'One billable request in total: the second submission must be answered entirely from the '
             . 'cache.'
+        );
+    }
+
+    /**
+     * A batch verdict written under an OLDER key scheme is discarded, not replayed.
+     *
+     * This store needs the stamp MORE than the single-address one, which is why it is asserted
+     * here in its own right rather than left to that cache's test.
+     * storeBatchVerifyResult() caches only PASSES, so a stale entry replayed here is a false
+     * ACCEPT - an address approved on a key that no longer names it. The single-address cache
+     * holds rejections too, so its worst stale outcome is a refusal the shopper can clear.
+     *
+     * An earlier revision carried the stamp on the single-address cache only, reasoning that
+     * the batch payload's distinct shape already guarded the two caches from each other. That
+     * is a different guard: shape stops cross-CACHE conflation, the stamp stops cross-DEPLOY
+     * staleness, and both key builders share one signature so a key-meaning change hits both.
+     */
+    public function testABatchVerdictWrittenUnderAnEarlierKeySchemeIsDiscardedRatherThanReplayed(): void
+    {
+        $address = $this->distinctAddress(1);
+
+        $this->validator->verifyMultipleAddresses([$address], false);
+
+        $store = $this->batchStore($this->shopper);
+        $this->assertCount(1, $store, 'The verdict must be cached normally first.');
+
+        $key = (string)array_key_first($store);
+        $payload = json_decode((string)$store[$key], true);
+        $this->assertSame(
+            self::VERIFY_KEY_SCHEMA_VERSION,
+            $payload['schema'] ?? null,
+            'A cached batch verdict must record the key scheme it was written under, or a verdict from '
+            . 'before a key change cannot be told apart from one written by this deploy - and because only '
+            . 'passes are stored here, mistaking one for the other approves an address.'
+        );
+
+        // The same PASS as written by a deploy whose key scheme was one version older.
+        $payload['schema'] = self::VERIFY_KEY_SCHEMA_VERSION - 1;
+        $store[$key] = json_encode($payload);
+        $this->shopper['session'][self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
+
+        $verdicts = $this->validator->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'A batch verdict stamped with another key scheme must be discarded and the address verified '
+            . 'again: the key it is filed under no longer names the same address. Replaying it would be a '
+            . 'false ACCEPT, since this store holds nothing but passes.'
+        );
+        $this->assertSame(
+            [0 => true],
+            $verdicts,
+            'And the LIVE verdict must be returned, so the stale entry can be seen not to have answered '
+            . 'the lookup rather than merely to have agreed with it.'
         );
     }
 

--- a/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
@@ -2073,6 +2073,105 @@ class ValidatorBatchVerifyCacheTest extends TestCase
     }
 
     /**
+     * An UNREADABLE THRESHOLD rejects every address, including the worst grade Loqate returns.
+     *
+     * The direction here is the opposite of the response-side guard above, and it is the one
+     * that was missing. checkQualityIndex() compares with <=, a string comparison, so a
+     * threshold of text sorting above 'E' does not fail closed - 'E' <= 'zzz' is TRUE on 8.3,
+     * and so is every other grade. A single unreadable config value therefore passed EVERY
+     * address at admin order create and on EVERY import row, silently, no matter what the
+     * merchant believed they had configured. That is a total bypass of the quality bar, not a
+     * degraded one.
+     *
+     * 'E' is the AQI under test on purpose: it is the worst grade, so it is the value that
+     * must never pass a threshold nobody can read. A test using 'A' would still pass if the
+     * guard regressed to comparing against the shipped default.
+     *
+     * Asserted alongside "nothing is cached", because a bogus pass that got stored would
+     * outlive the bad config for the rest of the session.
+     *
+     */
+    #[DataProvider('unreadableThresholdProvider')]
+    public function testAnUnreadableThresholdRejectsEveryAddressAndCachesNothing(
+        $threshold,
+        string $why
+    ): void {
+        $shopper = $this->createShopper(
+            null,
+            0,
+            new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => $threshold])),
+            static fn ($payload): array => array_map(
+                static fn (): array => [['AQI' => 'E', 'AVC' => self::PASSING_AVC]],
+                (array)$payload['Addresses']
+            )
+        );
+
+        $verdicts = $shopper['validator']->verifyMultipleAddresses([$this->distinctAddress(1)], false);
+
+        $this->assertSame(
+            [0 => false],
+            $verdicts,
+            sprintf(
+                'The worst AQI Loqate returns must NOT pass when the threshold is unreadable; this case '
+                . 'pins that %s. If this fails, an unreadable address_quality_index has become a blanket '
+                . 'approval of every address on the batch paths.',
+                $why
+            )
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($shopper),
+            'A verdict reached because the threshold could not be read is not a verdict and must never be '
+            . 'cached: cached, it would keep approving addresses after the config was corrected.'
+        );
+    }
+
+    /**
+     * Threshold values checkQualityIndex() must refuse to judge against, and why each matters.
+     *
+     * The three fail-OPEN cases are the point of the guard: each sorts above 'E' under the
+     * string comparison, so each passed every address before it existed. The remaining cases
+     * already failed closed incidentally, and are pinned so that stays true by rule rather
+     * than by accident of comparison semantics.
+     *
+     * @return array<string, array{0: mixed, 1: string}>
+     */
+    public static function unreadableThresholdProvider(): array
+    {
+        return [
+            "the fail-open case 'zzz'" => [
+                'zzz',
+                "'zzz' sorts above every grade, so 'E' <= 'zzz' was true and EVERY address passed",
+            ],
+            "a lowercase grade 'c'" => [
+                'c',
+                'lowercase sorts above uppercase in ASCII, so a plausible-looking typo in a data patch '
+                . 'passed every address rather than tightening anything',
+            ],
+            "a multi-character grade 'C+'" => [
+                'C+',
+                'a value that looks like a grade but is not one: it sorts above "C", so it silently '
+                . 'loosened the bar instead of being rejected',
+            ],
+            'an unset threshold' => [
+                null,
+                "null already failed closed via 'E' <= null being false; pinned so the guard, not "
+                . 'PHP comparison semantics, is what guarantees it',
+            ],
+            'a blank threshold' => [
+                '',
+                "the empty string already failed closed the same incidental way; pinned for the same "
+                . 'reason',
+            ],
+            'a numeric threshold' => [
+                3,
+                'an int is not a grade at all, and comparing a grade letter with an int is not a '
+                . 'comparison anyone reasoned about',
+            ],
+        ];
+    }
+
+    /**
      * Legitimate (threshold, AQI) pairs that must keep passing the fail-closed guard, with what
      * each one protects.
      *

--- a/Test/Unit/Helper/ValidatorVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorVerifyCacheTest.php
@@ -524,10 +524,19 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
-     * A verdict may not outlive the session that earned it. After a logout or a
-     * session regeneration the session data is gone, so the address has to be
-     * verified against the API again - proving the cache is session state and not
-     * hidden anywhere with a longer lifetime.
+     * A verdict may not outlive the session that earned it. In a BRAND-NEW browser session
+     * - a different visitor, a cleared cookie, a session garbage-collected between visits -
+     * there is no backing data to read, so the address has to be verified against the API
+     * again. That proves the cache is session state and is not hidden anywhere with a
+     * longer lifetime (a static, the registry, a cache backend, the customer entity).
+     *
+     * IT DOES NOT MODEL A LOGOUT OR A SESSION-ID REGENERATION, and must not be read as
+     * doing so - that is the belief LOQ-16978 exists to correct. Magento calls
+     * session_regenerate_id() on login and on logout, which changes the session ID while
+     * PRESERVING every value in $_SESSION, so the cache emphatically DOES survive both.
+     * What clears it there is Helper\ShopperScopedSession, not PHP; the logout and login
+     * cases are covered by ShopperScopedSessionTest::testACachedVerdictDoesNotSurviveALogin()
+     * and its siblings.
      */
     public function testCachedVerdictDoesNotSurviveASessionReset(): void
     {
@@ -536,12 +545,12 @@ class ValidatorVerifyCacheTest extends TestCase
         $this->validator->verifyAddress(self::ADDRESS);
         $this->assertCount(1, $this->verdictStore(), 'The verdict must be written to the session.');
 
-        $this->endSession($this->shopper);
+        $this->startBrandNewSession($this->shopper);
 
         $this->assertSame(
             [],
             $this->verdictStore(),
-            'Clearing the session must clear the verdict cache: it may not be held anywhere else.'
+            'A brand-new session must start with an empty verdict cache: it may not be held anywhere else.'
         );
 
         $result = $this->validator->verifyAddress(self::ADDRESS);
@@ -549,7 +558,7 @@ class ValidatorVerifyCacheTest extends TestCase
         $this->assertSame(
             2,
             $this->apiCallCount(),
-            'After a session reset the address must be verified against the API again.'
+            'In a brand-new session the address must be verified against the API again.'
         );
         $this->assertSame(['error' => false], $result);
         $this->assertCount(
@@ -2774,12 +2783,18 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
-     * Model the end of a browser session (logout, or Magento regenerating the
-     * session id): the session's backing data is dropped, which is precisely how
-     * this harness represents session state, so nothing the previous session
+     * Model a BRAND-NEW browser session: a different visitor, a cleared cookie, or a
+     * session PHP has garbage-collected between visits. The backing data is empty, which is
+     * precisely how this harness represents session state, so nothing an earlier session
      * cached can be read back.
+     *
+     * NOT a logout and NOT a session-id regeneration. Magento regenerates the session id on
+     * both login and logout and the DATA survives that (see Helper\ShopperScopedSession);
+     * emptying the store here would be the wrong model of either. The identity-change cases
+     * are ShopperScopedSessionTest's subject - testACachedVerdictDoesNotSurviveALogin()
+     * covers the logout/login hand-off, where the guard does the clearing that PHP does not.
      */
-    private function endSession(array $shopper): void
+    private function startBrandNewSession(array $shopper): void
     {
         $shopper['session']->exchangeArray([]);
     }

--- a/Test/Unit/Helper/ValidatorVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorVerifyCacheTest.php
@@ -1317,6 +1317,80 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
+     * A verdict with NO stamp at all is discarded too, not treated as current.
+     *
+     * The wrong-stamp case above is caught by any comparison; an ABSENT stamp is caught only
+     * because the default supplied for a missing key cannot equal the current version.
+     * Relaxing that default would silently admit every unstamped entry - exactly the set the
+     * deploy before the stamp wrote.
+     */
+    public function testACachedVerdictWithNoKeySchemeStampIsDiscardedRatherThanReplayed(): void
+    {
+        $this->stubApiResponses([self::acceptedResponse(), self::rejectedResponse()]);
+
+        $this->validator->verifyAddress(self::ADDRESS);
+        $store = $this->verdictStore();
+        $key = (string)array_key_first($store);
+        // Exactly what the deploy before the stamp wrote.
+        $store[$key] = json_encode(['error' => false]);
+        $this->sessionStore[self::VERIFY_CACHE_SESSION_KEY] = $store;
+
+        $result = $this->validator->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'An UNSTAMPED verdict must be re-verified: nothing establishes that the key it is filed under '
+            . 'still names this address under the current key scheme.'
+        );
+        $this->assertTrue($result['error'], 'And the live verdict must be the one returned.');
+    }
+
+    /**
+     * A BATCH-shaped entry must not be readable as a single-address verdict.
+     *
+     * The two caches live in separate session attributes, and this is the second, independent
+     * guard behind that separation: the payload shapes differ ("error" here, "valid" there), so
+     * a batch verdict degrades to a miss rather than answering an AVC lookup. It has to, because
+     * the two verdicts answer different questions - the AVC thresholds versus the address
+     * quality index - so replaying one for the other reports a verdict the merchant's
+     * configuration never produced.
+     *
+     * The plant carries the CURRENT key-scheme stamp on purpose. Stamp-less, the stamp check
+     * would reject it first and this test would pass whether or not the shape guard existed -
+     * the mistake that left the batch cache's equivalent test defending nothing once both
+     * caches gained a stamp. Stamped, the shape is the only thing left that can reject it.
+     */
+    public function testABatchShapedVerdictPlantedInTheSingleAddressStoreIsNotReadAsAVerdict(): void
+    {
+        $this->stubApiResponses([self::acceptedResponse(), self::rejectedResponse()]);
+
+        $this->validator->verifyAddress(self::ADDRESS);
+        $store = $this->verdictStore();
+        $key = (string)array_key_first($store);
+        $store[$key] = json_encode([
+            'valid' => true,
+            'schema' => $this->verifyKeySchemaVersion(),
+        ]);
+        $this->sessionStore[self::VERIFY_CACHE_SESSION_KEY] = $store;
+
+        $result = $this->validator->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'A verdict in the BATCH cache\'s shape must not satisfy a single-address lookup: it was judged '
+            . 'against the address quality index, not the AVC thresholds, so reading it here would let an '
+            . 'AQI verdict silently satisfy an AVC check the merchant configured.'
+        );
+        $this->assertTrue(
+            $result['error'],
+            'And the LIVE verdict must be returned, so the planted entry can be seen not to have answered '
+            . 'the lookup rather than merely to have agreed with it.'
+        );
+    }
+
+    /**
      * Two different region records on an otherwise identical address are two different
      * addresses: each must be verified, and each gets its own verdict.
      */

--- a/Test/Unit/Helper/ValidatorVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorVerifyCacheTest.php
@@ -26,7 +26,7 @@ use ReflectionProperty;
  * statements across five classes: Plugin\Frontend\CheckoutShippingInformation.php:32,
  * Plugin\Frontend\CheckoutBillingAddress.php:34 (which savePaymentInformation replays
  * at place order, so that one statement runs twice in a checkout),
- * Observer\QuoteSubmitBefore.php:60 and :84,
+ * Observer\QuoteSubmitBefore.php:85 and :109,
  * Plugin\Frontend\CustomerAccountAddress.php:37 and
  * Plugin\Admin\ValidateAddress.php:42. A single checkout of a single address therefore
  * invokes it 3-5 times depending on Magento version and checkout front-end, and
@@ -35,7 +35,7 @@ use ReflectionProperty;
  * "captured_addresses", matches solely addresses picked from the Loqate Capture
  * lookup, so a typed address is re-verified - and re-billed - on every one of those
  * paths. (The two verifyMultipleAddresses() sites, Plugin\Admin\OrderSave.php:49 and
- * Plugin\Admin\ValidateImportAddress.php:38, are deliberately NOT covered by this
+ * Plugin\Admin\ValidateImportAddress.php:53, are deliberately NOT covered by this
  * cache - LOQ-16976 - and so are not covered here either.)
  *
  * The contract asserted here: identical addresses are verified once per session
@@ -1462,7 +1462,7 @@ class ValidatorVerifyCacheTest extends TestCase
      *  - the plain POST shape: street is a real ARRAY and the county is a 'region'
      *    NAME (self::ADDRESS, used by most tests here);
      *  - the quote paths (CheckoutShippingInformation.php:32,
-     *    CheckoutBillingAddress.php:34, QuoteSubmitBefore.php:60/:84) pass
+     *    CheckoutBillingAddress.php:34, QuoteSubmitBefore.php:85/:109) pass
      *    Quote\Address::getData(), and AbstractAddress::setData() has already run the
      *    multiline street attribute through trim(implode("\n", $value)), so street is
      *    a NEWLINE-SEPARATED STRING and the county is a 'region_id' that

--- a/Test/Unit/Helper/ValidatorVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorVerifyCacheTest.php
@@ -38,29 +38,55 @@ use ReflectionProperty;
  * Plugin\Admin\ValidateImportAddress.php:53, are deliberately NOT covered by this
  * cache - LOQ-16976 - and so are not covered here either.)
  *
- * The contract asserted here: identical addresses are verified once per session
- * and the verdict is replayed from a bounded, session-scoped cache keyed by the
- * canonical address signature. The two keys are deliberately ASYMMETRIC:
- *  - a SUCCESS is keyed WITHOUT the region/county, because capture.js and
- *    parseAddress() both rewrite it ("Meath" becomes "Co. Meath", a region_id is
- *    re-resolved to a name) and that is exactly the re-billing the customer
- *    reported - see testMutatedCountyNameDoesNotTriggerASecondBillableApiCall();
- *  - a REJECTION is keyed WITH it, because a shopper who corrects a wrong county
- *    must be re-verified rather than locked out of checkout by a replayed
- *    rejection - see testCorrectingOnlyTheCountyAfterARejectionIsVerifiedAgain().
- * The rejection (strict) key is also the one READ FIRST, so reverting to a county
- * Loqate explicitly rejected replays that rejection instead of the county-agnostic
- * success - see testRevertingToTheRejectedCountyReplaysTheCachedRejection() and, for
- * the residual bypass that is deliberately kept,
- * testACountyVariantLoqateNeverRejectedStillPassesFromTheCachedSuccess().
- * Both verify keys also cover the FULL joined street Loqate is actually sent, not
- * just the two lines the captured-address signature carries - see
- * testEditingAStreetLineBeyondTheSecondIsVerifiedAgain(). More generally, the strict
- * key must project EVERY field parseAddress() sends to Loqate and the lossy key
- * exactly that list minus the county; that invariant is pinned structurally by
- * testStrictCacheKeyProjectsEveryFieldSentToLoqate() and, load-bearingly, per field
+ * THE CONTRACT ASSERTED HERE, in one sentence: two submissions share a cached verdict
+ * IF AND ONLY IF they sent Loqate the same normalised address. There is ONE cache key;
+ * it projects every field parseAddress() puts in the request; successes and rejections
+ * live under it alike; and identical addresses are therefore verified once per session,
+ * the verdict being replayed from a bounded, session-scoped store.
+ *
+ * ON THE REGION AXIS - the axis every defect in this cache has been about so far - that
+ * single rule reads: two submissions share a verdict iff their RESOLVED region label is
+ * identical. parseAddress() (Helper/Validator.php:851-883) resolves 'region' from
+ * 'region_id' through RegionFactory whenever a truthy region_id is present, and only
+ * then maps 'region' onto the request's Address4 - so the region segment of the key IS
+ * the region value Loqate was actually asked about, expressed as the resolved region
+ * NAME rather than an install-local numeric id (which is why one address presented by
+ * different checkout call paths still shares one verdict - see
+ * testBothCheckoutCallPathShapesOfOneAddressAreBilledOnce()). Three consequences, each
+ * pinned below:
+ *  - a shopper whose region_id stays put while the raw region TEXT churns around it -
+ *    which is what the Capture front end produces, since it sets both 'region' and
+ *    'region_id' from the SDK's ProvinceName (mapRegionSelectValue(),
+ *    view/base/web/capture.js:7896-7940, over dispatchChange() at :7884-7894, retried
+ *    with exponential backoff at :7942-7960) - sends the identical Address4 every time,
+ *    so one address is billed once across the 3-5 checkout call paths. See
+ *    testRelabellingTheRegionAroundAFixedRegionIdIsBilledOnce();
+ *  - two DIFFERENT region records resolve to two different labels, so each is verified
+ *    in its own right and neither is ever served the other's verdict. See
+ *    testTwoSubmissionsShareAVerdictOnlyWhenTheyResolveToTheSameRegion(),
+ *    testARegionThatWasNeverVerifiedIsNeverServedAnotherRegionsSuccess() and the
+ *    tripwire testRegionRecordsWhoseLabelsReadAlikeAreStillEachVerified();
+ *  - ACCEPTED LIMIT, asserted rather than assumed: where the region is FREE TEXT (no
+ *    region_id at all), re-spelling that text is a different key and costs ONE extra
+ *    verification. See testRespellingAFreeTextRegionCostsOneExtraVerificationAndBypassesNone().
+ *    That is the safe direction - a re-bill, never an address reaching checkout on a
+ *    verdict Loqate gave to a different address. No spelling rules are applied to close
+ *    it: a rule that merges two labels merges two PLACES whenever it is wrong, and that
+ *    is a verify bypass, whereas leaving them apart is only a re-bill.
+ *
+ * The one key also covers the FULL joined street Loqate is actually sent, not just the
+ * two lines the captured-address signature carries - see
+ * testEditingAStreetLineBeyondTheSecondIsVerifiedAgain(). More generally it must project
+ * EVERY field parseAddress() sends to Loqate. That invariant is pinned structurally by
+ * testTheVerifyCacheKeyProjectsEveryFieldSentToLoqate() and, load-bearingly, per field
  * by testEditingAnyFieldSentToLoqateAfterARejectionIsVerifiedAgain() and
- * testEditingAnyFieldSentToLoqateExceptTheCountyIsVerifiedAgainAfterASuccess().
+ * testEditingAnyFieldSentToLoqateIsVerifiedAgainAfterASuccess() - which assert the SAME
+ * guarantee on both sides, because one key serves both.
+ *
+ * A cached verdict also records the version of the key scheme it was written under and
+ * is discarded when that does not match, so a session that spans a deploy changing the
+ * key cannot be answered by a verdict looked up under the old scheme - see
+ * testACachedVerdictWrittenUnderAnEarlierKeySchemeIsDiscardedRatherThanReplayed().
  *
  * Entries are additionally namespaced per STORE VIEW and by a fingerprint of the
  * RESOLVED AVC thresholds, since the thresholds a verdict depends on are read at
@@ -164,9 +190,12 @@ class ValidatorVerifyCacheTest extends TestCase
             'base' => self::FIELD_EDIT_BASE,
             'edit' => ['city' => 'Manchester'],
         ],
+        // A GENUINELY DIFFERENT region, naming a different place rather than re-spelling
+        // the same one, so the fixture reads as an EDIT: the two submissions ask Loqate
+        // about Greater London and about Berkshire, and each must get its own verdict.
         'region' => [
             'base' => self::FIELD_EDIT_BASE,
-            'edit' => ['region' => 'Co. Meath'],
+            'edit' => ['region' => 'Berkshire'],
         ],
         'postcode' => [
             'base' => self::FIELD_EDIT_BASE,
@@ -176,6 +205,24 @@ class ValidatorVerifyCacheTest extends TestCase
             'base' => self::FIELD_EDIT_BASE,
             'edit' => ['country_id' => 'IE'],
         ],
+    ];
+
+    /**
+     * The rows of the install's region directory these tests resolve a region_id against,
+     * region_id => region name, as Magento's directory_country_region table holds them.
+     *
+     * Every name is distinct, because two rows are two places: whichever row a shopper
+     * picks is the region Loqate is asked about. The Dublin pair models a real distinction
+     * (a city postal district and the administrative county around it) and the Meath pair
+     * models an install whose region table carries an abbreviated label alongside a plain
+     * one - the two shapes a label-based collapsing rule would merge.
+     */
+    private const REGION_DIRECTORY = [
+        55 => 'Kildare',
+        100 => 'Dublin 1',
+        101 => 'County Dublin',
+        200 => 'Meath',
+        201 => 'Co. Meath',
     ];
 
     /** @var Validator The Validator under test (the "primary" shopper). */
@@ -419,6 +466,10 @@ class ValidatorVerifyCacheTest extends TestCase
      * The verdict must be cached where the rest of the module expects session
      * state to live: an assoc array under "loqate_verified_addresses", holding
      * serialised verdicts (mirroring the captured_addresses precedent).
+     *
+     * Asserted on the verdict FLAG rather than on the whole payload, because the payload
+     * also carries the key-scheme stamp - see
+     * testACachedVerdictWrittenUnderAnEarlierKeySchemeIsDiscardedRatherThanReplayed().
      */
     public function testSuccessfulVerdictIsStoredSerialisedUnderTheSessionKey(): void
     {
@@ -438,10 +489,14 @@ class ValidatorVerifyCacheTest extends TestCase
             (string)array_key_first($store),
             'The cache must be keyed, by the address signature namespaced to the store view.'
         );
-        $this->assertSame(
-            ['error' => false],
-            json_decode((string)reset($store), true),
+        $payload = json_decode((string)reset($store), true);
+        $this->assertIsArray(
+            $payload,
             'The verdict must be stored serialised, so it can be replayed verbatim.'
+        );
+        $this->assertFalse(
+            $payload['error'] ?? null,
+            'The stored payload must carry the verdict that was earned off the wire.'
         );
     }
 
@@ -623,84 +678,111 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
-     * The regression the customer reported: capture.js mutates the county
-     * ("Meath" -> "Co. Meath") between the shipping and billing saves. The
-     * county is not part of the canonical signature, so this is still the same
-     * address and must not be re-billed.
+     * The regression the customer reported, modelled the way it actually arrives: the raw
+     * region TEXT is rewritten between the shipping and the billing save while the
+     * region_id stays exactly where it is.
      *
-     * This is the mirror image of
-     * testCorrectingOnlyTheCountyAfterARejectionIsVerifiedAgain() and the reason the
-     * two cache keys are deliberately ASYMMETRIC: a SUCCESS is keyed without the
-     * county (lossy) so a rewritten county cannot re-bill it - the whole point of
-     * LOQ-16969 - while a REJECTION is keyed WITH the county (strict) so correcting a
-     * wrong county is re-verified instead of replaying a rejection forever. Making
-     * both keys the same, in either direction, breaks one of these two tests: do not
-     * "simplify" the asymmetry away.
+     * That is the shape the churn really has. The Capture front end sets both 'region' and
+     * 'region_id' from the SDK's ProvinceName (mapRegionSelectValue(),
+     * view/base/web/capture.js:7896-7940, over dispatchChange() at :7884-7894, retried with
+     * exponential backoff at :7942-7960), and parseAddress() then re-resolves 'region' from
+     * that region_id, so every one of these submissions asks Loqate about the SAME region -
+     * whatever text happened to be sitting in the field. One address, one billable
+     * verification, however many times the label is rewritten.
      */
-    public function testMutatedCountyNameDoesNotTriggerASecondBillableApiCall(): void
+    public function testRelabellingTheRegionAroundAFixedRegionIdIsBilledOnce(): void
     {
         $this->stubApiResponses([self::acceptedResponse()]);
+        $this->regionNames = self::REGION_DIRECTORY;
 
-        $address = [
-            'street' => ['12 Main Street'],
-            'city' => 'Navan',
-            'region' => 'Meath',
-            'postcode' => 'C15 XXXX',
-            'country_id' => 'IE',
-        ];
-
-        $this->validator->verifyAddress($address);
-        $this->validator->verifyAddress(array_merge($address, ['region' => 'Co. Meath']));
+        $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 200, 'region' => 'Meath']));
+        $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 200, 'region' => 'Co. Meath']));
+        $this->validator->verifyAddress(
+            self::addressInRegion('IE', ['region_id' => 200, 'region' => 'County Meath'])
+        );
 
         $this->assertSame(
             1,
             $this->apiCallCount(),
-            'A county/province rewritten by capture.js must not make the same address billable twice.'
+            'All three submissions name the same region record, so all three ask Loqate the identical '
+            . 'question: the address must be billed exactly once however often the region label text is '
+            . 'rewritten around that record.'
+        );
+        $this->assertCount(
+            1,
+            $this->verdictStore(),
+            'And they must share the one cache entry, rather than writing further entries that are never '
+            . 'read.'
         );
     }
 
     /**
-     * The checkout dead-end that the strict rejection key exists to prevent, and the
-     * most expensive failure mode of a cached rejection: a lost order.
+     * THE ACCEPTED LIMIT, pinned as behaviour so nobody has to trust a comment for it: on a
+     * country whose region is FREE TEXT - no region_id at all - re-spelling that text costs
+     * ONE extra billable verification.
      *
-     * A shopper submits an address with the WRONG county, Loqate rejects it, and the
-     * rejection is cached. Every later checkout call path replays that rejection for
-     * free (good - a rejection blocks checkout, so re-billing it is waste). But the
-     * moment the shopper fixes ONLY the county - the single field a rejection is most
-     * likely to be about, and the field the SUCCESS key deliberately ignores - the
-     * address must be sent to Loqate again. Were the rejection keyed on the lossy
-     * signature, the corrected address would hit the same key, be served the stale
-     * rejection with no API call, and the shopper could never get out of checkout for
-     * the rest of the session however often they corrected the county.
-     *
-     * The sequence continues in testRevertingToTheRejectedCountyReplaysTheCachedRejection()
-     * (revert to the rejected county) and
-     * testACountyVariantLoqateNeverRejectedStillPassesFromTheCachedSuccess() (the
-     * residual bypass that is deliberately kept), which together pin the ORDER the two
-     * keys are read in.
+     * This is the deliberate direction of the trade. The two submissions genuinely ask
+     * Loqate about different region text, so the second is verified and gets its OWN
+     * verdict; the price is one re-bill on a rare shape. The opposite direction - teaching
+     * the cache that two spellings name one place - buys that request back only while the
+     * guess is right, and whenever it is wrong it serves an address a verdict Loqate gave
+     * to a DIFFERENT place, which is a verify bypass on a typed address. A re-bill is
+     * recoverable; a bypass is not, so it is not attempted.
      */
-    public function testCorrectingOnlyTheCountyAfterARejectionIsVerifiedAgain(): void
+    public function testRespellingAFreeTextRegionCostsOneExtraVerificationAndBypassesNone(): void
     {
-        // Rejected first; accepted once the county is right.
+        $this->stubApiResponses([self::acceptedResponse(), self::rejectedResponse()]);
+
+        $accepted = $this->validator->verifyAddress(self::addressInRegion('IE', ['region' => 'Meath']));
+        $respelt = $this->validator->verifyAddress(self::addressInRegion('IE', ['region' => 'Co. Meath']));
+
+        $this->assertSame(['error' => false], $accepted, 'The first submission must be accepted off the wire.');
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'With no region record behind it, the region text IS the region Loqate is asked about, so '
+            . 're-spelling it asks a different question and costs one further verification. Accepted: a '
+            . 're-bill is the safe direction, because the alternative is serving an address a verdict '
+            . 'earned by a different place.'
+        );
+        $this->assertTrue(
+            $respelt['error'],
+            'And the re-spelt submission must carry ITS OWN verdict: whatever it costs, it must never be '
+            . 'answered with the verdict the other spelling earned.'
+        );
+    }
+
+    /**
+     * The checkout dead-end a cached rejection can cause, on the free-text region shape,
+     * and the most expensive failure mode this cache has: a lost order.
+     *
+     * A shopper submits an address whose region is wrong, Loqate rejects it, and the
+     * rejection is cached. Every later checkout call path replays that rejection for free
+     * (good - a rejection blocks checkout, so re-billing it is waste). But the moment the
+     * shopper edits the region, the address must be sent to Loqate again: it is a different
+     * address, so the recorded "no" no longer applies to it. An implementation that
+     * replayed the rejection anyway would leave the shopper unable to get out of checkout
+     * for the rest of the session however often they corrected the field.
+     *
+     * The sequence continues in
+     * testResubmittingTheExactAddressLoqateRejectedReplaysThatRejection().
+     */
+    public function testCorrectingAWrongFreeTextRegionAfterARejectionIsVerifiedAgain(): void
+    {
+        // Rejected first; accepted once the region is right.
         $this->stubApiResponses([self::rejectedResponse(), self::acceptedResponse()]);
 
-        $wrongCounty = [
-            'street' => ['12 Main Street'],
-            'city' => 'Navan',
-            'region' => 'Meath',
-            'postcode' => 'C15 XXXX',
-            'country_id' => 'IE',
-        ];
+        $wrongRegion = self::addressInRegion('IE', ['region' => 'Meath']);
 
         // (1) First submission: rejected off the wire.
-        $rejected = $this->validator->verifyAddress($wrongCounty);
+        $rejected = $this->validator->verifyAddress($wrongRegion);
 
         $this->assertSame(1, $this->apiCallCount(), 'The first submission must reach the API.');
         $this->assertTrue($rejected['error'], 'The address must be rejected.');
 
-        // (2) The identical address, county included, replayed by a later checkout
+        // (2) The identical address, region included, replayed by a later checkout
         // call path: served from the cache, still one billable request.
-        $replayed = $this->validator->verifyAddress($wrongCounty);
+        $replayed = $this->validator->verifyAddress($wrongRegion);
 
         $this->assertSame(
             1,
@@ -710,170 +792,538 @@ class ValidatorVerifyCacheTest extends TestCase
         $this->assertTrue($replayed['error'], 'The cached rejection must still reject the unchanged address.');
         $this->assertSame('The provided address is invalid.', (string)$replayed['message']);
 
-        // (3) ONLY the county corrected: this must be verified again and is free to
+        // (3) ONLY the region edited: this must be verified again and is free to
         // succeed, or the shopper is locked out of checkout for the whole session.
-        $corrected = $this->validator->verifyAddress(array_merge($wrongCounty, ['region' => 'Co. Meath']));
+        $corrected = $this->validator->verifyAddress(self::addressInRegion('IE', ['region' => 'Co. Meath']));
 
         $this->assertSame(
             2,
             $this->apiCallCount(),
-            'Correcting the county of a rejected address must trigger a fresh verification: '
-            . 'a rejection cached without the county is a permanent checkout dead-end.'
+            'Editing the region of a rejected address must trigger a fresh verification: a rejection that '
+            . 'outlives the address it was given for is a permanent checkout dead-end.'
         );
         $this->assertSame(
             ['error' => false],
             $corrected,
             'The corrected address must get the live verdict, not the cached rejection.'
         );
+
+        // (4) A region naming a different place again: Loqate has never judged this
+        // address in Kildare, so it must be asked.
+        $differentRegion = $this->validator->verifyAddress(self::addressInRegion('IE', ['region' => 'Kildare']));
+
+        $this->assertSame(
+            3,
+            $this->apiCallCount(),
+            'A region Loqate was never asked about must be verified in its own right, never answered by a '
+            . 'verdict earned for another region: that would put an address Loqate has never judged through '
+            . 'checkout.'
+        );
+        $this->assertSame(
+            ['error' => false],
+            $differentRegion,
+            'The differently-regioned address must get its own live verdict.'
+        );
     }
 
     /**
-     * The same dead-end guard for the other address shape checkout uses: the county
-     * arrives as a region_id that parseAddress() resolves through RegionFactory
-     * (Quote\Address and the admin grid both take this path), so the strict rejection
-     * key has to see the resolved name, not the raw id.
+     * I4 - CORRECTING A GENUINELY WRONG REGION CLEARS A CACHED REJECTION, on the shape
+     * checkout and the admin grid actually deliver: the region arrives as a region_id that
+     * parseAddress() resolves through RegionFactory.
+     *
+     * Three claims in one sequence, and the middle one is what stops the other two being
+     * satisfied by a cache that simply never hits:
+     *  - the rejected address is billed once;
+     *  - re-submitting it unchanged replays that rejection for free;
+     *  - picking a different region record is a different address, so it is verified again
+     *    and is free to be accepted. Otherwise the shopper cannot escape checkout by
+     *    correcting the one field the rejection was about.
      */
-    public function testCorrectingOnlyTheRegionIdAfterARejectionIsVerifiedAgain(): void
+    public function testCorrectingAGenuinelyWrongRegionClearsACachedRejection(): void
     {
         $this->stubApiResponses([self::rejectedResponse(), self::acceptedResponse()]);
-        $this->regionNames = [100 => 'Meath', 101 => 'Louth'];
+        $this->regionNames = self::REGION_DIRECTORY;
 
-        $address = [
-            'street' => ['12 Main Street'],
-            'city' => 'Navan',
-            'postcode' => 'C15 XXXX',
-            'country_id' => 'IE',
-        ];
-
-        $rejected = $this->validator->verifyAddress(array_merge($address, ['region_id' => 100]));
+        $rejected = $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 200]));
         $this->assertSame(1, $this->apiCallCount(), 'The first submission must reach the API.');
-        $this->assertTrue($rejected['error']);
+        $this->assertTrue($rejected['error'], 'The address must be rejected off the wire.');
 
-        $replayed = $this->validator->verifyAddress(array_merge($address, ['region_id' => 100]));
+        $replayed = $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 200]));
         $this->assertSame(
             1,
             $this->apiCallCount(),
-            'An unchanged rejected address must be replayed from the cache.'
+            'An unchanged rejected address must be replayed from the cache rather than re-billed.'
         );
-        $this->assertTrue($replayed['error']);
+        $this->assertTrue($replayed['error'], 'The replayed verdict must still be the rejection.');
 
-        $corrected = $this->validator->verifyAddress(array_merge($address, ['region_id' => 101]));
+        $corrected = $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 55]));
 
         $this->assertSame(
             2,
             $this->apiCallCount(),
-            'Picking a different region_id after a rejection must trigger a fresh verification.'
+            'Picking a different region record after a rejection must trigger a fresh billable '
+            . 'verification: the recorded "no" was given for another address, and a shopper who corrects '
+            . 'the region must not be held in checkout by it.'
         );
-        $this->assertSame(['error' => false], $corrected);
+        $this->assertSame(
+            ['error' => false],
+            $corrected,
+            'And the corrected address must get its own live verdict, not the cached rejection.'
+        );
     }
 
     /**
-     * The read ORDER of the two keys, which nothing else in this file pins.
+     * The guarantee for the address a shopper is most likely to submit next: the one Loqate
+     * has just said no to.
      *
-     * verifyAddress() reads the strict (rejection) key BEFORE the lossy (success) one.
-     * Both are plain cache reads, so the order costs nothing, and exactly one case
-     * changes: a shopper who is rejected, corrects the county, is accepted, and then
-     * REVERTS to the county Loqate explicitly rejected. Strict-read-first hands back
-     * that recorded rejection; lossy-read-first would hand back the county-agnostic
-     * success and let an address Loqate said no to through checkout.
-     *
-     * Flipping the two reads in verifyAddress() leaves every other test in this file
-     * green, so this test is what makes the order load-bearing. Neither variant issues
-     * a further billable request - the difference is purely which cached verdict wins.
+     * A shopper is rejected, edits the region, is accepted, and then puts the original
+     * region back. That third submission is byte-for-byte the address Loqate REJECTED, so it
+     * must be answered with that rejection - and answered from the cache, because re-billing
+     * an address Loqate has already judged is the waste this whole cache exists to remove.
+     * Neither half is optional: handing it the OTHER submission's "valid" would put an
+     * address Loqate said no to through checkout, and re-billing it would be paying twice
+     * for one answer.
      */
-    public function testRevertingToTheRejectedCountyReplaysTheCachedRejection(): void
+    public function testResubmittingTheExactAddressLoqateRejectedReplaysThatRejection(): void
     {
         $this->stubApiResponses([self::rejectedResponse(), self::acceptedResponse()]);
 
-        $wrongCounty = [
-            'street' => ['12 Main Street'],
-            'city' => 'Navan',
-            'region' => 'Meath',
-            'postcode' => 'C15 XXXX',
-            'country_id' => 'IE',
-        ];
-        $rightCounty = array_merge($wrongCounty, ['region' => 'Co. Meath']);
+        $rejectedRegion = self::addressInRegion('IE', ['region' => 'Meath']);
+        $acceptedRegion = self::addressInRegion('IE', ['region' => 'Co. Meath']);
 
-        // (1) Rejected with the wrong county, (2) accepted once it is corrected.
-        $this->assertTrue($this->validator->verifyAddress($wrongCounty)['error']);
-        $this->assertSame(['error' => false], $this->validator->verifyAddress($rightCounty));
+        // (1) Rejected with the first region, (2) accepted with the second.
+        $this->assertTrue($this->validator->verifyAddress($rejectedRegion)['error']);
+        $this->assertSame(['error' => false], $this->validator->verifyAddress($acceptedRegion));
         $this->assertSame(2, $this->apiCallCount(), 'Both submissions must have reached the API.');
 
-        // (3) Back to the county Loqate explicitly rejected.
-        $reverted = $this->validator->verifyAddress($wrongCounty);
+        // (3) Back to the exact address Loqate rejected.
+        $reverted = $this->validator->verifyAddress($rejectedRegion);
 
         $this->assertTrue(
             $reverted['error'],
-            'Reverting to a county Loqate explicitly REJECTED must replay that rejection: the strict key '
-            . 'is read before the county-agnostic success key, so the recorded "no" wins.'
+            'Re-submitting the exact address Loqate REJECTED must be answered with that rejection: any '
+            . 'other answer lets an address Loqate said no to through checkout.'
         );
         $this->assertSame('The provided address is invalid.', (string)$reverted['message']);
         $this->assertSame(
             2,
             $this->apiCallCount(),
-            'The rejection comes from the strict cache entry, so reverting must not cost a billable request.'
+            'And it must be answered from the cache: an address Loqate has already judged must never be '
+            . 'billed a second time.'
         );
     }
 
     /**
-     * The deliberately-accepted residual bypass, and the reason the SUCCESS key stays
-     * lossy (LOQ-16969): once ANY county variant of an address is accepted, every county
-     * variant Loqate has NOT explicitly rejected also passes from the cache for the rest
-     * of the session.
+     * The exact width of a cached success: it is replayed for the address that earned it and
+     * for nothing else.
      *
-     * This is a trade-off, not an oversight. Keying successes strictly would re-bill
-     * exactly what this ticket fixes (capture.js rewrites "Meath" to "Co. Meath",
-     * parseAddress() re-resolves a region_id to a name), and the pre-existing
-     * captured_addresses guard has always behaved this way. It is pinned here so that
-     * anyone tightening it does so knowingly, and so the scope of the bypass stays
-     * exactly this: variants Loqate never rejected, since a rejected one is caught by
-     * the strict read - see testRevertingToTheRejectedCountyReplaysTheCachedRejection().
+     * Asserted as one sequence over the region axis, because that is where the width is
+     * decided. A submission naming the SAME region record as the accepted one - whatever
+     * text happens to be in the region field - asks Loqate the identical question and is
+     * served the success for free. A submission naming a DIFFERENT region record asks a
+     * different question, so it is verified in its own right; serving it the cached "valid"
+     * would put an address Loqate has never judged through checkout, which is a verify
+     * bypass on a typed address (strictly wider than the captured-address bypass, which only
+     * ever covers addresses the Loqate lookup itself authored).
      */
-    public function testACountyVariantLoqateNeverRejectedStillPassesFromTheCachedSuccess(): void
+    public function testACachedSuccessIsReplayedForTheVerifiedRegionAndForNoOther(): void
     {
         $this->stubApiResponses([self::rejectedResponse(), self::acceptedResponse()]);
+        $this->regionNames = self::REGION_DIRECTORY;
 
-        $wrongCounty = [
-            'street' => ['12 Main Street'],
-            'city' => 'Navan',
-            'region' => 'Meath',
-            'postcode' => 'C15 XXXX',
-            'country_id' => 'IE',
-        ];
-
-        $this->assertTrue($this->validator->verifyAddress($wrongCounty)['error']);
+        $this->assertTrue($this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 55]))['error']);
         $this->assertSame(
             ['error' => false],
-            $this->validator->verifyAddress(array_merge($wrongCounty, ['region' => 'Co. Meath']))
+            $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 200]))
         );
         $this->assertSame(2, $this->apiCallCount(), 'Both submissions must have reached the API.');
 
-        // A THIRD county spelling, which Loqate has never been asked about: it is served
-        // the cached success, because the success key excludes the county.
-        $neverJudged = $this->validator->verifyAddress(array_merge($wrongCounty, ['region' => 'County Meath']));
+        // The accepted region record again, with the region label text rewritten around it
+        // the way the Capture front end rewrites it: the same question, already answered.
+        $sameRegionRelabelled = $this->validator->verifyAddress(
+            self::addressInRegion('IE', ['region_id' => 200, 'region' => 'County Meath'])
+        );
 
         $this->assertSame(
             ['error' => false],
-            $neverJudged,
-            'A county variant Loqate never rejected is deliberately served the cached success: the success '
-            . 'key excludes the county so a rewritten county cannot re-bill the same address.'
+            $sameRegionRelabelled,
+            'A submission naming the region record that was accepted must be served that success: it is '
+            . 'the address Loqate already approved, and re-billing it is the waste this cache removes.'
         );
         $this->assertSame(
             2,
             $this->apiCallCount(),
-            'The accepted trade-off is that this costs no further billable request either.'
+            'Re-submitting the accepted region must cost no further billable request.'
+        );
+
+        // A region record Loqate has never been asked about.
+        $differentRegion = $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 101]));
+
+        $this->assertSame(
+            3,
+            $this->apiCallCount(),
+            'A region Loqate was never asked about must be verified in its own right: serving it the '
+            . 'verdict another region earned puts an address Loqate has never judged through checkout.'
+        );
+        $this->assertSame(
+            ['error' => false],
+            $differentRegion,
+            'The differently-regioned address must get its own live verdict.'
         );
     }
 
     /**
-     * Same address, but Magento resolves a different region record ("Dublin" vs
-     * "Dublin 1"). Region is resolved via RegionFactory into Address4, which the
-     * signature deliberately excludes, so this must not re-bill either.
+     * I1 - THE WHOLE CONTRACT ON THE REGION AXIS, AS A TABLE: two submissions of one
+     * address that differ only in how the region is given share a billable verification IF
+     * AND ONLY IF they ask Loqate about the same region.
+     *
+     * Every row's justification is an EXTERNAL fact - which region RECORD of the install's
+     * directory each submission resolves to, or, where no record is named, what region text
+     * reaches the request - and never a statement about how the module is written. The
+     * external fact is not merely asserted in prose either: before the two submissions are
+     * made against one shopper, each address is sent on a throwaway shopper of its own and
+     * the region that actually reached Loqate is compared, so a row whose premise stops
+     * holding fails on its own precondition instead of quietly testing something else.
+     *
+     * @param array $firstRegion Magento region keys of the first submission ('region',
+     *                           'region_id'), or [] to name no region at all.
+     * @param array $secondRegion Magento region keys of the second submission.
+     * @param int $expectedCalls 1 when both ask about the same region, 2 when they do not.
+     * @param string $resolvesTo The external fact: which region each submission names.
      */
-    public function testDifferentRegionIdDoesNotTriggerASecondBillableApiCall(): void
-    {
+    #[DataProvider('regionAxisProvider')]
+    public function testTwoSubmissionsShareAVerdictOnlyWhenTheyResolveToTheSameRegion(
+        array $firstRegion,
+        array $secondRegion,
+        int $expectedCalls,
+        string $resolvesTo
+    ): void {
+        $this->regionNames = self::REGION_DIRECTORY;
+        $first = self::addressInRegion('IE', $firstRegion);
+        $second = self::addressInRegion('IE', $secondRegion);
+
+        // The row's premise, established on the wire rather than claimed: do these two
+        // submissions ask Loqate about the same region or about different ones? Compared
+        // the way any address field is compared - trivial reformatting of a value is not a
+        // different value, see testBuildAddressSignatureNormalisesCaseAndWhitespace().
+        $sentFirst = self::asComparableRegion($this->regionSentToLoqate($first));
+        $sentSecond = self::asComparableRegion($this->regionSentToLoqate($second));
+        if ($expectedCalls === 1) {
+            $this->assertSame(
+                $sentFirst,
+                $sentSecond,
+                sprintf('Precondition of this row: %s, so both submissions send Loqate one region.', $resolvesTo)
+            );
+        } else {
+            $this->assertNotSame(
+                $sentFirst,
+                $sentSecond,
+                sprintf('Precondition of this row: %s, so the two submissions send Loqate '
+                    . 'different regions.', $resolvesTo)
+            );
+        }
+
         $this->stubApiResponses([self::acceptedResponse()]);
-        $this->regionNames = [100 => 'Dublin', 101 => 'Dublin 1'];
+
+        $this->validator->verifyAddress($first);
+        $this->validator->verifyAddress($second);
+
+        $this->assertSame(
+            $expectedCalls,
+            $this->apiCallCount(),
+            sprintf(
+                'Two submissions must share one billable verification if and only if they ask Loqate about '
+                . 'the same address. Here %s, so the second submission must %s.',
+                $resolvesTo,
+                $expectedCalls === 1
+                    ? 'be answered from the first verdict without a further billable request - paying twice '
+                        . 'for one answer is the over-billing this cache exists to remove'
+                    : 'be verified in its own right - answering it with the first verdict would put an '
+                        . 'address Loqate has never judged through checkout'
+            )
+        );
+        $this->assertCount(
+            $expectedCalls,
+            $this->verdictStore(),
+            'One cache entry per address Loqate was actually asked about, so submissions that share a '
+            . 'verdict must share the entry rather than writing a second one that is never read.'
+        );
+    }
+
+    /**
+     * One row per way the region can arrive, justified by which region each submission
+     * names and by nothing else.
+     *
+     * @return array<string, array{0: array, 1: array, 2: int, 3: string}>
+     */
+    public static function regionAxisProvider(): array
+    {
+        return [
+            // Same region record, region label text churning around it. This is the
+            // reported regression: the Capture front end sets both region fields from
+            // ProvinceName, so a real churn carries the region_id with it.
+            'one region record, label text rewritten' => [
+                ['region_id' => 200, 'region' => 'Meath'],
+                ['region_id' => 200, 'region' => 'Co. Meath'],
+                1,
+                'both submissions name directory region 200, which is Meath',
+            ],
+            'one region record, a third label spelling' => [
+                ['region_id' => 200, 'region' => 'County Meath'],
+                ['region_id' => 200, 'region' => 'Meath'],
+                1,
+                'both submissions name directory region 200, which is Meath',
+            ],
+            'one region record, no label text at all on one side' => [
+                ['region_id' => 200],
+                ['region_id' => 200, 'region' => 'Co. Meath'],
+                1,
+                'both submissions name directory region 200, which is Meath',
+            ],
+            // The cross-call-path case: the dropdown and the typed field can name one
+            // place, which is why the region is keyed by the name it resolves to.
+            'a region record and the same place typed as free text' => [
+                ['region_id' => 200],
+                ['region' => 'Meath'],
+                1,
+                'directory region 200 IS Meath, so a shopper who picked it and one who typed it name one '
+                    . 'place',
+            ],
+            // An empty region_id names no record, so the typed text stands - the shape the
+            // customer-account and admin address POSTs actually deliver.
+            'an empty region_id beside the same label text' => [
+                ['region_id' => '', 'region' => 'Meath'],
+                ['region' => 'Meath'],
+                1,
+                'neither submission names a directory region, and both give the region as Meath',
+            ],
+            'no region record, identical label text' => [
+                ['region' => 'Meath'],
+                ['region' => 'Meath'],
+                1,
+                'neither submission names a directory region, and both give the region as Meath',
+            ],
+            'no region record, label text reformatted only' => [
+                ['region' => 'Meath'],
+                ['region' => '  meath '],
+                1,
+                'neither submission names a directory region, and both give the region as Meath, one of '
+                    . 'them re-cased and padded by the form',
+            ],
+
+            // Different regions. Each of these is a different question for Loqate.
+            'two different region records' => [
+                ['region_id' => 200],
+                ['region_id' => 55],
+                2,
+                'directory region 200 is Meath and 55 is Kildare, two different places',
+            ],
+            'no region record, different label text' => [
+                ['region' => 'Meath'],
+                ['region' => 'Co. Meath'],
+                2,
+                'neither submission names a directory region, so the region text is what Loqate is asked '
+                    . 'about, and the two texts differ',
+            ],
+            'a region record against no region at all' => [
+                [],
+                ['region_id' => 200],
+                2,
+                'the first submission names no region and the second names directory region 200, Meath',
+            ],
+            'the same label text with and without a region record behind it' => [
+                ['region_id' => 55, 'region' => 'Meath'],
+                ['region' => 'Meath'],
+                2,
+                'the first submission names directory region 55, Kildare, and the second names no region '
+                    . 'record so its typed Meath stands',
+            ],
+        ];
+    }
+
+    /**
+     * I2 - A REGION THAT WAS NEVER VERIFIED IS NEVER SERVED ANOTHER REGION'S SUCCESS.
+     *
+     * After one region of an address is accepted, an address in a different region must
+     * reach Loqate and come back with ITS OWN verdict - including a rejection.
+     *
+     * Asserted on the verdict as well as on the call count, because the call count alone
+     * would still pass an implementation that re-billed the address and then handed back
+     * the stale cached "valid" anyway. That failure is the expensive one: the address
+     * reaches checkout carrying a verdict Loqate never gave it, on a TYPED address, which
+     * is strictly wider than the captured-address bypass - that one only ever covers
+     * addresses picked from the Loqate lookup, i.e. addresses Loqate itself authored.
+     */
+    public function testARegionThatWasNeverVerifiedIsNeverServedAnotherRegionsSuccess(): void
+    {
+        $this->stubApiResponses([self::acceptedResponse(), self::rejectedResponse()]);
+        $this->regionNames = self::REGION_DIRECTORY;
+
+        $accepted = $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 200]));
+        $otherRegion = $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => 55]));
+
+        $this->assertSame(['error' => false], $accepted, 'The first region must be accepted off the wire.');
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'An address in a region Loqate was never asked about must be sent to Loqate: it is a different '
+            . 'address, and no verdict has ever been given for it.'
+        );
+        $this->assertTrue(
+            $otherRegion['error'],
+            'And it must carry ITS OWN verdict. Being handed the other region\'s "valid" is the failure '
+            . 'this cache must never produce: the address reaches checkout with a verdict Loqate never '
+            . 'gave it.'
+        );
+        $this->assertSame(
+            'The provided address is invalid.',
+            (string)$otherRegion['message'],
+            'And it must reject with the standard shopper-facing message.'
+        );
+    }
+
+    /**
+     * I3 - THE TRIPWIRE. Two different region records must each be verified in their own
+     * right however alike their labels read.
+     *
+     * The pairs below are exactly the pairs a label-based collapsing rule merges - a rule
+     * that strips a leading "County ", or prefixes "Co. ", or rewrites a bare "Dublin" to
+     * "Dublin 1", folds each of these two pairs onto one verdict. If such a rule is ever
+     * (re)introduced anywhere between the address and the cache key, this test is what goes
+     * red.
+     *
+     * Why they must stay apart is not a matter of taste: these are separate rows of the
+     * install's region directory, so a shopper who picks one has picked a different record
+     * from a shopper who picks the other, and each submission puts different region text on
+     * the wire - which the test asserts from the recorded payloads rather than claiming.
+     * Loqate is being asked two questions and must answer both. Merging them buys back one
+     * billable request while the guess is right and serves an address a verdict earned by a
+     * different place whenever it is wrong; keeping them apart costs at most one request.
+     *
+     * @param int $firstRegionId Directory region the first submission names.
+     * @param int $secondRegionId Directory region the second submission names.
+     * @param string $records The external fact: what those two directory rows are.
+     */
+    #[DataProvider('similarlyLabelledRegionPairProvider')]
+    public function testRegionRecordsWhoseLabelsReadAlikeAreStillEachVerified(
+        int $firstRegionId,
+        int $secondRegionId,
+        string $records
+    ): void {
+        $this->stubApiResponses([self::acceptedResponse(), self::rejectedResponse()]);
+        $this->regionNames = self::REGION_DIRECTORY;
+
+        $accepted = $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => $firstRegionId]));
+        $second = $this->validator->verifyAddress(self::addressInRegion('IE', ['region_id' => $secondRegionId]));
+
+        $this->assertSame(['error' => false], $accepted, 'The first submission must be accepted off the wire.');
+        $this->assertNotSame(
+            $this->apiRequests[0]['Addresses'][0]['Address4'] ?? null,
+            $this->apiRequests[1]['Addresses'][0]['Address4'] ?? null,
+            sprintf(
+                'Precondition, taken from the payloads themselves: %s, so the two submissions really do '
+                . 'ask Loqate about different regions.',
+                $records
+            )
+        );
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            sprintf(
+                '%s. Two different places are two different addresses, so each must be verified and '
+                . 'billed in its own right. Serving the second one the first one\'s verdict is a verify '
+                . 'bypass on a typed address; verifying it costs at most one request.',
+                $records
+            )
+        );
+        $this->assertTrue(
+            $second['error'],
+            'And the second submission must carry its own verdict, not the acceptance the other region '
+            . 'earned.'
+        );
+    }
+
+    /**
+     * The pairs a label-based collapsing rule merges, and which must therefore stay apart.
+     *
+     * @return array<string, array{0: int, 1: int, 2: string}>
+     */
+    public static function similarlyLabelledRegionPairProvider(): array
+    {
+        return [
+            'a city postal district and the county around it' => [
+                100,
+                101,
+                'directory region 100 is Dublin 1, a city postal district, and 101 is County Dublin, the '
+                    . 'administrative county around it',
+            ],
+            'two directory rows whose labels differ by an abbreviation' => [
+                200,
+                201,
+                'directory regions 200 and 201 are two separate rows of the install\'s region table, '
+                    . 'labelled Meath and Co. Meath',
+            ],
+        ];
+    }
+
+    /**
+     * A verdict must not outlive the key scheme it was looked up under. A session can span a
+     * deploy that changes how the key is built, and a payload written before it names an
+     * address that cannot be recovered from the key any more - so it is discarded and the
+     * address is verified again rather than answered by it.
+     *
+     * The cost is one re-verification per stale entry, once, which is the safe direction; the
+     * alternative is replaying a verdict that may belong to a different address entirely.
+     */
+    public function testACachedVerdictWrittenUnderAnEarlierKeySchemeIsDiscardedRatherThanReplayed(): void
+    {
+        $this->stubApiResponses([self::acceptedResponse(), self::rejectedResponse()]);
+        $schemaVersion = $this->verifyKeySchemaVersion();
+
+        $this->validator->verifyAddress(self::ADDRESS);
+        $store = $this->verdictStore();
+        $this->assertCount(1, $this->verdictStore(), 'The verdict must be cached normally first.');
+
+        $key = (string)array_key_first($store);
+        $payload = json_decode((string)$store[$key], true);
+        $this->assertIsArray($payload, 'The cached verdict must be readable as a payload.');
+        $this->assertContains(
+            $schemaVersion,
+            array_values($payload),
+            'A cached verdict must record the version of the key scheme it was written under, or a verdict '
+            . 'from before a key change cannot be told apart from one written by this deploy.'
+        );
+
+        // The same verdict as written by a deploy whose key scheme was one version older.
+        $store[$key] = json_encode(array_map(
+            static fn ($value) => $value === $schemaVersion ? $schemaVersion - 1 : $value,
+            $payload
+        ));
+        $this->sessionStore[self::VERIFY_CACHE_SESSION_KEY] = $store;
+
+        $result = $this->validator->verifyAddress(self::ADDRESS);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount(),
+            'A verdict stamped with another key scheme must be discarded and the address verified again: '
+            . 'the key it is filed under no longer names the same address.'
+        );
+        $this->assertTrue(
+            $result['error'],
+            'And the live verdict must be returned, so the stale entry can be seen not to have answered '
+            . 'the lookup.'
+        );
+    }
+
+    /**
+     * Two different region records on an otherwise identical address are two different
+     * addresses: each must be verified, and each gets its own verdict.
+     */
+    public function testADifferentRegionIdIsVerifiedInItsOwnRight(): void
+    {
+        $this->stubApiResponses([self::acceptedResponse(), self::rejectedResponse()]);
+        $this->regionNames = self::REGION_DIRECTORY;
 
         $address = [
             'street' => ['4 O\'Connell Street'],
@@ -882,14 +1332,17 @@ class ValidatorVerifyCacheTest extends TestCase
             'country_id' => 'IE',
         ];
 
-        $this->validator->verifyAddress(array_merge($address, ['region_id' => 100]));
-        $this->validator->verifyAddress(array_merge($address, ['region_id' => 101]));
+        $accepted = $this->validator->verifyAddress(array_merge($address, ['region_id' => 100]));
+        $other = $this->validator->verifyAddress(array_merge($address, ['region_id' => 101]));
 
+        $this->assertSame(['error' => false], $accepted, 'The first region must be accepted off the wire.');
         $this->assertSame(
-            1,
+            2,
             $this->apiCallCount(),
-            'A different region_id on an otherwise identical address must not make it billable twice.'
+            'Picking a different region on an otherwise identical address asks Loqate about a different '
+            . 'place, so it must be verified rather than answered from the first verdict.'
         );
+        $this->assertTrue($other['error'], 'And the second region must get its own verdict.');
     }
 
     /**
@@ -1021,66 +1474,76 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
-     * The STRUCTURAL half of the invariant the whole scheme rests on: the strict
-     * (rejection) key must project EVERY field parseAddress() sends to Loqate - every
-     * value of Validator::ADDRESS_MAPPING - and the lossy (success) key must be exactly
-     * that list minus the county.
+     * I5 - THE STRUCTURAL COVERAGE GATE: the ONE cache key must project EVERY field
+     * parseAddress() sends to Loqate, that is every value of Validator::ADDRESS_MAPPING.
+     *
+     * A verdict may only ever be replayed for the address Loqate actually judged, so a
+     * field that reaches the request but not the key breaks the contract in both
+     * directions: editing it would replay a wrong "invalid" the shopper cannot clear (the
+     * checkout dead-end) or a wrong "valid" that puts an unverified address through
+     * checkout. There is one key, so there is one list and one rule for successes and
+     * rejections alike.
      *
      * READ THIS BEFORE TRUSTING IT. This test cannot catch a field being ADDED to
-     * ADDRESS_MAPPING, and it is not claimed to: strictSignatureFields() and
-     * verifySignatureFields() DERIVE their lists from ADDRESS_MAPPING, so a new mapping
-     * extends both keys by construction and the sets stay equal. Adding
-     * 'company' => 'Company' to ADDRESS_MAPPING leaves this test green (verified with
-     * that exact mutant). What it does pin is the derivation itself: hand-writing either
-     * list again, dropping a field from one of them, or naming a COUNTY_FIELD that is not
-     * in ADDRESS_MAPPING at all, all fail here. The BEHAVIOURAL defence - that a mapped
-     * field genuinely reaches the key and genuinely costs a second billable request when
-     * it changes - is
-     * testEditingAnyFieldSentToLoqateAfterARejectionIsVerifiedAgain() and
-     * testEditingAnyFieldSentToLoqateExceptTheCountyIsVerifiedAgainAfterASuccess(),
-     * which iterate ADDRESS_MAPPING and fail on an unpinned new field.
+     * ADDRESS_MAPPING, and it is not claimed to: the list is DERIVED from ADDRESS_MAPPING,
+     * so a new mapping extends the key by construction and the two sets stay equal. Adding
+     * 'company' => 'Company' leaves this test green; what fails then is the per-field pair
+     * below, which has no fixture for it. What this test does pin is the derivation itself:
+     * hand-writing the list again, dropping a field from it, or naming a COUNTY_FIELD that
+     * is not in ADDRESS_MAPPING at all, all fail here - as does a key builder that stops
+     * distinguishing two addresses by their region, or one that keys an address carrying
+     * nothing identifiable at all.
      */
-    public function testStrictCacheKeyProjectsEveryFieldSentToLoqate(): void
+    public function testTheVerifyCacheKeyProjectsEveryFieldSentToLoqate(): void
     {
         $sentToLoqate = array_values(Validator::ADDRESS_MAPPING);
-        $county = (string)$this->privateConstant('COUNTY_FIELD');
-        $strict = $this->invokePrivate('strictSignatureFields', []);
-        $lossy = $this->invokePrivate('verifySignatureFields', []);
+        $region = (string)$this->privateConstant('COUNTY_FIELD');
+        $projected = $this->invokePrivate('verifyCacheSignatureFields', []);
 
         $this->assertContains(
-            $county,
+            $region,
             $sentToLoqate,
-            'COUNTY_FIELD must be one of the fields parseAddress() actually sends, or the strict key '
-            . 'appends a segment Loqate never sees and the lossy key drops nothing real.'
+            'COUNTY_FIELD must name one of the fields parseAddress() actually sends, or the key carries a '
+            . 'segment Loqate never sees.'
         );
         $this->assertEqualsCanonicalizing(
             $sentToLoqate,
-            $strict,
-            'The STRICT (rejection) key must project every field sent to Loqate: a rejection may only be '
-            . 'replayed for the exact address Loqate judged. A field that reaches the request but not this '
-            . 'list would make editing it replay a stale verdict - a wrong "invalid" the shopper cannot '
-            . 'clear (the checkout dead-end) or a wrong "valid" that lets an unverified address through.'
-        );
-        $this->assertEqualsCanonicalizing(
-            array_values(array_diff($sentToLoqate, [$county])),
-            $lossy,
-            'The LOSSY (success) key must be exactly the strict key minus the county: it may ignore the '
-            . 'churning county (that is the LOQ-16969 fix) and nothing else.'
+            $projected,
+            'The verify cache key must project every field sent to Loqate: a verdict may only be replayed '
+            . 'for the exact address Loqate judged. A field that reaches the request but not this list '
+            . 'would make editing it replay a stale verdict - a wrong "invalid" the shopper cannot clear '
+            . '(the checkout dead-end) or a wrong "valid" that lets an unverified address through.'
         );
         $this->assertSame(
-            [$county],
-            array_values(array_diff($strict, $lossy)),
-            'The county must be the ONLY field the two key families differ by.'
-        );
-        $this->assertSame(
-            [],
-            array_values(array_diff($lossy, $strict)),
-            'The lossy key must not project anything the strict key does not.'
-        );
-        $this->assertSame(
-            count($strict),
-            count(array_unique($strict)),
+            count($projected),
+            count(array_unique($projected)),
             'No field may appear twice in the key: a duplicated segment is dead weight in the session payload.'
+        );
+
+        // ...and the one key builder really is built over that list: two addresses that
+        // differ only in the region get different keys, and an address with nothing
+        // identifiable in it gets none at all.
+        $parsed = [
+            'Address' => '1 High St, Flat 2',
+            'Address1' => '1 High St',
+            'Address2' => 'Flat 2',
+            'Address3' => 'London',
+            'Address4' => 'Greater London',
+            'PostalCode' => 'SW1A 1AA',
+            'Country' => 'GB',
+        ];
+
+        $this->assertNotSame(
+            $this->invokePrivate('buildVerifyCacheSignature', [$parsed]),
+            $this->invokePrivate('buildVerifyCacheSignature', [array_merge($parsed, ['Address4' => 'Berkshire'])]),
+            'Two addresses in different regions must not share a key: one of them would be answered with a '
+            . 'verdict Loqate gave the other.'
+        );
+        $this->assertSame(
+            '',
+            $this->invokePrivate('buildVerifyCacheSignature', [['Address' => '', 'Address4' => 'Greater London']]),
+            'An address with nothing identifiable in it must have no key at all, so it is neither cached '
+            . 'nor served another address\'s verdict.'
         );
     }
 
@@ -1091,11 +1554,16 @@ class ValidatorVerifyCacheTest extends TestCase
      *
      * Driven from Validator::ADDRESS_MAPPING itself and through the public
      * verifyAddress(), so it pins the two things that actually matter and that the
-     * structural test above cannot see: that the field reaches the strict cache KEY, and
+     * structural test above cannot see: that the field reaches the cache KEY, and
      * that a change to it costs a second BILLABLE call rather than replaying the
      * rejection. A field added to ADDRESS_MAPPING with no fixture here fails outright
      * (that is the point: adding 'company' => 'Company' must not be able to leave the
      * suite green), and a field left out of the key fails on the call count.
+     *
+     * Its twin, testEditingAnyFieldSentToLoqateIsVerifiedAgainAfterASuccess(), asserts the
+     * SAME guarantee after an acceptance. There is one key, so no field is treated
+     * differently on the two sides and neither test is redundant: they pin the two verdicts
+     * a stale replay could serve.
      *
      * @param string $magentoField Magento address key, e.g. 'postcode'.
      * @param string $loqateField Loqate request field it is mapped onto, e.g. 'PostalCode'.
@@ -1124,7 +1592,7 @@ class ValidatorVerifyCacheTest extends TestCase
             $this->apiCallCount(),
             sprintf(
                 'Editing "%s" (sent to Loqate as %s) after a rejection must trigger a fresh verification: '
-                . 'the STRICT key must project every field Loqate judged, or the shopper is served the stale '
+                . 'the cache key must project every field Loqate judged, or the shopper is served the stale '
                 . 'rejection and can never get out of checkout however often they correct that field.',
                 $magentoField,
                 $loqateField
@@ -1138,24 +1606,27 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
-     * The mirror image on the success path: for every field EXCEPT the county, editing it
+     * The mirror image on the success path: for EVERY field sent to Loqate, editing it
      * after an acceptance must be verified again, or an unverified address is smuggled
      * past checkout on another address's "valid".
      *
-     * The county is the one deliberate exception (the LOQ-16969 trade-off) and is asserted
-     * as such here rather than skipped, so the exception stays exactly one field wide -
-     * anything else falling out of the lossy key fails.
+     * NO FIELD IS EXEMPT, the region included: an address in a different region is a
+     * different address and gets its own verdict. What is NOT an edit is the region LABEL
+     * churning while the region record stays put, which asks Loqate the identical question
+     * and is pinned where it belongs, in
+     * testRelabellingTheRegionAroundAFixedRegionIdIsBilledOnce(). This test's region
+     * fixture ("Greater London" -> "Berkshire") is deliberately a different place rather
+     * than a re-spelling; see self::FIELD_EDIT_FIXTURES.
      *
      * @param string $magentoField Magento address key, e.g. 'postcode'.
      * @param string $loqateField Loqate request field it is mapped onto, e.g. 'PostalCode'.
      */
     #[DataProvider('fieldSentToLoqateProvider')]
-    public function testEditingAnyFieldSentToLoqateExceptTheCountyIsVerifiedAgainAfterASuccess(
+    public function testEditingAnyFieldSentToLoqateIsVerifiedAgainAfterASuccess(
         string $magentoField,
         string $loqateField
     ): void {
         [$base, $edited] = $this->mappedFieldFixture($magentoField, $loqateField);
-        $isCounty = $loqateField === (string)$this->privateConstant('COUNTY_FIELD');
 
         $this->assertEditChangesTheLoqateRequest($base, $edited, $loqateField);
 
@@ -1166,28 +1637,13 @@ class ValidatorVerifyCacheTest extends TestCase
 
         $this->validator->verifyAddress($edited);
 
-        if ($isCounty) {
-            $this->assertSame(
-                1,
-                $this->apiCallCount(),
-                sprintf(
-                    'The county (%s) is the ONE field the success key deliberately ignores, because '
-                    . 'capture.js and parseAddress() both rewrite it - re-billing that churn is the defect '
-                    . 'LOQ-16969 fixes. Tightening this is tracked as LOQ-16979.',
-                    $loqateField
-                )
-            );
-
-            return;
-        }
-
         $this->assertSame(
             2,
             $this->apiCallCount(),
             sprintf(
-                'Editing "%s" (sent to Loqate as %s) must be verified again: the LOSSY key must project '
-                . 'every field sent to Loqate except the county, or a genuinely different address is served '
-                . 'this address\'s "valid" and reaches checkout unverified.',
+                'Editing "%s" (sent to Loqate as %s) must be verified again: the cache key must project '
+                . 'every field sent to Loqate - the region included - or a genuinely different address is '
+                . 'served this address\'s "valid" and reaches checkout unverified.',
                 $magentoField,
                 $loqateField
             )
@@ -1312,9 +1768,8 @@ class ValidatorVerifyCacheTest extends TestCase
             $store,
             'Once the retry succeeds, its verdict must be cached like any other success.'
         );
-        $this->assertSame(
-            ['error' => false],
-            json_decode((string)reset($store), true),
+        $this->assertFalse(
+            json_decode((string)reset($store), true)['error'] ?? null,
             'The cached entry must be the successful verdict from the retry.'
         );
 
@@ -1654,14 +2109,19 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
-     * The region is excluded from the dedup KEY, not from the REQUEST: Loqate needs
-     * the county to verify the address, and an "optimisation" that dropped it from the
-     * payload along with the key would silently degrade every verification.
+     * The region is sent to Loqate exactly as Magento holds it. Loqate needs it in order to
+     * verify the address at all, so an "optimisation" that pushed a rewritten form - or
+     * nothing at all - into the PAYLOAD rather than only into the cache key would silently
+     * degrade every verification.
+     *
+     * The region is excluded only from the CAPTURED-address signature, whose field list is
+     * fixed by the store it is compared against; the verify cache key carries it, and
+     * nothing drops it from the request.
      */
-    public function testRegionIsStillSentToLoqateAlthoughItIsExcludedFromTheDedupKey(): void
+    public function testTheRegionIsSentToLoqateExactlyAsMagentoSuppliesIt(): void
     {
         $this->stubApiResponses([self::acceptedResponse()]);
-        $this->regionNames = [100 => 'Dublin'];
+        $this->regionNames = self::REGION_DIRECTORY;
 
         $this->validator->verifyAddress(self::ADDRESS);
 
@@ -1669,7 +2129,8 @@ class ValidatorVerifyCacheTest extends TestCase
         $this->assertSame(
             'Greater London',
             $sent['Address4'] ?? null,
-            'The region/county must still be sent to Loqate as Address4, even though the dedup key ignores it.'
+            'The region must be sent to Loqate as Address4 exactly as Magento supplied it: how the cache '
+            . 'renders it is a KEY concern and must never reach the payload.'
         );
         $this->assertSame('1 High St, Flat 2', $sent['Address'] ?? null, 'The full street must be sent.');
         $this->assertSame('1 High St', $sent['Address1'] ?? null);
@@ -1678,7 +2139,7 @@ class ValidatorVerifyCacheTest extends TestCase
         $this->assertSame('SW1A 1AA', $sent['PostalCode'] ?? null);
         $this->assertSame('GB', $sent['Country'] ?? null);
 
-        // A county that arrived as a region_id must be resolved and sent too.
+        // A region that arrived as a region_id must be resolved and sent too.
         $this->validator->verifyAddress([
             'street' => ['4 O\'Connell Street'],
             'city' => 'Dublin',
@@ -1689,7 +2150,7 @@ class ValidatorVerifyCacheTest extends TestCase
 
         $this->assertSame(2, $this->apiCallCount(), 'A different address must be verified in its own right.');
         $this->assertSame(
-            'Dublin',
+            'Dublin 1',
             $this->lastApiRequest()['Addresses'][0]['Address4'] ?? null,
             'A region resolved from region_id must be sent as Address4.'
         );
@@ -1949,10 +2410,14 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
-     * The signature is the dedup key, so its projection is load-bearing: the
-     * region/county (Address4) must be excluded because capture.js rewrites it,
-     * while the city (Address3) must be included because two different towns can
-     * share a street name and postcode format.
+     * buildAddressSignature() is the CAPTURED-ADDRESS projection, and its field list is
+     * fixed by the store it is compared against, not by anything about the verify cache:
+     * Helper\Controller::storeCapturedAddress() writes ADDRESS_CAPTURE_MAPPING's keys, so
+     * the region/county (Address4) must stay OUT of it while the city (Address3) must
+     * stay IN - two different towns can share a street name and postcode format.
+     *
+     * The verify cache key does carry the region, but it is built on TOP of this projection
+     * rather than inside it - see testTheVerifyCacheKeyProjectsEveryFieldSentToLoqate().
      */
     public function testBuildAddressSignatureExcludesRegionAndIncludesCity(): void
     {
@@ -2078,6 +2543,12 @@ class ValidatorVerifyCacheTest extends TestCase
      * into a scalar field. Neither may throw out of verifyAddress() - a TypeError in a
      * checkout plugin is a 500 on the place-order call - and neither may reach the
      * signature as anything other than a plain string.
+     *
+     * THE REGION AND THE COUNTRY GET THEIR OWN CASE, because they are the pair the cache
+     * key treats most carefully and neither is type-checked upstream: an array 'region' is
+     * dropped by parseAddress() before any key is built, while an object 'region' survives
+     * that filter and reaches the key. Both must degrade to "no readable region" - the same
+     * key, one verification - rather than throwing or being answered by another address.
      */
     public function testNestedArrayAndObjectFieldsDegradeInsteadOfThrowing(): void
     {
@@ -2111,6 +2582,52 @@ class ValidatorVerifyCacheTest extends TestCase
                 'Country' => 'GB',
             ]),
             'Objects and arrays must normalise to the empty part, never throw.'
+        );
+
+        // The region and the country together, driven through the public entry point: an
+        // OBJECT region (which parseAddress() lets through, since it only filters arrays)
+        // alongside an OBJECT country code.
+        $objectRegionAndCountry = array_merge(
+            self::ADDRESS,
+            ['region' => new \stdClass(), 'country_id' => new \stdClass()]
+        );
+
+        $third = $this->validator->verifyAddress($objectRegionAndCountry);
+
+        $this->assertSame(
+            ['error' => false],
+            $third,
+            'An object region and an object country code must not throw out of verifyAddress(): both are '
+            . 'read while the cache key is built, and a TypeError here is a 500 on place-order.'
+        );
+        $this->assertSame(
+            3,
+            $this->apiCallCount(),
+            'The address is still identifiable by street, city and postcode, so it is verified in its '
+            . 'own right rather than being silently answered by another address.'
+        );
+        $this->assertCount(
+            3,
+            $this->verdictStore(),
+            'Its verdict is still cacheable: an unreadable region renders as the empty segment, which is '
+            . 'a usable key part, not an empty signature.'
+        );
+
+        // An ARRAY region takes the other path - parseAddress() drops it before any
+        // signature is built - and must land on the same key as the object one, since
+        // both mean "no readable region". One further submission, no further request.
+        $arrayRegion = array_merge(self::ADDRESS, ['region' => ['x'], 'country_id' => new \stdClass()]);
+
+        $this->assertSame(
+            ['error' => false],
+            $this->validator->verifyAddress($arrayRegion),
+            'An array region must degrade the same way, not throw.'
+        );
+        $this->assertSame(
+            3,
+            $this->apiCallCount(),
+            'Neither submission supplies a readable region, so as far as anything readable goes they '
+            . 'describe one address and the second must be served from the cache rather than billed.'
         );
     }
 
@@ -2161,9 +2678,8 @@ class ValidatorVerifyCacheTest extends TestCase
     /**
      * The namespace is a NAMESPACE: two store views that accept the same address must
      * store the identical signature under two different prefixes, rather than the store
-     * view leaking into the signature projection itself (which would, for instance,
-     * make the county-agnostic success key store-view-dependent in ways no other test
-     * would notice).
+     * view leaking into the signature projection itself (which would make one address
+     * project to several signatures in ways no other test would notice).
      */
     public function testTwoStoreViewsCacheTheSameSignatureUnderDifferentNamespaces(): void
     {
@@ -2461,8 +2977,8 @@ class ValidatorVerifyCacheTest extends TestCase
      * it outlives the session, it is rotated into backups and shipped to aggregators, and
      * under UK/EU data protection law a log full of shoppers' home addresses is a
      * reportable problem. So the only things permitted on these lines are the outcome
-     * (hit/miss), the key family, and a truncated hash - enough to reconcile the drop in
-     * billable requests, and nothing that identifies anybody.
+     * (hit/miss) and a truncated hash - enough to reconcile the drop in billable requests,
+     * and nothing that identifies anybody.
      *
      * Asserted as a WHITELIST (every debug record must match one exact shape) rather than
      * as a blacklist of forbidden strings, because a blacklist only catches the leaks
@@ -2481,8 +2997,8 @@ class ValidatorVerifyCacheTest extends TestCase
             'country_id' => 'IE',
         ];
 
-        // A full realistic sequence: miss, lossy hit, miss, strict hit, and the unkeyed
-        // case (an address with nothing identifiable in it).
+        // A full realistic sequence: an accepted address missed then hit, a rejected one
+        // missed then hit, and the unkeyed case (nothing identifiable in the address).
         $this->validator->verifyAddress(self::ADDRESS);
         $this->validator->verifyAddress(self::ADDRESS);
         $this->validator->verifyAddress($rejectedAddress);
@@ -2491,8 +3007,8 @@ class ValidatorVerifyCacheTest extends TestCase
 
         $records = $this->cacheLogRecords($this->shopper);
         $this->assertSame(
-            [['miss', 'none'], ['hit', 'lossy'], ['miss', 'none'], ['hit', 'strict'], ['miss', 'none']],
-            array_map(static fn (array $r): array => [$r['outcome'], $r['family']], $records),
+            ['miss', 'hit', 'miss', 'hit', 'miss'],
+            array_column($records, 'outcome'),
             'Every cache lookup outcome must be logged exactly once, in order.'
         );
 
@@ -2551,11 +3067,12 @@ class ValidatorVerifyCacheTest extends TestCase
      * What makes the instrumentation meaningful rather than decorative:
      *  - a MISS is logged before the billable request it accounts for, so misses and
      *    invoice lines can be counted one-to-one;
-     *  - a HIT logs the family the verdict actually came from, which is only knowable
-     *    because the two cache reads are separate and the strict one runs first;
-     *  - a hit issues no request at all.
+     *  - a hit issues no request at all;
+     *  - a replayed verdict is logged the same way whether it was an acceptance or a
+     *    rejection, because both are one address whose verification was not paid for twice,
+     *    which is what the reconciliation counts.
      */
-    public function testCacheOutcomeLogsAreOrderedAndReportTheKeyFamilyTheVerdictCameFrom(): void
+    public function testCacheOutcomeLogsAreOrderedSoMissesCanBeCountedAgainstBillableRequests(): void
     {
         $this->stubApiResponses([self::acceptedResponse()]);
 
@@ -2569,29 +3086,17 @@ class ValidatorVerifyCacheTest extends TestCase
             . 'the Loqate invoice), and a hit must issue no request at all.'
         );
 
-        $records = $this->cacheLogRecords($this->shopper);
-        $this->assertSame(
-            [['miss', 'none'], ['hit', 'lossy']],
-            array_map(static fn (array $r): array => [$r['outcome'], $r['family']], $records),
-            'A miss has no key family yet; a success is cached under the LOSSY (county-blind) key, so the '
-            . 'hit must be reported as lossy.'
-        );
-
-        // A rejection is cached under the STRICT key, so its replay must say so - that is
-        // the distinction the split cache reads exist to make visible.
+        // The same timeline for an address Loqate rejected: one saved request either way.
         $rejecting = $this->createShopper();
         $this->stubShopperResponses($rejecting, [self::rejectedResponse()]);
         $rejecting['validator']->verifyAddress(self::ADDRESS);
         $rejecting['validator']->verifyAddress(self::ADDRESS);
 
         $this->assertSame(
-            [['miss', 'none'], ['hit', 'strict']],
-            array_map(
-                static fn (array $r): array => [$r['outcome'], $r['family']],
-                $this->cacheLogRecords($rejecting)
-            ),
-            'A replayed rejection must be reported as a STRICT hit: the family is what tells an operator '
-            . 'whether a hit came from the rejection key or the county-blind success key.'
+            ['log:miss', 'api', 'log:hit'],
+            $this->eventTimeline($rejecting),
+            'A replayed rejection is a saved billable request exactly as a replayed acceptance is, and must '
+            . 'be reported the same way: the log is there to be counted against the invoice.'
         );
     }
 
@@ -2756,6 +3261,83 @@ class ValidatorVerifyCacheTest extends TestCase
         return (array)$this->apiRequests[$this->apiCallCount() - 1];
     }
 
+    /**
+     * One fixed address in $countryId, carrying exactly the region keys given and nothing
+     * else variable, so a pair of these differs in the region alone and any second billable
+     * request can only be the region's doing.
+     *
+     * An empty $regionFields omits both region fields, which is how Magento presents an
+     * address whose region input was never filled in.
+     *
+     * @param string $countryId Magento country code, in whatever case the test needs.
+     * @param array $regionFields Magento region keys to carry: 'region' (free text) and/or
+     *                            'region_id' (a row of the install's region directory).
+     * @return array Magento-shaped address.
+     */
+    private static function addressInRegion(string $countryId, array $regionFields): array
+    {
+        return array_merge(
+            [
+                'street' => ['12 Main Street'],
+                'city' => 'Navan',
+                'postcode' => 'C15 XXXX',
+                'country_id' => $countryId,
+            ],
+            $regionFields
+        );
+    }
+
+    /**
+     * The region label that actually reaches Loqate for an address, taken from a throwaway
+     * shopper of its own so the answer cannot be affected by - or affect - the cache under
+     * test.
+     *
+     * This is what makes the region-axis rows justifiable by an external fact: what Loqate
+     * was asked is observable, rather than something a test has to claim.
+     *
+     * @param array $address Magento-shaped address.
+     * @return string|null Value sent as Address4, or null when the field was never populated.
+     */
+    private function regionSentToLoqate(array $address): ?string
+    {
+        $shopper = $this->createShopper();
+        $this->stubShopperResponses($shopper, [self::acceptedResponse()]);
+        $shopper['validator']->verifyAddress($address);
+
+        $sent = $shopper['requests'][0]['Addresses'][0]['Address4'] ?? null;
+
+        return $sent === null ? null : (string)$sent;
+    }
+
+    /**
+     * One region value as any address field is compared: trimmed, whitespace-collapsed and
+     * case-folded, because a form re-formatting a value has not changed which place it names
+     * (the rule itself is pinned by testBuildAddressSignatureNormalisesCaseAndWhitespace()).
+     *
+     * @param string|null $region Region as it reached Loqate, or null when none did.
+     * @return string|null
+     */
+    private static function asComparableRegion(?string $region): ?string
+    {
+        return $region === null ? null : mb_strtoupper(preg_replace('/\s+/', ' ', trim($region)));
+    }
+
+    /**
+     * The version of the verify cache's key scheme, failing with an explanation when the
+     * production code does not stamp its cached verdicts with one.
+     */
+    private function verifyKeySchemaVersion(): int
+    {
+        $version = $this->privateConstant('VERIFY_KEY_SCHEMA_VERSION');
+        $this->assertIsInt(
+            $version,
+            'Validator::VERIFY_KEY_SCHEMA_VERSION must be an integer, so a verdict written before the key '
+            . 'scheme changed can be told apart from one written after it.'
+        );
+
+        return $version;
+    }
+
     /** A unique, fully-formed address per index. */
     private function distinctAddress(int $index): array
     {
@@ -2896,8 +3478,8 @@ class ValidatorVerifyCacheTest extends TestCase
         $reflection = new ReflectionClass(Validator::class);
         if (!$reflection->hasConstant($name)) {
             $this->fail(sprintf(
-                'Validator::%s is not defined: the asymmetric cache keys must name the field they differ '
-                . 'by in exactly one place, so both key builders and these tests agree on it.',
+                'Validator::%s is not defined, so the production code and these tests can no longer agree '
+                . 'on what the verify cache key is made of.',
                 $name
             ));
         }
@@ -2938,20 +3520,20 @@ class ValidatorVerifyCacheTest extends TestCase
     }
 
     /**
-     * The ONE line shape the verify cache instrumentation may write: an outcome, a key
-     * family and a 12-hex hash (or "unkeyed"). Anything else - an address, a signature, a
-     * store id - fails to match, which is what makes this a whitelist rather than a
-     * guess at what a leak would look like.
+     * The ONE line shape the verify cache instrumentation may write: an outcome and a
+     * 12-hex hash (or "unkeyed"). Anything else - an address, a signature, a store id -
+     * fails to match, which is what makes this a whitelist rather than a guess at what a
+     * leak would look like.
      */
     private const CACHE_LOG_PATTERN =
-        '/^Loqate verify cache (hit|miss) \[family=(strict|lossy|none), key=([0-9a-f]{12}|unkeyed)\]$/';
+        '/^Loqate verify cache (hit|miss) \[key=([0-9a-f]{12}|unkeyed)\]$/';
 
     /**
      * The cache-outcome debug records of a shopper, parsed, asserting on the way that each
      * one matches the whitelisted shape and carries no log context.
      *
      * @param array $shopper Shopper harness from createShopper().
-     * @return array<int, array{outcome: string, family: string, token: string}>
+     * @return array<int, array{outcome: string, token: string}>
      */
     private function cacheLogRecords(array $shopper): array
     {
@@ -2962,8 +3544,8 @@ class ValidatorVerifyCacheTest extends TestCase
                 $record['message'],
                 sprintf(
                     'Debug record #%d ("%s") is not one of the permitted cache-outcome lines. These records '
-                    . 'may contain the outcome, the key family and a truncated hash only - never the '
-                    . 'address and never the signature.',
+                    . 'may contain the outcome and a truncated hash only - never the address and never the '
+                    . 'signature.',
                     $index,
                     $record['message']
                 )
@@ -2979,7 +3561,7 @@ class ValidatorVerifyCacheTest extends TestCase
             );
 
             preg_match(self::CACHE_LOG_PATTERN, $record['message'], $matches);
-            $parsed[] = ['outcome' => $matches[1], 'family' => $matches[2], 'token' => $matches[3]];
+            $parsed[] = ['outcome' => $matches[1], 'token' => $matches[2]];
         }
 
         return $parsed;

--- a/Test/Unit/Helper/ValidatorVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorVerifyCacheTest.php
@@ -589,8 +589,8 @@ class ValidatorVerifyCacheTest extends TestCase
      * doing so - that is the belief LOQ-16978 exists to correct. Magento calls
      * session_regenerate_id() on login and on logout, which changes the session ID while
      * PRESERVING every value in $_SESSION, so the cache emphatically DOES survive both.
-     * What clears it there is Helper\ShopperScopedSession, not PHP; the logout and login
-     * cases are covered by ShopperScopedSessionTest::testACachedVerdictDoesNotSurviveALogin()
+     * What clears it there is Helper\ShopperScopedAddressStores, not PHP; the logout and login
+     * cases are covered by ShopperScopedAddressStoresTest::testACachedVerdictDoesNotSurviveALogin()
      * and its siblings.
      */
     public function testCachedVerdictDoesNotSurviveASessionReset(): void
@@ -3371,9 +3371,9 @@ class ValidatorVerifyCacheTest extends TestCase
      * cached can be read back.
      *
      * NOT a logout and NOT a session-id regeneration. Magento regenerates the session id on
-     * both login and logout and the DATA survives that (see Helper\ShopperScopedSession);
+     * both login and logout and the DATA survives that (see Helper\ShopperScopedAddressStores);
      * emptying the store here would be the wrong model of either. The identity-change cases
-     * are ShopperScopedSessionTest's subject - testACachedVerdictDoesNotSurviveALogin()
+     * are ShopperScopedAddressStoresTest's subject - testACachedVerdictDoesNotSurviveALogin()
      * covers the logout/login hand-off, where the guard does the clearing that PHP does not.
      */
     private function startBrandNewSession(array $shopper): void

--- a/Test/Unit/Model/AdminNotification/UnverifiedAdminOrderMessageTest.php
+++ b/Test/Unit/Model/AdminNotification/UnverifiedAdminOrderMessageTest.php
@@ -3,6 +3,7 @@
 namespace Loqate\ApiIntegration\Test\Unit\Model\AdminNotification;
 
 use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Logger\Logger;
 use Loqate\ApiIntegration\Model\AdminNotification\UnverifiedAdminOrderMessage;
 use Magento\Framework\Notification\MessageInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -39,6 +40,9 @@ class UnverifiedAdminOrderMessageTest extends TestCase
      * @var array<int>|null
      */
     private ?array $storeIds = [1];
+
+    /** @var array<int> Store ids the store manager reports as inactive. */
+    private array $inactiveStoreIds = [];
 
     /**
      * Every combination of the two toggles, for both groups, with whether the notice must show.
@@ -250,6 +254,34 @@ class UnverifiedAdminOrderMessageTest extends TestCase
     }
 
     /**
+     * An INACTIVE store view in the combination must NOT raise the notice.
+     *
+     * A disabled store view cannot take an order, so there are no unverified orders to warn
+     * about. This notice is MAJOR severity, and a MAJOR notice about something that cannot
+     * happen is what teaches an admin to dismiss the next one unread.
+     */
+    public function testAnInactiveStoreViewInTheCombinationDoesNotRaiseTheNotice(): void
+    {
+        $this->config = [
+            'loqate_settings/address_settings/enable_create_order_admin' => '0',
+            'loqate_settings/address_settings/enable_checkout' => '0',
+        ];
+        $this->storeConfig = [
+            2 => ['loqate_settings/address_settings/enable_checkout' => '1'],
+        ];
+        $this->storeIds = [1, 2];
+        $this->inactiveStoreIds = [2];
+
+        $this->assertFalse(
+            $this->message()->isDisplayed(),
+            'Only the disabled store view is in the combination, and it cannot take an order, so there is '
+            . 'nothing to warn about. Compare '
+            . 'testAStoreViewOverrideRaisesTheNoticeEvenWhenTheDefaultScopeLooksFine(), which is the same '
+            . 'configuration with the store view enabled and MUST warn.'
+        );
+    }
+
+    /**
      * An unreadable store list falls back to the current scope rather than throwing.
      *
      * getStores() touches the database, and a system message renders on admin pages that must
@@ -297,18 +329,27 @@ class UnverifiedAdminOrderMessageTest extends TestCase
         } else {
             $stores = [];
             foreach ($this->storeIds as $storeId) {
-                $store = new class ($storeId) {
+                $store = new class ($storeId, !in_array($storeId, $this->inactiveStoreIds, true)) {
                     /** @var int */
                     private $id;
 
-                    public function __construct(int $id)
+                    /** @var bool */
+                    private $active;
+
+                    public function __construct(int $id, bool $active)
                     {
                         $this->id = $id;
+                        $this->active = $active;
                     }
 
                     public function getId(): int
                     {
                         return $this->id;
+                    }
+
+                    public function getIsActive(): bool
+                    {
+                        return $this->active;
                     }
                 };
                 $stores[] = $store;
@@ -316,6 +357,6 @@ class UnverifiedAdminOrderMessageTest extends TestCase
             $storeManager->method('getStores')->willReturn($stores);
         }
 
-        return new UnverifiedAdminOrderMessage($helper, $storeManager);
+        return new UnverifiedAdminOrderMessage($helper, $storeManager, $this->createMock(Logger::class));
     }
 }

--- a/Test/Unit/Model/AdminNotification/UnverifiedAdminOrderMessageTest.php
+++ b/Test/Unit/Model/AdminNotification/UnverifiedAdminOrderMessageTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Model\AdminNotification;
+
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Model\AdminNotification\UnverifiedAdminOrderMessage;
+use Magento\Framework\Notification\MessageInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The admin notice for the toggle combination that verifies nothing.
+ *
+ * Observer\QuoteSubmitBefore returns early in the admin area so admin order create is not
+ * billed twice for the same order. The cost is that admin order create obeys only the
+ * enable_create_order_admin toggles - and in ONE combination, enable_create_order_admin OFF
+ * with enable_checkout ON, the observer had been the only thing verifying an admin-created
+ * order, so nothing verifies it now.
+ *
+ * These tests exist because that fact used to live only in a docblock. A merchant does not read
+ * docblocks, so the behaviour change was invisible to the only person who could act on it. What
+ * is asserted here is therefore not the wording but the TRIGGER: the notice appears in exactly
+ * the combination that verifies nothing, and stays silent in every combination that does not.
+ */
+class UnverifiedAdminOrderMessageTest extends TestCase
+{
+    /** @var array<string, mixed> Config values keyed by path, read by the Data stub. */
+    private array $config = [];
+
+    /**
+     * Every combination of the two toggles, for both groups, with whether the notice must show.
+     *
+     * The whole point is that only ONE of the four combinations per group is a problem. A test
+     * that only covered that one case would still pass if the notice fired unconditionally,
+     * which would train merchants to dismiss it.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: bool, 2: string}>
+     */
+    public static function toggleCombinationProvider(): array
+    {
+        $path = static fn (string $group, string $field): string
+            => 'loqate_settings/' . $group . '/' . $field;
+
+        $combination = static fn (string $group, $admin, $checkout): array => [
+            $path($group, 'enable_create_order_admin') => $admin,
+            $path($group, 'enable_checkout') => $checkout,
+        ];
+
+        return [
+            'address: admin OFF, checkout ON - the unverified combination' => [
+                $combination('address_settings', '0', '1'),
+                true,
+                'this is the case the notice exists for: the observer was the only thing '
+                . 'verifying admin-created addresses and now nothing is',
+            ],
+            'phone: admin OFF, checkout ON - the unverified combination' => [
+                $combination('phone_settings', '0', '1'),
+                true,
+                'the phone toggles have the same pair and the same consequence, so the notice '
+                . 'must not be address-only',
+            ],
+            'address: both ON - verification runs' => [
+                $combination('address_settings', '1', '1'),
+                false,
+                'admin order create IS verified here, via Plugin\Admin\OrderSave',
+            ],
+            'address: admin ON, checkout OFF - verification runs' => [
+                $combination('address_settings', '1', '0'),
+                false,
+                'the admin toggle is what governs this path, and it is on',
+            ],
+            'address: both OFF - the merchant asked for no verification' => [
+                $combination('address_settings', '0', '0'),
+                false,
+                'nothing is verified anywhere and that is exactly what was configured, so there '
+                . 'is nothing to warn about - warning here would make the notice noise',
+            ],
+            'address: ints rather than the strings core_config_data returns' => [
+                $combination('address_settings', 0, 1),
+                true,
+                'a data patch writes ints while core_config_data yields strings, and the notice '
+                . 'must not depend on which wrote the value',
+            ],
+        ];
+    }
+
+    #[DataProvider('toggleCombinationProvider')]
+    public function testTheNoticeShowsOnlyForTheCombinationThatVerifiesNothing(
+        array $config,
+        bool $expected,
+        string $why
+    ): void {
+        $this->config = $config;
+
+        $this->assertSame(
+            $expected,
+            $this->message()->isDisplayed(),
+            sprintf('Notice visibility is wrong: %s.', $why)
+        );
+    }
+
+    /**
+     * Both groups at once must be reported in ONE notice naming both.
+     *
+     * Two separate notices would need two identities and two dismissals for one mistake.
+     */
+    public function testBothGroupsAffectedAreNamedInOneNotice(): void
+    {
+        $this->config = [
+            'loqate_settings/address_settings/enable_create_order_admin' => '0',
+            'loqate_settings/address_settings/enable_checkout' => '1',
+            'loqate_settings/phone_settings/enable_create_order_admin' => '0',
+            'loqate_settings/phone_settings/enable_checkout' => '1',
+        ];
+
+        $text = (string)$this->message()->getText();
+
+        $this->assertStringContainsString('Address Settings', $text, 'The address group must be named.');
+        $this->assertStringContainsString('Phone Settings', $text, 'The phone group must be named.');
+        $this->assertStringContainsString(
+            'Enable on Create Order (Admin)',
+            $text,
+            'The notice must name the setting to change, in the words the admin UI uses, or a '
+            . 'merchant cannot act on it.'
+        );
+    }
+
+    /**
+     * The identity must not vary with configuration.
+     *
+     * Magento keys a dismissal on the identity, so an identity derived from the current config
+     * state would make a dismissal apply to one combination only and resurface the notice on
+     * the next unrelated change.
+     */
+    public function testTheIdentityIsStableAcrossConfigurationChanges(): void
+    {
+        $this->config = [
+            'loqate_settings/address_settings/enable_create_order_admin' => '0',
+            'loqate_settings/address_settings/enable_checkout' => '1',
+        ];
+        $whenAffected = $this->message()->getIdentity();
+
+        $this->config = [
+            'loqate_settings/address_settings/enable_create_order_admin' => '1',
+            'loqate_settings/address_settings/enable_checkout' => '1',
+        ];
+
+        $this->assertSame(
+            $whenAffected,
+            $this->message()->getIdentity(),
+            'The identity is a dismissal key, not a description of the current state.'
+        );
+    }
+
+    public function testTheSeverityIsMajorRatherThanCritical(): void
+    {
+        $this->assertSame(
+            MessageInterface::SEVERITY_MAJOR,
+            $this->message()->getSeverity(),
+            'Unverified addresses are a real correctness problem, so not a minor notice - but it '
+            . 'is a configuration choice the merchant can act on, not a fault, so not critical '
+            . 'either. Critical severity here would crowd out genuine outages.'
+        );
+    }
+
+    /**
+     * An unset toggle must not be read as the unverified combination.
+     *
+     * etc/config.xml defaults both toggles to 1, so absent values mean "never configured".
+     * Reading absent-as-off would fire the notice on a fresh install where nothing is wrong.
+     */
+    public function testAnUnconfiguredModuleDoesNotRaiseTheNotice(): void
+    {
+        $this->config = [];
+
+        $this->assertFalse(
+            $this->message()->isDisplayed(),
+            'With no configuration written at all, enable_checkout is not ON, so the combination '
+            . 'does not apply and the notice must stay silent.'
+        );
+    }
+
+    /**
+     * The message under test, reading config through a stub of the module's own helper.
+     *
+     * @return UnverifiedAdminOrderMessage
+     */
+    private function message(): UnverifiedAdminOrderMessage
+    {
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturnCallback(
+            fn ($configPath) => $this->config[$configPath] ?? null
+        );
+
+        return new UnverifiedAdminOrderMessage($helper);
+    }
+}

--- a/Test/Unit/Model/AdminNotification/UnverifiedAdminOrderMessageTest.php
+++ b/Test/Unit/Model/AdminNotification/UnverifiedAdminOrderMessageTest.php
@@ -5,6 +5,7 @@ namespace Loqate\ApiIntegration\Test\Unit\Model\AdminNotification;
 use Loqate\ApiIntegration\Helper\Data;
 use Loqate\ApiIntegration\Model\AdminNotification\UnverifiedAdminOrderMessage;
 use Magento\Framework\Notification\MessageInterface;
+use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -24,8 +25,20 @@ use PHPUnit\Framework\TestCase;
  */
 class UnverifiedAdminOrderMessageTest extends TestCase
 {
-    /** @var array<string, mixed> Config values keyed by path, read by the Data stub. */
+    /** @var array<string, mixed> Default-scope config values keyed by path, read by the Data stub. */
     private array $config = [];
+
+    /** @var array<int, array<string, mixed>> Per-store-view overrides, keyed by store id then path. */
+    private array $storeConfig = [];
+
+    /**
+     * Store view ids the store manager reports, or null to make getStores() throw.
+     *
+     * Defaults to a single store view so the combination tests read as "one ordinary store".
+     *
+     * @var array<int>|null
+     */
+    private ?array $storeIds = [1];
 
     /**
      * Every combination of the two toggles, for both groups, with whether the notice must show.
@@ -181,6 +194,85 @@ class UnverifiedAdminOrderMessageTest extends TestCase
     }
 
     /**
+     * A per-STORE-VIEW enable_checkout over a default of off must still raise the notice.
+     *
+     * This is the case a single read at the current scope cannot see. enable_checkout is
+     * showInStore, enable_create_order_admin is showInDefault only, and in the admin area a
+     * scope-less read resolves to the DEFAULT store - so a merchant who switched checkout
+     * verification on for one store view, with the admin toggle off, has orders going
+     * unverified and would have been told nothing.
+     */
+    public function testAStoreViewOverrideRaisesTheNoticeEvenWhenTheDefaultScopeLooksFine(): void
+    {
+        $this->config = [
+            // Default scope: checkout off, so the pair does NOT trip here.
+            'loqate_settings/address_settings/enable_create_order_admin' => '0',
+            'loqate_settings/address_settings/enable_checkout' => '0',
+        ];
+        // Store view 2 turns checkout verification on, which completes the combination.
+        $this->storeConfig = [
+            2 => ['loqate_settings/address_settings/enable_checkout' => '1'],
+        ];
+        $this->storeIds = [1, 2];
+
+        $this->assertTrue(
+            $this->message()->isDisplayed(),
+            'A store view in the unverified combination must raise the notice: one store view is one set '
+            . 'of orders going unverified. If this fails, the notice is blind to per-store-view '
+            . 'configuration and stays silent in a case it exists for.'
+        );
+        $this->assertStringContainsString(
+            'Address Settings',
+            (string)$this->message()->getText(),
+            'And the affected group must still be named.'
+        );
+    }
+
+    /**
+     * The group is named ONCE however many store views trip it.
+     *
+     * Without the early exit, three affected store views would produce "Address Settings,
+     * Address Settings, Address Settings".
+     */
+    public function testAGroupIsNamedOnceHoweverManyStoreViewsTripIt(): void
+    {
+        $this->config = [
+            'loqate_settings/address_settings/enable_create_order_admin' => '0',
+            'loqate_settings/address_settings/enable_checkout' => '1',
+        ];
+        $this->storeIds = [1, 2, 3];
+
+        $this->assertSame(
+            1,
+            substr_count((string)$this->message()->getText(), 'Address Settings'),
+            'One group, named once, however many store views are in the combination.'
+        );
+    }
+
+    /**
+     * An unreadable store list falls back to the current scope rather than throwing.
+     *
+     * getStores() touches the database, and a system message renders on admin pages that must
+     * stay usable - including the pages an admin would use to repair a broken store table. A
+     * missed notice beats an unusable admin, and the fallback still catches the default-scope
+     * case, which is the common one.
+     */
+    public function testAnUnreadableStoreListFallsBackToTheCurrentScope(): void
+    {
+        $this->config = [
+            'loqate_settings/address_settings/enable_create_order_admin' => '0',
+            'loqate_settings/address_settings/enable_checkout' => '1',
+        ];
+        $this->storeIds = null;
+
+        $this->assertTrue(
+            $this->message()->isDisplayed(),
+            'With the store list unreadable, the default-scope combination must still be detected and the '
+            . 'notice must not throw out of an admin page render.'
+        );
+    }
+
+    /**
      * The message under test, reading config through a stub of the module's own helper.
      *
      * @return UnverifiedAdminOrderMessage
@@ -191,7 +283,39 @@ class UnverifiedAdminOrderMessageTest extends TestCase
         $helper->method('getConfigValue')->willReturnCallback(
             fn ($configPath) => $this->config[$configPath] ?? null
         );
+        // Falls back to the default-scope value when a store has no override of its own, which
+        // is what Magento's config inheritance does.
+        $helper->method('getConfigValueForStore')->willReturnCallback(
+            fn ($configPath, $storeId) => $this->storeConfig[$storeId][$configPath]
+                ?? $this->config[$configPath]
+                ?? null
+        );
 
-        return new UnverifiedAdminOrderMessage($helper);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        if ($this->storeIds === null) {
+            $storeManager->method('getStores')->willThrowException(new \RuntimeException('no store table'));
+        } else {
+            $stores = [];
+            foreach ($this->storeIds as $storeId) {
+                $store = new class ($storeId) {
+                    /** @var int */
+                    private $id;
+
+                    public function __construct(int $id)
+                    {
+                        $this->id = $id;
+                    }
+
+                    public function getId(): int
+                    {
+                        return $this->id;
+                    }
+                };
+                $stores[] = $store;
+            }
+            $storeManager->method('getStores')->willReturn($stores);
+        }
+
+        return new UnverifiedAdminOrderMessage($helper, $storeManager);
     }
 }

--- a/Test/Unit/Observer/QuoteSubmitBeforeTest.php
+++ b/Test/Unit/Observer/QuoteSubmitBeforeTest.php
@@ -1,0 +1,657 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Observer;
+
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Logger\Logger;
+use Loqate\ApiIntegration\Observer\QuoteSubmitBefore;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\LocalizedException;
+use ArrayObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Observer\QuoteSubmitBefore, which had NO coverage at all.
+ *
+ * The observer is registered GLOBALLY in etc/events.xml, on purpose: it exists because
+ * Hyvä's GraphQL checkout does not use the REST ShippingInformationManagement /
+ * BillingAddressManagement services the other plugins intercept, and 'graphql' and
+ * 'webapi_rest' are separate area codes that do NOT inherit 'frontend' - so moving the
+ * registration into etc/frontend/events.xml would silently disable verification on the very
+ * paths it was added for. A global registration, however, also fires on ADMIN order create,
+ * where Plugin\Admin\OrderSave already verifies both addresses in ONE batch call
+ * (verifyMultipleAddresses()); this observer would then add up to two further single-address
+ * calls for the same order, and the two paths cannot share a verdict because one judges the
+ * AVC and the other the AQI. So the admin area is excluded at RUNTIME instead.
+ *
+ * That makes three things load-bearing, and this file pins each of them:
+ *  - in 'adminhtml' NOTHING is verified, asserted on a spy rather than on the absence of an
+ *    error, because the observer's normal outcome for a valid address is also "no error" -
+ *    see testTheAdminAreaVerifiesNothing();
+ *  - in EVERY non-admin area the previous behaviour is completely unchanged, which has to be
+ *    asserted for 'frontend', 'graphql' AND 'webapi_rest' individually: an area-code
+ *    comparison written as a whitelist rather than an exclusion would pass for 'frontend'
+ *    alone - see testEveryNonAdminAreaStillVerifiesBothAddressesAndPhoneNumbers();
+ *  - when the area cannot be resolved at all (State::getAreaCode() throws, which it does when
+ *    no area code has been set yet) the observer fails TOWARDS verifying and swallows the
+ *    throwable - ANY throwable, not just the documented LocalizedException. Both halves
+ *    matter: skipping verification on an unknown area would let unverified addresses through
+ *    checkout unnoticed, while letting anything escape from here aborts the order submission
+ *    outright, a failure mode this class only acquired by taking a State dependency - see
+ *    testAnUnresolvableAreaStillVerifiesAndDoesNotAbortTheOrder() and
+ *    testAnyThrowableFromTheAreaLookupIsSwallowedSoItCannotKillTheOrder().
+ */
+class QuoteSubmitBeforeTest extends TestCase
+{
+    /** Config path gating address verification at checkout. */
+    private const ADDRESS_CHECKOUT = 'loqate_settings/address_settings/enable_checkout';
+
+    /** Config path gating phone verification at checkout. */
+    private const PHONE_CHECKOUT = 'loqate_settings/phone_settings/enable_checkout';
+
+    /** A shipping address as Quote\Address::getData() delivers it (newline-string street). */
+    private const SHIPPING_ADDRESS = [
+        'street' => "1 High St\nFlat 2\n",
+        'city' => 'London',
+        'postcode' => 'SW1A 1AA',
+        'country_id' => 'GB',
+        'telephone' => '02079460000',
+    ];
+
+    /** A billing address that is deliberately a DIFFERENT address from the shipping one. */
+    private const BILLING_ADDRESS = [
+        'street' => "77 Office Park\nUnit 4\n",
+        'city' => 'Reading',
+        'postcode' => 'RG1 1AA',
+        'country_id' => 'GB',
+        'telephone' => '01189990000',
+    ];
+
+    /** @var ArrayObject Ordered log of every Validator call the observer made. */
+    private $validatorCalls;
+
+    /** @var ArrayObject Ordered log of every record written to the module logger. */
+    private $logRecords;
+
+    /** @var ArrayObject Live store configuration, config path => value. */
+    private $config;
+
+    /** @var array Value the Validator returns from verifyAddress(). */
+    private $addressResponse = ['error' => false];
+
+    /** @var mixed Value the Validator returns from verifyPhoneNumber(). */
+    private $phoneResponse = true;
+
+    protected function setUp(): void
+    {
+        $this->validatorCalls = new ArrayObject();
+        $this->logRecords = new ArrayObject();
+        // Both features on, which is the configuration the observer was written for; the
+        // tests that care about a feature being off turn it off explicitly.
+        $this->config = new ArrayObject([
+            'loqate_settings/settings/api_key' => 'TEST-API-KEY-0000',
+            self::ADDRESS_CHECKOUT => '1',
+            self::PHONE_CHECKOUT => '1',
+        ]);
+        $this->addressResponse = ['error' => false];
+        $this->phoneResponse = true;
+    }
+
+    /**
+     * THE guard (task 3): on admin order create the observer must verify NOTHING.
+     *
+     * Asserted on a SPY - the recorded list of Validator calls - and not on the absence of an
+     * exception, because a valid address produces no exception either, so "it did not throw"
+     * would pass just as happily with the guard deleted. The addresses here are additionally
+     * stubbed to be INVALID, so removing the guard fails this test twice over: the spy records
+     * two verifications AND the observer aborts the admin's order with a LocalizedException.
+     */
+    public function testTheAdminAreaVerifiesNothing(): void
+    {
+        $this->addressResponse = ['error' => true, 'message' => 'The provided address is invalid.'];
+        $this->phoneResponse = false;
+        $observer = $this->createObserver(Area::AREA_ADMINHTML);
+
+        $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+
+        $this->assertSame(
+            [],
+            $this->recordedCalls(),
+            'Admin order create is already verified by Plugin\Admin\OrderSave, in ONE batch call. This '
+            . 'observer must not verify anything there: every call it makes is a second, separately '
+            . 'billable Loqate request for an address the merchant has already paid to have checked, and '
+            . 'the two paths cannot share a verdict because they judge different thresholds.'
+        );
+        $this->assertSame(
+            [],
+            iterator_to_array($this->logRecords),
+            'Skipping the admin area is normal operation, not a fault: it must not write anything to the log.'
+        );
+    }
+
+    /**
+     * The other half of the guard, and the half a whitelist-shaped check would break: in EVERY
+     * non-admin area the pre-existing behaviour must be completely unchanged.
+     *
+     * All three areas are covered individually because they are genuinely different codes and
+     * none of them inherits another: 'frontend' is the Luma page, 'webapi_rest' is the REST
+     * checkout the Luma front-end actually posts to, and 'graphql' is Hyvä. An "is this area
+     * frontend?" test written the wrong way round - or a registration moved into
+     * etc/frontend/events.xml - keeps working on the first and silently stops verifying on the
+     * other two, which are the paths this observer was added for in the first place.
+     *
+     * @param string $areaCode Area the request is being handled in.
+     */
+    #[DataProvider('nonAdminAreaProvider')]
+    public function testEveryNonAdminAreaStillVerifiesBothAddressesAndPhoneNumbers(string $areaCode): void
+    {
+        $observer = $this->createObserver($areaCode);
+
+        $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+
+        $this->assertSame(
+            [
+                ['verifyAddress', self::SHIPPING_ADDRESS],
+                ['verifyPhoneNumber', '02079460000', 'GB'],
+                ['verifyAddress', self::BILLING_ADDRESS],
+                ['verifyPhoneNumber', '01189990000', 'GB'],
+            ],
+            $this->recordedCalls(),
+            sprintf(
+                'In the "%s" area both addresses and both phone numbers must still be verified, in that '
+                . 'order: %s does not inherit any other area, so excluding the admin area must not '
+                . 'exclude this one with it.',
+                $areaCode,
+                $areaCode
+            )
+        );
+    }
+
+    /**
+     * ...and the rejection path in every non-admin area: an invalid address must still abort
+     * the order submission with a LocalizedException carrying the shopper-facing message.
+     *
+     * This is what the observer is FOR, so it is asserted per area as well: an area guard that
+     * accidentally covered 'graphql' would not merely skip a billable call there, it would let
+     * an address Loqate rejected through Hyvä checkout.
+     *
+     * @param string $areaCode Area the request is being handled in.
+     */
+    #[DataProvider('nonAdminAreaProvider')]
+    public function testAnInvalidAddressStillAbortsTheOrderInEveryNonAdminArea(string $areaCode): void
+    {
+        $this->addressResponse = ['error' => true, 'message' => 'The provided address is invalid.'];
+        $observer = $this->createObserver($areaCode);
+
+        try {
+            $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+            $this->fail(sprintf(
+                'An invalid address must still abort the order submission in the "%s" area: without the '
+                . 'LocalizedException the order is placed with an address Loqate rejected.',
+                $areaCode
+            ));
+        } catch (LocalizedException $exception) {
+            $this->assertSame(
+                'The provided address is invalid.' . PHP_EOL . 'The provided address is invalid.',
+                $exception->getMessage(),
+                'Both rejected addresses must be reported, joined one per line, exactly as before.'
+            );
+        }
+
+        $this->assertSame(
+            [
+                ['verifyAddress', self::SHIPPING_ADDRESS],
+                ['verifyPhoneNumber', '02079460000', 'GB'],
+                ['verifyAddress', self::BILLING_ADDRESS],
+                ['verifyPhoneNumber', '01189990000', 'GB'],
+            ],
+            $this->recordedCalls(),
+            'A rejected shipping address must not stop the billing address being verified: the shopper is '
+            . 'shown every problem at once, which is the pre-existing behaviour.'
+        );
+    }
+
+    /**
+     * An invalid PHONE number must still abort the order too, in every non-admin area - the
+     * observer verifies two things, and only one of them is an address.
+     *
+     * @param string $areaCode Area the request is being handled in.
+     */
+    #[DataProvider('nonAdminAreaProvider')]
+    public function testAnInvalidPhoneNumberStillAbortsTheOrderInEveryNonAdminArea(string $areaCode): void
+    {
+        $this->phoneResponse = false;
+        $observer = $this->createObserver($areaCode);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage(
+            'The provided phone number is invalid.' . PHP_EOL . 'The provided phone number is invalid.'
+        );
+
+        $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+    }
+
+    /**
+     * The three area codes the observer MUST keep running in. Named from
+     * Magento\Framework\App\Area so a renamed constant fails here rather than silently
+     * testing a string Magento no longer uses.
+     */
+    public static function nonAdminAreaProvider(): array
+    {
+        return [
+            'Luma page' => [Area::AREA_FRONTEND],
+            'Hyvä GraphQL checkout' => [Area::AREA_GRAPHQL],
+            'Luma REST checkout' => [Area::AREA_WEBAPI_REST],
+        ];
+    }
+
+    /**
+     * State::getAreaCode() THROWS when no area code has been set yet, and the observer then
+     * has to decide which way to fail. It fails towards VERIFYING, and this test pins both
+     * halves of that decision.
+     *
+     * The direction is not arbitrary: the two failure modes are not symmetric. Treating an
+     * unresolvable area as admin would skip verification silently - unverified addresses reach
+     * checkout, nobody notices, and it is a correctness and compliance problem. Treating it as
+     * non-admin costs at worst one duplicate billable call, which shows up on the invoice and
+     * never blocks an order. And the exception must be SWALLOWED rather than propagated for
+     * the same reason: a LocalizedException out of this observer aborts the order submission
+     * altogether, so an unset area code would stop the store taking orders.
+     */
+    public function testAnUnresolvableAreaStillVerifiesAndDoesNotAbortTheOrder(): void
+    {
+        $observer = $this->createObserver(
+            new LocalizedException('Area code is not set')
+        );
+
+        $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+
+        $this->assertSame(
+            [
+                ['verifyAddress', self::SHIPPING_ADDRESS],
+                ['verifyPhoneNumber', '02079460000', 'GB'],
+                ['verifyAddress', self::BILLING_ADDRESS],
+                ['verifyPhoneNumber', '01189990000', 'GB'],
+            ],
+            $this->recordedCalls(),
+            'An area code that cannot be resolved must fail TOWARDS verifying: skipping verification '
+            . 'there would let unverified addresses through checkout with nothing to show it happened.'
+        );
+
+        $messages = array_column(iterator_to_array($this->logRecords), 'message');
+        $this->assertCount(
+            1,
+            $messages,
+            'The swallowed exception must leave exactly one trace in the log, so an unset area code is '
+            . 'diagnosable rather than invisible.'
+        );
+        $this->assertStringContainsString(
+            'Area code is not set',
+            $messages[0],
+            'The log line must carry the underlying reason.'
+        );
+    }
+
+    /**
+     * ...and the verification it falls back to is a REAL one: with the area unresolvable, an
+     * invalid address must still abort the order, and the exception the merchant sees must be
+     * the ADDRESS rejection - not the swallowed area-code exception leaking out under a
+     * misleading message.
+     */
+    public function testAnUnresolvableAreaStillRejectsAnInvalidAddress(): void
+    {
+        $this->addressResponse = ['error' => true, 'message' => 'The provided address is invalid.'];
+        $observer = $this->createObserver(new LocalizedException('Area code is not set'));
+
+        try {
+            $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+            $this->fail('An invalid address must still be rejected when the area cannot be resolved.');
+        } catch (LocalizedException $exception) {
+            $this->assertSame(
+                'The provided address is invalid.' . PHP_EOL . 'The provided address is invalid.',
+                $exception->getMessage(),
+                'The exception must be the address rejection. If the area-code exception propagated '
+                . 'instead, the merchant would be shown "Area code is not set" as the reason their '
+                . 'customer could not place an order.'
+            );
+        }
+    }
+
+    /**
+     * EVERY throwable out of State::getAreaCode() is swallowed, not only the LocalizedException
+     * the real method documents - and this test is the record of that decision rather than the
+     * consequence of an accident.
+     *
+     * It used to assert the opposite, on the stated grounds that widening the catch should be a
+     * deliberate decision with a test to update rather than a silent one. The decision has now
+     * been taken, and it went the other way, for the reason a narrow catch could not answer:
+     * State is an interceptable @api class, so a plugin on it, a broken DI compilation or a
+     * not-yet-initialised object manager can raise something that is not a LocalizedException,
+     * and ANY throwable escaping a sales_model_service_quote_submit_before observer KILLS THE
+     * ORDER. That failure mode did not exist before this class took a State dependency, so
+     * resolving the area must never be the reason a customer cannot check out.
+     *
+     * Nothing is traded away in exchange, and each half is asserted for every throwable type:
+     *  - it does not escape - the observer runs to completion, so the order is not aborted;
+     *  - it fails TOWARDS verifying, with exactly the calls
+     *    testAnUnresolvableAreaStillVerifiesAndDoesNotAbortTheOrder() asserts, so the wider
+     *    catch cannot quietly change WHICH addresses get verified;
+     *  - it leaves exactly ONE log record carrying the underlying message, identically for
+     *    every type, so an \Error is as diagnosable as a LocalizedException. Swallowing without
+     *    that line is the outcome this test exists to forbid.
+     *
+     * The provider covers the documented type AND two undocumented ones deliberately: an
+     * \Error is not an \Exception, so catch (\Exception) - the plausible half-measure - passes
+     * the first two rows and fails the third, and the original narrow catch (LocalizedException)
+     * passes the first row alone.
+     *
+     * @param \Throwable $areaFault What State::getAreaCode() raises instead of an area code.
+     */
+    #[DataProvider('areaLookupFaultProvider')]
+    public function testAnyThrowableFromTheAreaLookupIsSwallowedSoItCannotKillTheOrder(
+        \Throwable $areaFault
+    ): void {
+        $observer = $this->createObserver($areaFault);
+
+        $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+
+        $this->assertSame(
+            [
+                ['verifyAddress', self::SHIPPING_ADDRESS],
+                ['verifyPhoneNumber', '02079460000', 'GB'],
+                ['verifyAddress', self::BILLING_ADDRESS],
+                ['verifyPhoneNumber', '01189990000', 'GB'],
+            ],
+            $this->recordedCalls(),
+            sprintf(
+                'A %s out of the area lookup must be swallowed and the request must fail TOWARDS '
+                . 'verifying, exactly as an unresolvable area does: if this throwable escaped instead it '
+                . 'would abort the order submission, and resolving the application area must never be '
+                . 'the reason an order fails.',
+                get_class($areaFault)
+            )
+        );
+
+        $messages = array_column(iterator_to_array($this->logRecords), 'message');
+        $this->assertCount(
+            1,
+            $messages,
+            sprintf(
+                'A swallowed %s must leave exactly one trace in the log. Widening the catch is only '
+                . 'defensible because diagnosis is preserved, not traded away: a silent catch turns an '
+                . 'unresolvable area into an invisible extra billable call.',
+                get_class($areaFault)
+            )
+        );
+        $this->assertStringContainsString(
+            'object manager is not initialised',
+            $messages[0],
+            'The log line must carry the underlying reason, identically for every throwable type - the '
+            . 'observer cannot tell the merchant what went wrong if it only records that something did.'
+        );
+    }
+
+    /**
+     * The throwable types State::getAreaCode() must not be able to kill an order with.
+     *
+     * All three carry the SAME message, so the log assertion above is one assertion about every
+     * type rather than three variants of it: the observer must not treat an undocumented
+     * throwable as less worth reporting than the documented one.
+     */
+    public static function areaLookupFaultProvider(): array
+    {
+        $message = 'object manager is not initialised';
+
+        return [
+            // The only type real Magento documents here: State::getAreaCode() throws it when no
+            // area code has been set yet.
+            'LocalizedException, the documented case' => [new LocalizedException($message)],
+            // A plugin on the interceptable State class, or any fault below it.
+            'RuntimeException, an undocumented runtime fault' => [new \RuntimeException($message)],
+            // Not an \Exception at all, so catch (\Exception) would let this one through.
+            'Error, which a catch (\Exception) would not hold' => [new \Error($message)],
+        ];
+    }
+
+    /**
+     * Existing behaviour that must survive the new guard, because the guard runs before all of
+     * it: with no API key configured nothing is verified, whatever the area.
+     */
+    public function testNoApiKeyConfiguredVerifiesNothing(): void
+    {
+        $this->config['loqate_settings/settings/api_key'] = '';
+        $observer = $this->createObserver(Area::AREA_FRONTEND);
+
+        $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+
+        $this->assertSame([], $this->recordedCalls(), 'Without an API key there is nothing to verify with.');
+    }
+
+    /**
+     * Existing behaviour: a virtual quote has no shippable address, so only the billing
+     * address is verified. Magento still hands back a shipping address object on a virtual
+     * quote, so this is a real branch and not a defensive one.
+     */
+    public function testAVirtualQuoteVerifiesTheBillingAddressOnly(): void
+    {
+        $observer = $this->createObserver(Area::AREA_FRONTEND);
+
+        $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS, true));
+
+        $this->assertSame(
+            [
+                ['verifyAddress', self::BILLING_ADDRESS],
+                ['verifyPhoneNumber', '01189990000', 'GB'],
+            ],
+            $this->recordedCalls(),
+            'A virtual quote has nothing to ship, so its shipping address must not be verified or billed.'
+        );
+    }
+
+    /**
+     * Existing behaviour: each feature is gated independently, so turning address verification
+     * off must not take phone verification with it, or vice versa.
+     */
+    public function testEachFeatureToggleIsHonouredIndependently(): void
+    {
+        $this->config[self::ADDRESS_CHECKOUT] = '';
+        $observer = $this->createObserver(Area::AREA_FRONTEND);
+
+        $observer->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+
+        $this->assertSame(
+            [
+                ['verifyPhoneNumber', '02079460000', 'GB'],
+                ['verifyPhoneNumber', '01189990000', 'GB'],
+            ],
+            $this->recordedCalls(),
+            'With address verification off, only the phone numbers may be verified.'
+        );
+
+        $this->validatorCalls = new ArrayObject();
+        $this->config[self::ADDRESS_CHECKOUT] = '1';
+        $this->config[self::PHONE_CHECKOUT] = '';
+
+        // The spy closure captures the call log by reference at construction time, so the
+        // second observer has to be built AFTER the log is swapped for a fresh one.
+        $phoneOff = $this->createObserver(Area::AREA_FRONTEND);
+        $phoneOff->execute($this->quoteEvent(self::SHIPPING_ADDRESS, self::BILLING_ADDRESS));
+
+        $this->assertSame(
+            [
+                ['verifyAddress', self::SHIPPING_ADDRESS],
+                ['verifyAddress', self::BILLING_ADDRESS],
+            ],
+            $this->recordedCalls(),
+            'With phone verification off, only the addresses may be verified.'
+        );
+    }
+
+    /**
+     * Build the observer under test, wired to recording doubles.
+     *
+     * @param string|\Throwable $area Area code State::getAreaCode() answers with, or a
+     *                                throwable it raises instead.
+     * @return QuoteSubmitBefore
+     */
+    private function createObserver($area): QuoteSubmitBefore
+    {
+        $config = $this->config;
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturnCallback(
+            static fn ($configPath) => $config[$configPath] ?? ''
+        );
+
+        // A recording spy rather than a set of expectations, so a test can assert exactly WHICH
+        // calls were made, in WHICH order and with WHICH arguments - and, for the admin guard,
+        // that the list is empty. Both of those are stronger than "the method was not called".
+        $calls = $this->validatorCalls;
+        $validator = $this->createMock(Validator::class);
+        $validator->method('verifyAddress')->willReturnCallback(
+            function ($address, $checkForCaptured = true) use ($calls): array {
+                $calls[] = ['verifyAddress', $address];
+
+                return $this->addressResponse;
+            }
+        );
+        $validator->method('verifyPhoneNumber')->willReturnCallback(
+            function ($phone, $country = null) use ($calls) {
+                $calls[] = ['verifyPhoneNumber', $phone, $country];
+
+                return $this->phoneResponse;
+            }
+        );
+
+        $records = $this->logRecords;
+        $logger = $this->createMock(Logger::class);
+        foreach (['debug', 'info', 'error'] as $level) {
+            $logger->method($level)->willReturnCallback(
+                static function ($message, array $context = []) use ($records, $level) {
+                    $records[] = ['level' => $level, 'message' => (string)$message, 'context' => $context];
+                }
+            );
+        }
+
+        $appState = $this->createMock(State::class);
+        if ($area instanceof \Throwable) {
+            $appState->method('getAreaCode')->willThrowException($area);
+        } else {
+            $appState->method('getAreaCode')->willReturn($area);
+        }
+
+        return new QuoteSubmitBefore($helper, $validator, $logger, $appState);
+    }
+
+    /**
+     * An Observer carrying a quote with the given addresses, in the shape
+     * sales_model_service_quote_submit_before delivers it.
+     *
+     * The quote and address doubles are anonymous classes rather than mocks: the observer
+     * only asks them for data, they need no Magento base class (nothing type-checks them),
+     * and this keeps the fixture readable enough that a reader can see what the observer is
+     * actually given.
+     *
+     * @param array|null $shipping Shipping address data, or null for a quote with none.
+     * @param array|null $billing Billing address data, or null for a quote with none.
+     * @param bool $isVirtual Whether the quote is virtual (nothing to ship).
+     * @return Observer
+     */
+    private function quoteEvent(?array $shipping, ?array $billing, bool $isVirtual = false): Observer
+    {
+        $shippingAddress = $shipping === null ? null : self::addressDouble($shipping);
+        $billingAddress = $billing === null ? null : self::addressDouble($billing);
+
+        $quote = new class ($shippingAddress, $billingAddress, $isVirtual) {
+            private $shippingAddress;
+            private $billingAddress;
+            private $isVirtual;
+
+            public function __construct($shippingAddress, $billingAddress, bool $isVirtual)
+            {
+                $this->shippingAddress = $shippingAddress;
+                $this->billingAddress = $billingAddress;
+                $this->isVirtual = $isVirtual;
+            }
+
+            public function getShippingAddress()
+            {
+                return $this->shippingAddress;
+            }
+
+            public function getBillingAddress()
+            {
+                return $this->billingAddress;
+            }
+
+            public function getIsVirtual()
+            {
+                return $this->isVirtual;
+            }
+        };
+
+        $event = new class ($quote) {
+            private $quote;
+
+            public function __construct($quote)
+            {
+                $this->quote = $quote;
+            }
+
+            public function getQuote()
+            {
+                return $this->quote;
+            }
+        };
+
+        return (new Observer())->setEvent($event);
+    }
+
+    /**
+     * A Quote\Address double: the three accessors the observer uses, answered from one data
+     * array exactly as AbstractAddress does.
+     *
+     * @param array $data Address data as Quote\Address::getData() returns it.
+     * @return object
+     */
+    private static function addressDouble(array $data): object
+    {
+        return new class ($data) {
+            /** @var array */
+            private $data;
+
+            public function __construct(array $data)
+            {
+                $this->data = $data;
+            }
+
+            public function getData()
+            {
+                return $this->data;
+            }
+
+            public function getTelephone()
+            {
+                return $this->data['telephone'] ?? null;
+            }
+
+            public function getCountryId()
+            {
+                return $this->data['country_id'] ?? null;
+            }
+        };
+    }
+
+    /**
+     * Every Validator call the observer made, in order, as ['method', ...arguments].
+     *
+     * @return array<int, array>
+     */
+    private function recordedCalls(): array
+    {
+        return array_values(iterator_to_array($this->validatorCalls));
+    }
+}

--- a/Test/Unit/Plugin/Admin/ValidateImportAddressTest.php
+++ b/Test/Unit/Plugin/Admin/ValidateImportAddressTest.php
@@ -457,6 +457,42 @@ class ValidateImportAddressTest extends TestCase
     }
 
     /**
+     * ...and the ONE exception that must NOT be absorbed, which is the contrast that gives the
+     * test above its meaning.
+     *
+     * An \InvalidArgumentException on this path is not a runtime fault. It is
+     * ShopperScopedAddressStores::assertEnrolled() reporting that a session store was reached
+     * without being enrolled in the shopper-ownership flush - a bug a developer has to fix,
+     * and the single signal that a store is escaping the guard that stops one shopper
+     * inheriting another's verify bypass.
+     *
+     * Swallowing it would be worse than a silent failure. This plugin has no logger, so the
+     * report would go nowhere at all, and the assertion that exists specifically to be
+     * impossible to ignore would become impossible to notice. So it propagates, and the
+     * import fails loudly.
+     *
+     * Safe to propagate because it cannot be a deserialisation failure: every call site that
+     * unserialises a cache entry catches \InvalidArgumentException itself and degrades to a
+     * miss, so a malformed session entry never reaches this catch. If that stops being true,
+     * this test is the one that should be revisited - not the narrowing.
+     */
+    public function testAnEnrolmentFailurePropagatesRatherThanBeingSwallowed(): void
+    {
+        $subject = $this->createMock(Address::class);
+        $subject->method('getBehavior')->willReturn(Import::BEHAVIOR_ADD_UPDATE);
+        $subject->method('getSource')->willThrowException(
+            new \InvalidArgumentException(
+                'Session key "loqate_email" is not enrolled in the shopper-ownership flush.'
+            )
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not enrolled in the shopper-ownership flush');
+
+        $this->createPlugin()->afterValidateData($subject, self::errorAggregator());
+    }
+
+    /**
      * Run the plugin over a file of $rowCount rows, answering each chunk from
      * $this->batchResults.
      *

--- a/Test/Unit/Plugin/Admin/ValidateImportAddressTest.php
+++ b/Test/Unit/Plugin/Admin/ValidateImportAddressTest.php
@@ -1,0 +1,619 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Plugin\Admin;
+
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Plugin\Admin\ValidateImportAddress;
+use Magento\CustomerImportExport\Model\Import\Address;
+use Magento\ImportExport\Model\Import;
+use Magento\ImportExport\Model\Import\AbstractEntity;
+use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingError;
+use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregator;
+use ArrayIterator;
+use ArrayObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Unit tests for Plugin\Admin\ValidateImportAddress, which had NO coverage at all.
+ *
+ * The plugin verifies a customer-address import file in chunks of 100 rows and reports each
+ * invalid row back to the merchant by ROW NUMBER. Validator::verifyMultipleAddresses() has
+ * THREE return shapes, and the plugin used to hand all three straight to array_merge():
+ *  - array<int, bool>, keys 0..N-1 per chunk - the normal case;
+ *  - false, when the billable API call itself failed OR answered a row count that cannot be
+ *    attributed to the addresses sent (the Validator's row-count guard - see
+ *    ValidatorBatchVerifyCacheTest - which is why the false branch now carries strictly more
+ *    traffic than "the API was down");
+ *  - ['noKeyFound' => true], when no API key is configured.
+ * array_merge($allRowsResult, false) is a TypeError in PHP 8, and the plugin's own
+ * catch (\Exception) does NOT catch it - a TypeError is an \Error, not an \Exception - so a
+ * single failed Loqate request part-way through an import took the whole admin request down
+ * with a 500 instead of degrading. That is what testAFailedBatchIsReportedOnceAndDoesNotCrash()
+ * pins, and it is why the test asserts the plugin RETURNS rather than merely "does not error":
+ * a test that only checked the reported errors would still have crashed before it got there.
+ *
+ * The 'noKeyFound' shape merges without throwing, which makes it the more insidious of the
+ * two: a string key lands in row-indexed data, and every subsequent chunk is reported against
+ * a row numbering that has an extra entry in it - see
+ * testNoKeyFoundIsNeverMergedIntoRowIndexedData().
+ *
+ * The row arithmetic itself is the third thing pinned here. It is CORRECT as written and must
+ * not be "fixed": each chunk comes back keyed 0..N-1 in input order (a guarantee
+ * Validator::verifyMultipleAddresses() upholds by pre-seeding its result - see
+ * ValidatorBatchVerifyCacheTest), so array_merge() renumbering by insertion order yields
+ * 0..149 across chunks of 100 and ($index + 1) is the import row number by construction.
+ * Nothing else in the suite pins that arithmetic across a chunk boundary, which is exactly
+ * where an off-by-one hides - see testInvalidRowsAreReportedWithCorrectRowNumbersAcrossChunks().
+ */
+class ValidateImportAddressTest extends TestCase
+{
+    /** Config path gating this feature. */
+    private const IMPORT_ENABLED = 'loqate_settings/address_settings/enable_customer_import';
+
+    /** Rows per verification batch, as the plugin chunks them. */
+    private const CHUNK_SIZE = 100;
+
+    /** @var ArrayObject Live store configuration, config path => value. */
+    private $config;
+
+    /** @var ArrayObject Batches handed to Validator::verifyMultipleAddresses(), in order. */
+    private $batchCalls;
+
+    /**
+     * Queued Validator::verifyMultipleAddresses() return values, one per call. A call past
+     * the end of the queue fails the test rather than reusing the last entry, because "how
+     * many chunks were verified" is itself part of what several of these tests assert.
+     *
+     * @var array<int, mixed>
+     */
+    private $batchResults = [];
+
+    protected function setUp(): void
+    {
+        $this->config = new ArrayObject([
+            'loqate_settings/settings/api_key' => 'TEST-API-KEY-0000',
+            self::IMPORT_ENABLED => '1',
+        ]);
+        $this->batchCalls = new ArrayObject();
+        $this->batchResults = [];
+    }
+
+    /**
+     * THE crash (task 4): a billable call that fails part-way through an import must degrade,
+     * not take the admin request down.
+     *
+     * Asserted on three things, each of which the pre-fix code got wrong:
+     *  - the plugin RETURNS the error aggregator. Before, array_merge($allRowsResult, false)
+     *    raised a TypeError, which catch (\Exception) does not catch, so the import died with
+     *    a 500 - this test errors outright if that comes back;
+     *  - exactly ONE error is reported, at CRITICAL, with NO row number, because no row is at
+     *    fault and the merchant must not be sent looking for one;
+     *  - verification STOPS. Continuing would either pass the remaining rows unverified or
+     *    attribute a transport failure to individual rows, and the failure has already been
+     *    reported.
+     */
+    public function testAFailedBatchIsReportedOnceAndDoesNotCrash(): void
+    {
+        // 250 rows = three chunks, so the failure genuinely happens MID-import and there is a
+        // third chunk left that must not be verified.
+        $this->batchResults = [
+            self::allValid(self::CHUNK_SIZE),
+            false,
+            self::allValid(50),
+        ];
+
+        $result = $this->runPlugin(250);
+
+        $this->assertInstanceOf(
+            ProcessingErrorAggregator::class,
+            $result,
+            'The plugin must return the aggregator it was given. Before LOQ-16976 this line was never '
+            . 'reached: array_merge($allRowsResult, false) raised a TypeError, which the plugin\'s own '
+            . 'catch (\Exception) does not catch, so a mid-import Loqate failure was a 500.'
+        );
+        $this->assertCount(
+            1,
+            $result->recordedErrors,
+            'A failed batch must be reported ONCE, not once per row: the merchant needs one actionable '
+            . '"try again", not a hundred identical ones.'
+        );
+
+        $error = $result->recordedErrors[0];
+        $this->assertSame(
+            AbstractEntity::ERROR_CODE_SYSTEM_EXCEPTION,
+            $error['errorCode'],
+            'A Loqate outage is a system fault, not a data fault in the file.'
+        );
+        $this->assertSame(
+            ProcessingError::ERROR_LEVEL_CRITICAL,
+            $error['errorLevel'],
+            'The error must be CRITICAL so the import is refused: letting the file through would import '
+            . 'addresses that were never verified, which is the same fail-closed stance the module takes '
+            . 'in admin order create and at checkout.'
+        );
+        $this->assertNull(
+            $error['rowNumber'],
+            'No row is at fault, so no row number may be reported: a row number here sends the merchant '
+            . 'to edit a row that is probably perfectly valid.'
+        );
+        $this->assertNull($error['columnName'], 'No column is at fault either.');
+        $this->assertStringContainsString(
+            'could not be validated',
+            (string)$error['errorMessage'],
+            'The message must say the addresses could not be validated...'
+        );
+        $this->assertStringContainsString(
+            'try the import again',
+            (string)$error['errorMessage'],
+            '...and tell the merchant what to do about it.'
+        );
+
+        $this->assertSame(
+            2,
+            count($this->batchCalls),
+            'Verification must STOP at the failed chunk: the remaining rows cannot be verified any more '
+            . 'reliably, and every further chunk is another billable request against an API that has '
+            . 'just failed.'
+        );
+    }
+
+    /**
+     * The FIRST chunk failing is the same contract, and worth its own case because it is the
+     * only path on which $allRowsResult is still empty - the shape where a merge of false
+     * would have been most tempting to consider harmless.
+     */
+    public function testAFailedFirstBatchIsReportedWithoutVerifyingAnyFurtherChunk(): void
+    {
+        $this->batchResults = [false, self::allValid(50)];
+
+        $result = $this->runPlugin(150);
+
+        $this->assertCount(1, $result->recordedErrors, 'Exactly one error, whichever chunk failed.');
+        $this->assertNull($result->recordedErrors[0]['rowNumber'], 'Still no row number.');
+        $this->assertSame(1, count($this->batchCalls), 'The second chunk must not be verified.');
+    }
+
+    /**
+     * The 'noKeyFound' shape must never reach the row-indexed data.
+     *
+     * It merges without throwing, which is what makes it worse than the false case rather than
+     * better: 'noKeyFound' becomes a string key inside an array whose keys are row offsets, so
+     * every reported row number afterwards is computed from a numbering with a phantom entry
+     * in it - and if the entry were ever falsy, ($index + 1) of the string key would itself be
+     * reported as "Invalid address at row #1", a row the merchant cannot fix because it is not
+     * the row that is wrong.
+     *
+     * There is nothing to validate without a key, so the import must be left exactly as it was
+     * found: no errors, and no further chunk verified. The queued second chunk - which would
+     * report a row - is what makes this test fail if the guard is removed.
+     */
+    public function testNoKeyFoundIsNeverMergedIntoRowIndexedData(): void
+    {
+        $this->batchResults = [
+            ['noKeyFound' => true],
+            // Would be reported as "Invalid address at row #1" once merged behind the phantom
+            // key, even though it is really row #101 of the file.
+            [0 => false] + self::allValid(self::CHUNK_SIZE),
+        ];
+
+        $result = $this->runPlugin(200);
+
+        $this->assertSame(
+            [],
+            $result->recordedErrors,
+            'With no API key there is nothing to validate, so the import must be left exactly as it was '
+            . 'found. A "noKeyFound" entry must never be merged into row-indexed data: it is not a row, '
+            . 'and it shifts the numbering of every row reported after it.'
+        );
+        $this->assertSame(
+            1,
+            count($this->batchCalls),
+            'Verification must stop: there is no key, so no further chunk can be verified either.'
+        );
+    }
+
+    /**
+     * ...and the half of that guard the ORDER of the chunks decides: an invalid row found
+     * BEFORE the key disappeared must still be reported.
+     *
+     * testNoKeyFoundIsNeverMergedIntoRowIndexedData() passes with either `break` or
+     * `return $result` in this branch, because there the 'noKeyFound' chunk is the FIRST one and
+     * $allRowsResult is still empty - so it pins the "never merged" half and nothing else. This
+     * case is the one that distinguishes them: chunk 1 reports a genuinely invalid row, chunk 2
+     * comes back 'noKeyFound' (the API key removed mid-import, a config cache flushed under a
+     * long-running import), and returning there would throw $allRowsResult away and import the
+     * bad row silently. Breaking keeps the verdicts already earned and lets the reporting loop
+     * run on them, which is strictly better than nothing and is the whole reason the branch is a
+     * `break`.
+     */
+    public function testAnInvalidRowFoundBeforeTheKeyDisappearedIsStillReported(): void
+    {
+        $this->batchResults = [
+            // Row 7 of the file is genuinely invalid, and Loqate said so before the key went.
+            self::invalidAt(self::CHUNK_SIZE, [7]),
+            ['noKeyFound' => true],
+        ];
+
+        $result = $this->runPlugin(200);
+
+        $this->assertSame(
+            [8],
+            array_column($result->recordedErrors, 'rowNumber'),
+            'The invalid row found in chunk 1 must still be reported after chunk 2 comes back with no key. '
+            . 'Returning instead of breaking discards every verdict already collected, so a row Loqate had '
+            . 'ALREADY rejected imports unnoticed - the exact outcome this plugin exists to prevent - and '
+            . 'it does so only when the key disappears part-way through, which is unreproducible on demand.'
+        );
+        $this->assertSame(
+            'Invalid address at row #8',
+            (string)$result->recordedErrors[0]['errorMessage'],
+            'And it must be reported against its own row number: the numbering of the chunks already '
+            . 'verified is unaffected by a later chunk having nothing to say.'
+        );
+        $this->assertSame(
+            2,
+            count($this->batchCalls),
+            'Verification must still stop at the keyless chunk: without a key no further chunk can be '
+            . 'verified either.'
+        );
+    }
+
+    /**
+     * THE row arithmetic, across a chunk boundary - the one place an off-by-one can hide and
+     * the reason ValidateImportAddress must keep receiving each chunk keyed 0..N-1 in input
+     * order.
+     *
+     * 250 rows in chunks of 100/100/50, with invalid rows placed at the file positions that
+     * break different mistakes: the very first row (0), an interior one (5), the LAST row of
+     * chunk 1 (99) and the FIRST row of chunk 2 (100) - which is the pair an off-by-one
+     * collapses onto one number - the last row of chunk 2 (149), and the last row of the file
+     * (249).
+     */
+    public function testInvalidRowsAreReportedWithCorrectRowNumbersAcrossChunks(): void
+    {
+        $this->batchResults = [
+            self::invalidAt(self::CHUNK_SIZE, [0, 5, 99]),
+            self::invalidAt(self::CHUNK_SIZE, [0, 49]),
+            self::invalidAt(50, [49]),
+        ];
+
+        $result = $this->runPlugin(250);
+
+        $this->assertSame(
+            [1, 6, 100, 101, 150, 250],
+            array_column($result->recordedErrors, 'rowNumber'),
+            'Row numbers are 1-based file positions and must survive the chunk boundary: rows 99 and 100 '
+            . 'of the file are the last row of chunk 1 and the first row of chunk 2, so an off-by-one '
+            . 'anywhere in the chunking or the merge collapses or shifts them.'
+        );
+        $this->assertSame(
+            [
+                'Invalid address at row #1',
+                'Invalid address at row #6',
+                'Invalid address at row #100',
+                'Invalid address at row #101',
+                'Invalid address at row #150',
+                'Invalid address at row #250',
+            ],
+            array_map(
+                static fn (array $error): string => (string)$error['errorMessage'],
+                $result->recordedErrors
+            ),
+            'The message the merchant reads must name the same row as the machine-readable row number.'
+        );
+        foreach ($result->recordedErrors as $error) {
+            $this->assertSame(
+                ProcessingError::ERROR_LEVEL_CRITICAL,
+                $error['errorLevel'],
+                'An invalid address must block the import, not merely annotate it.'
+            );
+        }
+
+        // ...and the chunking itself, since the row numbers above are only meaningful if the
+        // chunks really were the file's rows in order.
+        $batches = array_values(iterator_to_array($this->batchCalls));
+        $this->assertSame(
+            [self::CHUNK_SIZE, self::CHUNK_SIZE, 50],
+            array_map(static fn (array $call): int => count($call['batch']), $batches),
+            'The file must be verified in chunks of 100 rows, in order, with the remainder last.'
+        );
+        $this->assertSame(
+            ['ROW-0', 'ROW-100', 'ROW-200'],
+            array_map(
+                static fn (array $call): string => (string)reset($call['batch'])['postcode'],
+                $batches
+            ),
+            'Each chunk must start at the row it should: the row numbers reported above are derived from '
+            . 'the chunk offset, so a chunk that started elsewhere would number every row in it wrongly.'
+        );
+        $this->assertSame(
+            [false, false, false],
+            array_column($batches, 'checkForCaptured'),
+            'The import must pass $checkForCaptured = false: an import file cannot contain addresses '
+            . 'picked from the Loqate lookup in this shopper\'s session, so consulting that store would '
+            . 'match rows against another customer\'s captured addresses.'
+        );
+    }
+
+    /**
+     * A clean file must be reported clean, and a single chunk shorter than the chunk size must
+     * not be padded or shifted by the chunking.
+     */
+    public function testACleanFileIsReportedWithoutErrors(): void
+    {
+        $this->batchResults = [self::allValid(7)];
+
+        $result = $this->runPlugin(7);
+
+        $this->assertSame([], $result->recordedErrors, 'A file whose every row verified must report nothing.');
+        $this->assertSame(1, count($this->batchCalls), 'Seven rows are one chunk.');
+    }
+
+    /**
+     * DEFENSIVENESS ONLY, and explicitly so: this is the plugin's behaviour on a verdict array
+     * with a GAP in it, a shape Validator::verifyMultipleAddresses() can no longer produce.
+     *
+     * It used to be a statement of a known limit. It is not one any more. A short or shifted
+     * response now fails the whole batch inside the Validator (its row-count guard returns
+     * false, which the false branch above handles), so every chunk this plugin receives is
+     * either a complete verdict array, false, or 'noKeyFound'. The test is kept, re-framed,
+     * because the plugin is a separate unit that stubs the Validator out: it has no way to
+     * enforce that guarantee, and what it does when handed a gappy array is worth pinning -
+     * it must degrade, not crash, and above all it must not report the GAP as an invalid row,
+     * which would block an import over rows nobody rejected.
+     *
+     * The shifted row number in the expectation below is therefore NOT an endorsement. It is
+     * the arithmetic consequence of array_merge() renumbering by insertion order, recorded here
+     * so that if a future change ever makes gappy arrays reachable again - a new caller, a
+     * relaxed guard - the cost is already written down and is found by reading this test rather
+     * than by a merchant editing a valid row while the bad one imports.
+     */
+    public function testAGappyVerdictArrayIsToleratedEvenThoughTheValidatorCanNoLongerProduceOne(): void
+    {
+        $this->batchResults = [
+            // Row 50 of chunk 1 has no entry at all. Unreachable through
+            // Validator::verifyMultipleAddresses() since its row-count guard, but the plugin
+            // cannot know that: this is a stubbed Validator.
+            self::invalidAt(self::CHUNK_SIZE, [3], [50]),
+            self::invalidAt(50, [0]),
+        ];
+
+        $result = $this->runPlugin(150);
+
+        $this->assertSame(
+            [4, 100],
+            array_column($result->recordedErrors, 'rowNumber'),
+            'The plugin must degrade rather than crash, and must not report the gap itself as an invalid '
+            . 'row - a missing verdict is not a rejection, and reporting it would block an import over a '
+            . 'row nobody rejected. Row 4 keeps its true number. The first row of chunk 2 is row 101 of '
+            . 'the file and is reported as 100, because array_merge() renumbers by insertion order and the '
+            . 'chunk before it was one entry short: the arithmetic consequence of a gap, recorded rather '
+            . 'than endorsed, and now UNREACHABLE through Validator::verifyMultipleAddresses() - a row '
+            . 'count that does not match the addresses sent returns false and is handled above.'
+        );
+    }
+
+    /**
+     * Existing behaviour that gates everything: with no API key, or with the feature switched
+     * off, or on an import behaviour other than "add/update", the plugin must not verify
+     * anything at all - and must still hand the aggregator back untouched.
+     *
+     * @param array<string, string> $config Configuration overrides.
+     * @param string $behavior Import behaviour of the run.
+     */
+    #[DataProvider('disabledCaseProvider')]
+    public function testTheFeatureGatesVerifyNothing(array $config, string $behavior): void
+    {
+        foreach ($config as $path => $value) {
+            $this->config[$path] = $value;
+        }
+
+        $result = $this->runPlugin(10, $behavior);
+
+        $this->assertSame([], $result->recordedErrors, 'Nothing was verified, so nothing may be reported.');
+        $this->assertSame(
+            0,
+            count($this->batchCalls),
+            'No billable request may be issued when the feature does not apply.'
+        );
+    }
+
+    public static function disabledCaseProvider(): array
+    {
+        return [
+            'no API key configured' => [
+                ['loqate_settings/settings/api_key' => ''],
+                Import::BEHAVIOR_ADD_UPDATE,
+            ],
+            'customer import verification switched off' => [
+                [self::IMPORT_ENABLED => ''],
+                Import::BEHAVIOR_ADD_UPDATE,
+            ],
+            'a delete run, not add/update' => [[], Import::BEHAVIOR_DELETE],
+            'a replace run, not add/update' => [[], Import::BEHAVIOR_REPLACE],
+        ];
+    }
+
+    /**
+     * An exception thrown while reading the import source must be swallowed and the aggregator
+     * returned untouched, which is pre-existing behaviour: the plugin is an afterValidateData
+     * plugin, so throwing here would replace Magento's own validation report with a stack
+     * trace.
+     */
+    public function testAnExceptionWhileReadingTheSourceLeavesTheImportUntouched(): void
+    {
+        $aggregator = self::errorAggregator();
+        $subject = $this->createMock(Address::class);
+        $subject->method('getBehavior')->willReturn(Import::BEHAVIOR_ADD_UPDATE);
+        $subject->method('getSource')->willThrowException(new \RuntimeException('source file is gone'));
+
+        $result = $this->createPlugin()->afterValidateData($subject, $aggregator);
+
+        $this->assertSame($aggregator, $result, 'The aggregator must be handed straight back.');
+        $this->assertSame([], $result->recordedErrors, 'Nothing may be reported for a fault we cannot attribute.');
+    }
+
+    /**
+     * Run the plugin over a file of $rowCount rows, answering each chunk from
+     * $this->batchResults.
+     *
+     * @param int $rowCount Number of rows in the import file.
+     * @param string $behavior Import behaviour of the run.
+     * @return ProcessingErrorAggregator&object{recordedErrors: array} The aggregator it returned.
+     */
+    private function runPlugin(int $rowCount, string $behavior = Import::BEHAVIOR_ADD_UPDATE)
+    {
+        $rows = [];
+        for ($i = 0; $i < $rowCount; $i++) {
+            // 'postcode' doubles as the row's identity, so a test can assert WHICH rows ended
+            // up in which chunk and not merely how many.
+            $rows[] = [
+                'street' => ['1 High St'],
+                'city' => 'London',
+                'postcode' => 'ROW-' . $i,
+                'country_id' => 'GB',
+            ];
+        }
+
+        $subject = $this->createMock(Address::class);
+        $subject->method('getBehavior')->willReturn($behavior);
+        $subject->method('getSource')->willReturn(new ArrayIterator($rows));
+
+        $aggregator = self::errorAggregator();
+        $result = $this->createPlugin()->afterValidateData($subject, $aggregator);
+
+        $this->assertSame(
+            $aggregator,
+            $result,
+            'afterValidateData() must return the aggregator it was given, whatever happened: it is an '
+            . 'after-plugin, and its return value replaces validateData()\'s.'
+        );
+
+        return $result;
+    }
+
+    /**
+     * The plugin under test, built WITHOUT its constructor.
+     *
+     * AbstractPlugin's constructor wants Magento\Framework\App\Action\Context, UrlInterface
+     * and JsonFactory, none of which this plugin uses and none of which exists in this
+     * bootstrap. Stubbing three framework classes to satisfy a constructor whose values are
+     * never read would make the fixture less faithful, not more, so the two collaborators the
+     * plugin actually reads are injected into their declared properties instead.
+     *
+     * @return ValidateImportAddress
+     */
+    private function createPlugin(): ValidateImportAddress
+    {
+        $config = $this->config;
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturnCallback(
+            static fn ($configPath) => $config[$configPath] ?? ''
+        );
+
+        $calls = $this->batchCalls;
+        $results = $this->batchResults;
+        $validator = $this->createMock(Validator::class);
+        $validator->method('verifyMultipleAddresses')->willReturnCallback(
+            function ($addresses, $checkForCaptured = true) use ($calls, $results) {
+                $position = count($calls);
+                $calls[] = ['batch' => $addresses, 'checkForCaptured' => $checkForCaptured];
+
+                $this->assertArrayHasKey(
+                    $position,
+                    $results,
+                    sprintf(
+                        'The plugin verified chunk #%d, but this test only queued %d chunk(s). How many '
+                        . 'chunks are verified is part of what these tests assert, so an unqueued call '
+                        . 'is a failure rather than something to answer with a default.',
+                        $position + 1,
+                        count($results)
+                    )
+                );
+
+                return $results[$position];
+            }
+        );
+
+        $plugin = (new ReflectionClass(ValidateImportAddress::class))->newInstanceWithoutConstructor();
+        foreach (['validator' => $validator, 'helper' => $helper] as $property => $value) {
+            $reflection = new \ReflectionProperty(ValidateImportAddress::class, $property);
+            $reflection->setAccessible(true);
+            $reflection->setValue($plugin, $value);
+        }
+
+        return $plugin;
+    }
+
+    /**
+     * A ProcessingErrorAggregator that records what was reported to it, in order, keeping the
+     * real parameter names so a test failure reads like the merchant's import report.
+     *
+     * @return ProcessingErrorAggregator&object{recordedErrors: array}
+     */
+    private static function errorAggregator()
+    {
+        return new class extends ProcessingErrorAggregator {
+            /** @var array<int, array> */
+            public $recordedErrors = [];
+
+            public function addError(
+                $errorCode,
+                $errorLevel = ProcessingError::ERROR_LEVEL_CRITICAL,
+                $rowNumber = null,
+                $columnName = null,
+                $errorMessage = null,
+                $errorDescription = null
+            ) {
+                $this->recordedErrors[] = [
+                    'errorCode' => $errorCode,
+                    'errorLevel' => $errorLevel,
+                    'rowNumber' => $rowNumber,
+                    'columnName' => $columnName,
+                    'errorMessage' => $errorMessage,
+                    'errorDescription' => $errorDescription,
+                ];
+
+                return $this;
+            }
+        };
+    }
+
+    /**
+     * A chunk verdict array in which every row passed: keys 0..$count-1, as
+     * Validator::verifyMultipleAddresses() guarantees.
+     *
+     * @param int $count Rows in the chunk.
+     * @return array<int, bool>
+     */
+    private static function allValid(int $count): array
+    {
+        return self::invalidAt($count, []);
+    }
+
+    /**
+     * A chunk verdict array with the given LOCAL offsets failing, and optionally some rows
+     * missing entirely (a row Loqate did not answer keeps no entry at all).
+     *
+     * @param int $count Rows in the chunk.
+     * @param int[] $invalidOffsets Local offsets that must come back false.
+     * @param int[] $unansweredOffsets Local offsets that must have no entry at all.
+     * @return array<int, bool>
+     */
+    private static function invalidAt(int $count, array $invalidOffsets, array $unansweredOffsets = []): array
+    {
+        $verdicts = [];
+        for ($offset = 0; $offset < $count; $offset++) {
+            if (in_array($offset, $unansweredOffsets, true)) {
+                continue;
+            }
+
+            $verdicts[$offset] = !in_array($offset, $invalidOffsets, true);
+        }
+
+        return $verdicts;
+    }
+}

--- a/Test/stubs/Magento/Customer/Model/Session.php
+++ b/Test/stubs/Magento/Customer/Model/Session.php
@@ -19,5 +19,21 @@ if (!class_exists(\Magento\Customer\Model\Session::class, false)) {
         {
             return $this;
         }
+
+        /**
+         * Identity of the logged-in shopper, null for a guest.
+         *
+         * Unlike getData()/setData(), the real Magento\Customer\Model\Session DECLARES
+         * this method (it is @api there), so it has to be declared here too: the test
+         * doubles only addMethods() what the class under test does not already declare,
+         * and Helper\ShopperScopedSession calls it on every session access to decide
+         * whether the shopper-scoped caches still belong to the current shopper.
+         *
+         * @return int|string|null
+         */
+        public function getCustomerId()
+        {
+            return null;
+        }
     }
 }

--- a/Test/stubs/Magento/Customer/Model/Session.php
+++ b/Test/stubs/Magento/Customer/Model/Session.php
@@ -26,7 +26,7 @@ if (!class_exists(\Magento\Customer\Model\Session::class, false)) {
          * Unlike getData()/setData(), the real Magento\Customer\Model\Session DECLARES
          * this method (it is @api there), so it has to be declared here too: the test
          * doubles only addMethods() what the class under test does not already declare,
-         * and Helper\ShopperScopedSession calls it on every session access to decide
+         * and Helper\ShopperScopedAddressStores calls it on every session access to decide
          * whether the shopper-scoped caches still belong to the current shopper.
          *
          * @return int|string|null

--- a/Test/stubs/Magento/CustomerImportExport/Model/Import/Address.php
+++ b/Test/stubs/Magento/CustomerImportExport/Model/Import/Address.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Plugin\Admin\ValidateImportAddress::afterValidateData() declares this as its $subject
+ * type, so the class has to exist for the plugin to be callable at all, and it calls
+ * exactly the two accessors stubbed here.
+ *
+ * Deliberately does NOT extend Magento\ImportExport\Model\Import\AbstractEntity, which the
+ * real class reaches through AbstractCustomer: the stubs are loaded in sorted path order
+ * (Test/bootstrap.php), which puts this file before AbstractEntity's, so an extends clause
+ * would be resolved before its parent existed. Both accessors are declared on AbstractEntity
+ * in the real code, which changes nothing for a test double.
+ */
+
+namespace Magento\CustomerImportExport\Model\Import;
+
+if (!class_exists(\Magento\CustomerImportExport\Model\Import\Address::class, false)) {
+    class Address
+    {
+        /**
+         * Import behaviour of the current run, e.g. Import::BEHAVIOR_ADD_UPDATE.
+         *
+         * @return string
+         */
+        public function getBehavior()
+        {
+            return '';
+        }
+
+        /**
+         * The import source, an iterator over the file's rows.
+         *
+         * Declared without a return type exactly like the real accessor, whose
+         * AbstractSource return is only documented, so a test double can hand back any
+         * iterator - which is all iterator_to_array() in the plugin needs.
+         *
+         * @return \Iterator|null
+         */
+        public function getSource()
+        {
+            return null;
+        }
+    }
+}

--- a/Test/stubs/Magento/Framework/App/Area.php
+++ b/Test/stubs/Magento/Framework/App/Area.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Only the area-code constants are stubbed, which is all
+ * Observer\QuoteSubmitBefore::isAdminArea() uses. The values match Magento's, and the
+ * three non-admin ones are listed because they are the areas the observer MUST keep
+ * running in: 'graphql' (Hyvä checkout) and 'webapi_rest' (Luma checkout) do not
+ * inherit 'frontend', which is why the registration in etc/events.xml stays global.
+ */
+
+namespace Magento\Framework\App;
+
+if (!class_exists(\Magento\Framework\App\Area::class, false)) {
+    class Area
+    {
+        const AREA_GLOBAL = 'global';
+        const AREA_FRONTEND = 'frontend';
+        const AREA_ADMINHTML = 'adminhtml';
+        const AREA_WEBAPI_REST = 'webapi_rest';
+        const AREA_GRAPHQL = 'graphql';
+    }
+}

--- a/Test/stubs/Magento/Framework/App/Config/ScopeConfigInterface.php
+++ b/Test/stubs/Magento/Framework/App/Config/ScopeConfigInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real interface is absent.
+ * One type per file so Magento's DI PhpScanner can parse it.
+ *
+ * Signatures mirror the framework's, including the $scopeCode default of null, because
+ * Helper\Data::getConfigValue() relies on omitting it and getConfigValueForStore() relies on
+ * supplying it - and a test that cannot tell those two calls apart is what let a scope-blind
+ * read ship.
+ */
+
+namespace Magento\Framework\App\Config;
+
+if (!interface_exists(\Magento\Framework\App\Config\ScopeConfigInterface::class, false)) {
+    interface ScopeConfigInterface
+    {
+        const SCOPE_TYPE_DEFAULT = 'default';
+
+        /**
+         * @param string $path
+         * @param string $scope
+         * @param null|int|string $scopeCode
+         * @return mixed
+         */
+        public function getValue($path, $scope = self::SCOPE_TYPE_DEFAULT, $scopeCode = null);
+
+        /**
+         * @param string $path
+         * @param string $scope
+         * @param null|int|string $scopeCode
+         * @return bool
+         */
+        public function isSetFlag($path, $scope = self::SCOPE_TYPE_DEFAULT, $scopeCode = null);
+    }
+}

--- a/Test/stubs/Magento/Framework/App/Helper/AbstractHelper.php
+++ b/Test/stubs/Magento/Framework/App/Helper/AbstractHelper.php
@@ -3,6 +3,11 @@
 /**
  * Lightweight test stub — defined only when the real class is absent.
  * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Exposes $scopeConfig from the Context exactly as the real AbstractHelper does, because
+ * Helper\Data's config reads go through that inherited property. Without it, Data's own methods
+ * could not be exercised at all and every test had to mock Data wholesale - which is how a
+ * scope-blind config read stayed invisible to a green suite.
  */
 
 namespace Magento\Framework\App\Helper;
@@ -10,8 +15,12 @@ namespace Magento\Framework\App\Helper;
 if (!class_exists(\Magento\Framework\App\Helper\AbstractHelper::class, false)) {
     class AbstractHelper
     {
+        /** @var \Magento\Framework\App\Config\ScopeConfigInterface|null */
+        protected $scopeConfig;
+
         public function __construct(Context $context)
         {
+            $this->scopeConfig = $context->getScopeConfig();
         }
     }
 }

--- a/Test/stubs/Magento/Framework/App/Helper/Context.php
+++ b/Test/stubs/Magento/Framework/App/Helper/Context.php
@@ -3,12 +3,36 @@
 /**
  * Lightweight test stub — defined only when the real class is absent.
  * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Carries the scope config because that is the one collaborator this module's helpers reach
+ * through it: AbstractHelper exposes it as $this->scopeConfig, and Helper\Data reads every
+ * config value that way. The argument is optional so a bare Context still constructs.
  */
 
 namespace Magento\Framework\App\Helper;
 
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
 if (!class_exists(\Magento\Framework\App\Helper\Context::class, false)) {
     class Context
     {
+        /** @var ScopeConfigInterface|null */
+        private $scopeConfig;
+
+        /**
+         * @param ScopeConfigInterface|null $scopeConfig
+         */
+        public function __construct($scopeConfig = null)
+        {
+            $this->scopeConfig = $scopeConfig;
+        }
+
+        /**
+         * @return ScopeConfigInterface|null
+         */
+        public function getScopeConfig()
+        {
+            return $this->scopeConfig;
+        }
     }
 }

--- a/Test/stubs/Magento/Framework/App/RequestInterface.php
+++ b/Test/stubs/Magento/Framework/App/RequestInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real interface is absent.
+ * One type per file so Magento's DI PhpScanner can parse it.
+ *
+ * Only the members Helper\Controller actually uses are declared: it reads request
+ * parameters and nothing else. Adding the rest of Magento's RequestInterface here would
+ * make the stub a maintenance liability without making any test stronger.
+ */
+
+namespace Magento\Framework\App;
+
+if (!interface_exists(\Magento\Framework\App\RequestInterface::class, false)) {
+    interface RequestInterface
+    {
+        public function getParam($key, $defaultValue = null);
+
+        public function getParams();
+    }
+}

--- a/Test/stubs/Magento/Framework/App/State.php
+++ b/Test/stubs/Magento/Framework/App/State.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Observer\QuoteSubmitBefore takes this to exclude the admin area, where
+ * Plugin\Admin\OrderSave already verifies the order's addresses in one batch call.
+ * getAreaCode() is declared without a return type, exactly like the real one, so a
+ * test double can also make it throw LocalizedException - the case the real method
+ * hits when no area code has been set yet.
+ */
+
+namespace Magento\Framework\App;
+
+if (!class_exists(\Magento\Framework\App\State::class, false)) {
+    class State
+    {
+        /**
+         * @return string
+         * @throws \Magento\Framework\Exception\LocalizedException
+         */
+        public function getAreaCode()
+        {
+            return Area::AREA_GLOBAL;
+        }
+    }
+}

--- a/Test/stubs/Magento/Framework/Controller/ResultFactory.php
+++ b/Test/stubs/Magento/Framework/Controller/ResultFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Needed because Helper\Controller type-hints this class in its constructor, so a test
+ * that builds a Controller - and therefore anything covering the captured-address store
+ * it owns - cannot even create a double for it without the type existing.
+ */
+
+namespace Magento\Framework\Controller;
+
+if (!class_exists(\Magento\Framework\Controller\ResultFactory::class, false)) {
+    class ResultFactory
+    {
+        const TYPE_JSON = 'json';
+
+        const TYPE_RAW = 'raw';
+
+        public function create($type, array $arguments = [])
+        {
+            return null;
+        }
+    }
+}

--- a/Test/stubs/Magento/Framework/Event/Observer.php
+++ b/Test/stubs/Magento/Framework/Event/Observer.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * The real class extends DataObject and declares getEvent()/setEvent(); only getEvent()
+ * is stubbed, since that is all Observer\QuoteSubmitBefore calls. It is declared with no
+ * return type (as the real one is) so a test double can return any event-shaped object -
+ * the observer only asks it for getQuote().
+ */
+
+namespace Magento\Framework\Event;
+
+if (!class_exists(\Magento\Framework\Event\Observer::class, false)) {
+    class Observer
+    {
+        /** @var mixed */
+        private $event;
+
+        /**
+         * @return mixed
+         */
+        public function getEvent()
+        {
+            return $this->event;
+        }
+
+        /**
+         * @param mixed $event
+         * @return $this
+         */
+        public function setEvent($event)
+        {
+            $this->event = $event;
+
+            return $this;
+        }
+    }
+}

--- a/Test/stubs/Magento/Framework/Event/ObserverInterface.php
+++ b/Test/stubs/Magento/Framework/Event/ObserverInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real interface is absent.
+ * One type per file so Magento's DI PhpScanner can parse it.
+ */
+
+namespace Magento\Framework\Event;
+
+if (!interface_exists(\Magento\Framework\Event\ObserverInterface::class, false)) {
+    interface ObserverInterface
+    {
+        /**
+         * @param Observer $observer
+         * @return void
+         */
+        public function execute(Observer $observer);
+    }
+}

--- a/Test/stubs/Magento/Framework/Exception/LocalizedException.php
+++ b/Test/stubs/Magento/Framework/Exception/LocalizedException.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Observer\QuoteSubmitBefore throws this to abort an order submission, and catches it
+ * around State::getAreaCode(). The real constructor takes a Phrase; this one accepts
+ * anything stringable, because the Test/stubs __() returns a plain string.
+ */
+
+namespace Magento\Framework\Exception;
+
+if (!class_exists(\Magento\Framework\Exception\LocalizedException::class, false)) {
+    class LocalizedException extends \Exception
+    {
+        /**
+         * @param mixed $phrase
+         * @param \Throwable|null $cause
+         * @param int $code
+         */
+        public function __construct($phrase = '', ?\Throwable $cause = null, $code = 0)
+        {
+            parent::__construct((string)$phrase, (int)$code, $cause);
+        }
+    }
+}

--- a/Test/stubs/Magento/Framework/Notification/MessageInterface.php
+++ b/Test/stubs/Magento/Framework/Notification/MessageInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real interface is absent.
+ * One type per file so Magento's DI PhpScanner can parse it.
+ *
+ * The SEVERITY_* values mirror the real interface's, because
+ * UnverifiedAdminOrderMessage::getSeverity() returns one of them and a test asserting the
+ * severity would otherwise be asserting against a number this file invented.
+ */
+
+namespace Magento\Framework\Notification;
+
+if (!interface_exists(\Magento\Framework\Notification\MessageInterface::class, false)) {
+    interface MessageInterface
+    {
+        const SEVERITY_CRITICAL = 1;
+        const SEVERITY_MAJOR = 2;
+        const SEVERITY_MINOR = 3;
+        const SEVERITY_NOTICE = 4;
+
+        /**
+         * @return string
+         */
+        public function getIdentity();
+
+        /**
+         * @return bool
+         */
+        public function isDisplayed();
+
+        /**
+         * @return string
+         */
+        public function getText();
+
+        /**
+         * @return int
+         */
+        public function getSeverity();
+    }
+}

--- a/Test/stubs/Magento/ImportExport/Model/Import.php
+++ b/Test/stubs/Magento/ImportExport/Model/Import.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Only the behaviour constants are stubbed: Plugin\Admin\ValidateImportAddress compares
+ * the subject's behaviour against BEHAVIOR_ADD_UPDATE and does nothing else with this
+ * class. The values match Magento's, so a test that sets the wrong behaviour really does
+ * take the "not our behaviour" branch.
+ */
+
+namespace Magento\ImportExport\Model;
+
+if (!class_exists(\Magento\ImportExport\Model\Import::class, false)) {
+    class Import
+    {
+        const BEHAVIOR_APPEND = 'append';
+        const BEHAVIOR_ADD_UPDATE = 'add_update';
+        const BEHAVIOR_REPLACE = 'replace';
+        const BEHAVIOR_DELETE = 'delete';
+        const BEHAVIOR_CUSTOM = 'custom';
+    }
+}

--- a/Test/stubs/Magento/ImportExport/Model/Import/AbstractEntity.php
+++ b/Test/stubs/Magento/ImportExport/Model/Import/AbstractEntity.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Only the error code Plugin\Admin\ValidateImportAddress reports with is stubbed; the value
+ * matches Magento's, so a test can assert the code the merchant's import report is grouped
+ * by rather than a placeholder.
+ */
+
+namespace Magento\ImportExport\Model\Import;
+
+if (!class_exists(\Magento\ImportExport\Model\Import\AbstractEntity::class, false)) {
+    abstract class AbstractEntity
+    {
+        const ERROR_CODE_SYSTEM_EXCEPTION = 'systemException';
+    }
+}

--- a/Test/stubs/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingError.php
+++ b/Test/stubs/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingError.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * Only the severity levels are stubbed. Plugin\Admin\ValidateImportAddress reports at
+ * ERROR_LEVEL_CRITICAL, which is the level that makes Magento refuse the import rather than
+ * merely annotate it, so the distinction is load-bearing and the values match Magento's.
+ */
+
+namespace Magento\ImportExport\Model\Import\ErrorProcessing;
+
+if (!class_exists(\Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingError::class, false)) {
+    class ProcessingError
+    {
+        const ERROR_LEVEL_CRITICAL = 'critical';
+        const ERROR_LEVEL_NOT_CRITICAL = 'non-critical';
+        const ERROR_LEVEL_WARNING = 'warning';
+        const ERROR_LEVEL_NOTICE = 'notice';
+    }
+}

--- a/Test/stubs/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregator.php
+++ b/Test/stubs/Magento/ImportExport/Model/Import/ErrorProcessing/ProcessingErrorAggregator.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real class is absent.
+ * One class per file so Magento's DI PhpScanner can parse it.
+ *
+ * This is the object Address::validateData() returns and that
+ * Plugin\Admin\ValidateImportAddress::afterValidateData() both receives as $result and adds
+ * its errors to. addError() keeps the real signature - and, in particular, the real PARAMETER
+ * ORDER - because the plugin passes the row number positionally as the third argument: a
+ * stub that reordered them would make a mis-attributed row number look correct.
+ */
+
+namespace Magento\ImportExport\Model\Import\ErrorProcessing;
+
+if (!class_exists(\Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregator::class, false)) {
+    class ProcessingErrorAggregator
+    {
+        /**
+         * @param string $errorCode
+         * @param string $errorLevel
+         * @param int|null $rowNumber
+         * @param string|null $columnName
+         * @param string|null $errorMessage
+         * @param string|null $errorDescription
+         * @return $this
+         */
+        public function addError(
+            $errorCode,
+            $errorLevel = ProcessingError::ERROR_LEVEL_CRITICAL,
+            $rowNumber = null,
+            $columnName = null,
+            $errorMessage = null,
+            $errorDescription = null
+        ) {
+            return $this;
+        }
+    }
+}

--- a/Test/stubs/Magento/Store/Model/ScopeInterface.php
+++ b/Test/stubs/Magento/Store/Model/ScopeInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real interface is absent.
+ * One type per file so Magento's DI PhpScanner can parse it.
+ *
+ * The constant VALUES matter and are the framework's own ('store', 'website'), not tokens
+ * invented here: Helper\Data passes them straight to ScopeConfigInterface::getValue(), so a
+ * test asserting the scope a config read used is asserting these strings. Inventing values
+ * would let a wrong-scope read pass.
+ */
+
+namespace Magento\Store\Model;
+
+if (!interface_exists(\Magento\Store\Model\ScopeInterface::class, false)) {
+    interface ScopeInterface
+    {
+        const SCOPE_STORE = 'store';
+        const SCOPE_STORES = 'stores';
+        const SCOPE_WEBSITE = 'website';
+        const SCOPE_WEBSITES = 'websites';
+    }
+}

--- a/Test/stubs/Magento/Store/Model/StoreManagerInterface.php
+++ b/Test/stubs/Magento/Store/Model/StoreManagerInterface.php
@@ -10,5 +10,15 @@ namespace Magento\Store\Model;
 if (!interface_exists(\Magento\Store\Model\StoreManagerInterface::class, false)) {
     interface StoreManagerInterface
     {
+        /**
+         * Declared without a return type on purpose: the real interface returns
+         * StoreInterface[] and a narrower signature here would not be satisfiable by the
+         * lightweight doubles the unit tests use.
+         *
+         * @param bool $withDefault
+         * @param bool $codeKey
+         * @return array
+         */
+        public function getStores($withDefault = false, $codeKey = false);
     }
 }

--- a/Test/stubs/Magento/Store/Model/StoreManagerInterface.php
+++ b/Test/stubs/Magento/Store/Model/StoreManagerInterface.php
@@ -11,13 +11,14 @@ if (!interface_exists(\Magento\Store\Model\StoreManagerInterface::class, false))
     interface StoreManagerInterface
     {
         /**
-         * Declared without a return type on purpose: the real interface returns
-         * StoreInterface[] and a narrower signature here would not be satisfiable by the
-         * lightweight doubles the unit tests use.
+         * Signature copied from the framework's, including the absence of a native return type
+         * and both default values. It is NOT loosened for the tests' benefit: a stub that
+         * diverges from the interface it stands in for lets a real incompatibility pass a green
+         * suite, which is the one thing a stub must never do.
          *
          * @param bool $withDefault
          * @param bool $codeKey
-         * @return array
+         * @return \Magento\Store\Api\Data\StoreInterface[]
          */
         public function getStores($withDefault = false, $codeKey = false);
     }

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+    Adminhtml-only DI: the system message below is a notice for merchants and has no meaning
+    outside the admin area, so it is registered here rather than in etc/di.xml.
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\Notification\MessageList">
+        <arguments>
+            <argument name="messages" xsi:type="array">
+                <item name="loqateUnverifiedAdminOrder" xsi:type="string">Loqate\ApiIntegration\Model\AdminNotification\UnverifiedAdminOrderMessage</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -7,6 +7,13 @@
         is persisted. This is the correct hook for Hyvä Checkout compatibility
         because Hyvä does not use the REST ShippingInformationManagement or
         BillingAddressManagement services that the existing plugins intercept.
+
+        DO NOT move this into etc/frontend/events.xml. Hyvä GraphQL checkout runs in the
+        'graphql' area and the REST checkout in 'webapi_rest', and NEITHER inherits
+        'frontend', so a frontend-only registration would silently disable verification on
+        the exact paths this observer was added for. The registration is global on purpose;
+        admin order create - which Plugin\Admin\OrderSave already verifies in one batch
+        call - is excluded at runtime instead, in QuoteSubmitBefore::isAdminArea().
     -->
     <event name="sales_model_service_quote_submit_before">
         <observer name="loqate_quote_submit_before_validate"


### PR DESCRIPTION
Fixes [LOQ-16976](https://gbg.atlassian.net/browse/LOQ-16976), [LOQ-16977](https://gbg.atlassian.net/browse/LOQ-16977), [LOQ-16978](https://gbg.atlassian.net/browse/LOQ-16978) and [LOQ-16979](https://gbg.atlassian.net/browse/LOQ-16979).

> **Stacked PR.** Base is `fix/LOQ-16969-dedupe-verify-requests` (#40), not `master`, so the diff shows only this branch's work and can reuse #40's cache primitives instead of duplicating them. Retarget to `master` once #40 merges.

> **⚠️ This PR grew beyond its title.** It opened as LOQ-16976 + LOQ-16977. LOQ-16978 and LOQ-16979 were then implemented on the same branch, followed by fixes for what an adversarial review of the whole series found — including two defects in the earlier commits. That is four tickets in one PR, against this repo's one-ticket-per-stacked-PR convention. **Say the word and I will split the last seven commits into a PR stacked on this one**; they are a contiguous run from `3360b7a` onward and separate cleanly.

LOQ-16969 (#40) stopped the *single*-address verify path re-billing. This does the same for the *batch* path, fixes the response-to-address attribution that per-address caching depends on, then bounds and scopes the session stores those caches live in.

---

# LOQ-16977 — index attribution

`array_search(false, $addressesToCheck)` searched an array whose values were all truthy, so it always returned `false`, which coerces to key `0`. Every API response row overwrote `$result[0]`, and the captured addresses' own verdicts were never merged into `$result` at all — dropped silently, except via the early return when nothing needed the API. It failed *open*: callers simply never iterate the missing keys, which is why it went unnoticed.

Each sent address now records its original key in a parallel array, and every verdict is attributed through it. Slots are reserved in input key order, which is load-bearing: `ValidateImportAddress` merges chunks with `array_merge()`, which renumbers integer keys by insertion order, so an out-of-order result would silently mis-number every import row.

**Scope correction vs the ticket text:** this only triggers when `$checkForCaptured = true` *and* at least one captured address matches — i.e. admin order create (`Plugin/Admin/OrderSave.php:49`). Customer import passes `false` and took the correct sequential branch, so **import was never affected by the mis-attribution**.

# LOQ-16976 — batch verdict cache

Verdicts here come from the **AQI**, not the AVC, so the cache is a **physically separate session attribute** from the single-address one — not a prefix inside a shared array — making conflation structurally impossible rather than convention-enforced. Its fingerprint hashes the AQI threshold `checkQualityIndex()` actually gates on, not the AVC comparer string.

The cache is consulted per address before the payload is built, so a batch bills only its misses: 5 addresses with 3 already verified sends 2. An all-hit or all-captured batch sends **no request**. Failures are never cached.

## Admin order create was billing both paths

`sales_model_service_quote_submit_before` is registered globally, so `QuoteSubmitBefore` fired on admin order create and billed up to 2 single-address calls on top of the batch call. AQI and AVC verdicts cannot be shared, so the fix is to stop the redundant path running: an `App\State` guard returning early on `adminhtml`.

Registration is deliberately **not** moved to `etc/frontend/events.xml`. The observer exists for Hyvä's GraphQL checkout, and `graphql`/`webapi_rest` are separate area codes that do not inherit `frontend` — the move would silently disable verification on the exact path it was built for. A note in `etc/events.xml` records this, because `etc/frontend/` and `etc/adminhtml/` both already exist and the mistake is one file away.

**That guard has a sharp edge, and it is now surfaced rather than documented.** With `enable_create_order_admin` **off** and `enable_checkout` **on**, this observer had been the only thing verifying an admin-created order — and nothing is now. The behaviour is kept deliberately (`enable_create_order_admin = No` is the merchant asking for admin order create not to be verified), but a merchant in that state configured verification on and has none. See the admin notice below.

## Two faults found while building this, neither in the tickets

**1. Positional attribution was unsound (data corruption).** The connector's `array_column($response, 'Matches')` (`vendor/lqt/api-connector/src/Client/Verify.php:51`) drops records *missing* the key and reindexes, so a mid-list error envelope shifted row *N* onto address *N-1* — and the new cache would then persist that verdict under the **wrong address's signature**. The same flattening collapses `{"Items":…}`, `{}` and `{"error":"Unauthorized"}` to `[]`, so an import previously ran **fully unverified with no diagnostic**. A row-count guard now rejects any mismatch outright and logs it.

**2. `checkQualityIndex()` failed open on the response side.** `null <= 'A'` is `true` under PHP 8, so a row with no readable AQI was answered **VALID**, while `verifyAddress()` fails closed on the equivalent missing AVC. Now fails closed on shape (`!is_string($qualityIndex) || $qualityIndex === ''`). The *threshold* side of the same comparison turned out to fail open too — see LOQ-16969 hardening below; that one was missed on the first pass.

These two guards catch **disjoint** faults — neither subsumes the other. Verified on PHP 8.3: `array_column()` only drops records *missing* the key; a record that **has** `Matches` set to `[]` or `null` **survives** with the count preserved, sails past the count guard, and reaches the comparison. That shape is precisely Loqate reporting *no match found*, where "valid" is the worst possible answer.

## Import hardening

`ValidateImportAddress` no longer crashes on a mid-import API failure. `verifyMultipleAddresses()` returns `false` on API error and `['noKeyFound' => true]` with no API key, and `array_merge($allRowsResult, false)` is a **TypeError in PHP 8** that the surrounding `catch (\Exception)` does not catch. Both shapes are handled before the merge; the row-number arithmetic is unchanged (it was already correct — each batch returns keys `0..N-1`, so merging preserves row numbers).

---

# LOQ-16978 — bound the captured-address store, and stop it outliving its shopper

`captured_addresses` grew by one serialised address per Capture `retrieve()` call, unbounded, for the whole session — and a match in it is an outright **verify bypass**. Two problems followed: an inflated session payload on every request, and a bypass that outlived the shopper who earned it, because `session_regenerate_id()` preserves session data so logout/login alone does not clear it.

Bounded at **50 with FIFO eviction**, matching `VERIFY_CACHE_LIMIT`: the two stores are consulted for the same addresses by the same verify call, so different bounds would only mean one holding entries the other evicted. `BATCH_VERIFY_CACHE_LIMIT`'s 200 exists to hold a 100-row import chunk, and no import writes this store.

`Helper/ShopperScopedAddressStores.php` is now the **only** route to the three address stores. Every access compares the customer id against a sibling owner marker and flushes all three when it changes, covering guest → logged in, A → B and logged in → guest. The raw session property is removed from both helpers, so no path reaches those attributes unguarded, and `assertEnrolled()` **throws** for an unenrolled key rather than letting it silently escape the flush. An unreadable id gets its own negative sentinel so it can never collide with the guest owner.

Also: the store now de-duplicates on the same normalised projection `checkForCapturedAddress()` matches on, rather than on serialised bytes, so it cannot spend several slots on one address the matcher treats as one — and `checkForCapturedAddress()` rejects a non-array store and skips non-string elements, because the production serializer forwards to `json_decode()`, whose string parameter raises a `TypeError` the existing `InvalidArgumentException` catch does not cover. A malformed store now costs a missed bypass, never a fatal mid-checkout.

# LOQ-16979 — key verify verdicts on the region actually sent to Loqate

A cached success was keyed on a signature that **dropped the region entirely**, so once any region variant of an address was accepted, every variant Loqate had not explicitly rejected passed from cache too. A shopper could get an address through carrying a region that was never verified. This was the accepted cost of #40's asymmetric strict/lossy key pair, taken because the region label churns.

**The first attempt at this fix was wrong and was replaced, not patched.** It substituted a canonicaliser mirroring the Irish label rewrites quoted in LOQ-16969 — strip `County `, prefix `Co. `, rewrite `Dublin` to `Dublin 1`. Those rules do not belong in this module: `handleRetrieveApiResponse` does not exist here and `view/base/web/capture.js` contains no such rewriting. They came from the reporter's own fork. Worse, they merged in the **unsafe direction** — folding `County Dublin` onto `Dublin 1`, two different places, while splitting it from its own synonym `Co. Dublin` — so the bypass survived *and* the LOQ-16969 saving failed at the same time.

**What ships instead:** key on `Address4`, the region value actually sent to Loqate. `parseAddress()` already resolves it from `region_id` when one is present and from the raw `region` string when not, so this single choice is the whole fix — two submissions share a verdict **if and only if they asked Loqate the same question**.

- `County Dublin` and `Dublin 1` are different region records → two keys → the second is verified in its own right.
- `Meath` / `Co. Meath` / `County Meath` arriving around one `region_id` are all overwritten by `parseAddress()` with that record's name → one key. They were never distinct requests.
- **Zero country-specific rules anywhere.**

Keyed on the resolved **name** rather than the numeric `region_id` deliberately: the name is what was billed, so there is no coarsening in either direction, whereas the id is *finer* than the request and would split the quote-path shape (`'region_id' => 100`) from the POST-path shape (`'region' => 'Greater London'`) of one address, billing a single checkout twice. Pinned by `testBothCheckoutCallPathShapesOfOneAddressAreBilledOnce()`.

**The asymmetry is gone.** Because the region no longer churns in the key, successes and rejections no longer need separate keys. The strict and lossy builders, the success-key marker and the whole key-family disjointness argument are deleted — **one signature, on every read and every write, on both paths**, and net ~290 lines fewer than the design it replaces.

Accepted limit, in the safe direction: with no `region_id`, the region text *is* the region, so re-spelling it is a different key and costs one extra verification. A re-bill, never a bypass — replacing a collapse of label spellings that *was* a bypass.

# LOQ-16969 — hardening found by reviewing the series

**An unrecognised Address Quality Index threshold passed every address.** The threshold is compared with `<=`, a string comparison. The earlier revision reasoned only about a *blank* threshold (`'A' <= null` is `false`, so everything is rejected — safe) and left it. Wrong case: `'E' <= 'zzz'` is **`true`**, so a threshold of any text sorting above `E` silently approved every address on the batch paths, including the worst grade Loqate returns. Valid values are now `A`–`E`; anything else rejects and logs. Pinned over six values including the plausible `c` and `C+` typos.

**The enrolment assertion was being swallowed.** `ValidateImportAddress` caught `\Exception` around the whole verification block, which included `assertEnrolled()` reporting an unguarded session store. The plugin has no logger — its base class serves ten plugins and does not carry one — so the one assertion built to be impossible to ignore was landing nowhere. `\InvalidArgumentException` now propagates; genuine runtime faults are still absorbed.

**The admin now gets told when order create verifies nothing.** `Model/AdminNotification/UnverifiedAdminOrderMessage` raises a system message naming the affected settings, in the words the admin UI uses, when it detects `enable_create_order_admin` off with `enable_checkout` on. Evaluated **per store view**, because `enable_checkout` is `showInStore` while `enable_create_order_admin` is `showInDefault` only — a single scope-less read resolves to the default store in the admin area and would have been blind to exactly the configuration that produces the gap. Inactive store views are skipped (a disabled view cannot take an order, and a spurious MAJOR notice is what teaches an admin to dismiss the next one unread).

**The batch verdict cache is stamped with the key-scheme version**, like the single-address one. It needed it *more*: that store holds only **passes**, so a stale entry replayed after a deploy is a false **accept**, where the single-address cache can at worst replay a refusal the shopper can clear.

Plus a rename — `ShopperScopedSession` → `ShopperScopedAddressStores`, because it guards the three address stores and not the module's session generally — and the removal of several comments that outlived the fixes they declined, each capable of talking a reader into restoring the defect on a superseded paragraph's authority.

---

# Merchant-visible changes

`CHANGELOG.md` is added in this PR and is the authority; both entries are action-required.

1. **Admin order create is no longer AVC-checked** and obeys only the `enable_create_order_admin` toggles. Merchants running `enable_create_order_admin = No` with `enable_checkout = Yes` now verify nothing there and must switch the admin toggle on. The new system message names them.
2. **An unrecognised `address_quality_index` now rejects addresses** instead of accepting all of them. Only affects installs that wrote the value via a data patch, `config:set` or SQL, since the field has no admin form control.
3. **A customer import can now fail where it previously continued silently** — the plugin no longer absorbs `\InvalidArgumentException`. In practice that is the module reporting a programming error, but a core or third-party one raised during verification will now fail the import rather than pass it silently.
4. An import that previously passed rows whose **response** AQI could not be read will now reject them, and an admin order carrying such an address will be blocked instead of placed. Intended.

# Tests

`OK (328 tests, 1419 assertions)`, up from #40's 97/532.

**Runs in a container only** — this repo's suite needs `ext-dom`/`ext-mbstring`/`ext-xmlwriter`, which the dev host lacks:

```
docker run --rm -v "$PWD":/app -w /app php:8.3-cli ./vendor/bin/phpunit
```

**A green suite was explicitly not treated as evidence.** Each acceptance criterion was mutation-verified by breaking the production code and confirming the suite goes red:

| Mutation | Result |
| --- | --- |
| Reintroduce label-based region collapsing | 9 failures |
| Drop the region from the cache key (the original defect) | 18 failures |
| Remove the batch key-scheme check | 1 failure |
| Remove the threshold whitelist | 2 failures |
| Restore the broad `catch (\Exception)` | 2 failures |
| Point both verdict caches at one session key | 10 failures |
| Revert the notice to a single scope-less config read | 1 failure |
| Drop `$storeId` from `getConfigValueForStore()` | 2 failures |
| Delete the batch cross-cache shape guard | 1 failure |

The last two of those were **green** until the final commit, which is the point: `Helper\Data` had no tests at all, and the notice's own test stubs `Data` and models Magento's config inheritance itself, so it asserted that model rather than the mechanism. The cross-cache shape guard was defended by a test that planted an unstamped entry — once the batch cache gained a stamp, the stamp check rejected the plant first and deleting the shape guard left the test green.

The region tests are written as **behavioural invariants** ("two submissions share a verdict if and only if they resolve to the same region"; "a region never verified is never served another region's success"), established on the wire rather than from control flow, and include a case that fails if label collapsing is reintroduced. This matters because the suite previously contained a test asserting that a never-rejected region variant is *"deliberately"* served the cached success — added by #40 to defend the behaviour that three commits later became LOQ-16979. The suite endorsed the defect until a customer reported it.

`Helper/Data`, `Observer/QuoteSubmitBefore`, `Plugin/Admin/ValidateImportAddress` and the new notice had **zero** prior coverage.

# Deferred, with tickets

- **[LOQ-17148](https://gbg.atlassian.net/browse/LOQ-17148)** — the **customer import half of LOQ-16976 is not fixed**, and the code says so. Eviction is FIFO, so re-running a file larger than the 200-entry cache yields close to zero hits; only passing verdicts are cached; and `address_quality_index` defaults to `A` with no admin field to loosen it, so most rows fail and are never cacheable. Practical dedupe on that path is near nil. The ticket carries the two fixable causes.
- **[LOQ-17149](https://gbg.atlassian.net/browse/LOQ-17149)** — `loqate_email`, `loqate_phone`, `loqate_email_to_validate` and `loqate_billing_errors` are still unbounded verify-bypass session stores, the first two holding **raw PII**, and are not enrolled in the shopper-change flush. Also covers the admin-identity gap: the flush scopes by *customer*, so an admin-user swap in one browser is not covered, and the batch cache's flush is a no-op in adminhtml where the customer session holds no customer id.
- **[LOQ-17015](https://gbg.atlassian.net/browse/LOQ-17015)** — the same address repeated within one batch is still billed once per occurrence; both copies miss in the pre-flight pass. Matters most for imports, where a CSV legitimately repeats addresses. Any dedupe must preserve the one-response-row-per-sent-item assumption the count guard depends on; the code comments name the safe and unsafe implementations.
- **Concurrency** — read/bill/write is not atomic, so two genuinely concurrent submissions of the same batch can both bill. Same documented limit as #40; locking deliberately not attempted.
- **Response-side AQI residual, for reviewer judgement.** The response-AQI guard is a shape test, so garbage sorting at or below the threshold still passes (`'0'`, `'5'`, `'!'`). Narrowing it needs the Cleansing API's documented AQI value set, which is not establishable from this repo, and over-rejection blocks imports and orders — worse than the residual. The *threshold* side is now whitelisted; the *response* side is deliberately not. `testALegitimateQualityIndexStillPassesAndIsStillCached()` pins that distinction.
- **Two small design items left open on purpose.** `ShopperScopedAddressStores` is constructed with `new` rather than injected — the flush is reachable through the injected session double and pinned end-to-end, so it cannot break silently, and churning fixtures under review pressure was judged the worse risk. And `assertEnrolled()` could throw a module-specific exception subclass so the narrowed catch is exact rather than well-reasoned; the comment names it.
- Ten test comments cite `Helper/Validator.php` line numbers that have since shifted. Cosmetic; not corrected rather than churn ten files.
