### PR TITLE
fix(LOQ-17148): dedupe an import run's repeated addresses, and descope cross-run with the numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ predate it and are described by their git tags and commit history.
   admin field, so this only affects installs that wrote it via a data patch,
   `config:set`, or direct SQL.
 
+- **No change to which import rows are rejected.** `checkQualityIndex()` now
+  distinguishes "readable quality index that misses the threshold" from "quality
+  index or threshold that could not be read", because the first is a verdict worth
+  remembering and the second is a fault report. Both still reject the row, an
+  unreadable threshold still rejects every row including grade `E`, and it is still
+  logged every time.
+
 - **A customer import can now fail where it previously continued silently.** The
   import plugin used to absorb every exception and hand back an untouched result,
   which meant a misconfiguration inside the module surfaced as an import reporting
@@ -48,6 +55,18 @@ predate it and are described by their git tags and commit history.
   in one session, at checkout and on admin order create (LOQ-16969, LOQ-16976).
   Verify verdicts are cached per shopper for the session, keyed on the region value
   actually sent to Loqate.
+- Repeated billable requests for the same address across the chunks of ONE customer
+  import run (LOQ-17148). An import file is verified in chunks of 100 rows inside a
+  single request, and the session cache holds passing verdicts only — so a REJECTED
+  address was re-sent, and re-billed, in every chunk it appeared in, which on a
+  default install (strictest threshold) is most of a file. Verdicts of both polarities
+  are now remembered for the length of the run, so every repeated address costs one
+  billed address however often it appears and however large the file: **29% fewer
+  billed addresses on a 1000-row file holding 700 distinct addresses, 58.8% on 1000
+  rows holding 400.** The run-scoped memory is never persisted — a rejection never
+  outlives the request, so correcting the file or loosening the threshold always
+  re-verifies — and a quality index or threshold that could not be READ is remembered
+  nowhere, so one connector fault cannot mark every matching row invalid.
 - Multi-address verification results were collapsed onto the first row, so one
   address's verdict could be reported against another's (LOQ-16977).
 - A cached verify success could be replayed for a region that was never verified
@@ -62,9 +81,32 @@ predate it and are described by their git tags and commit history.
 
 ### Known limitations
 
-- Repeat-request dedupe is near-nil on the **customer import** path: the batch cache
-  holds 200 entries, and only passing verdicts are cached, so re-running a large
-  file yields few hits (LOQ-17148).
+- **Dedupe across import RUNS is not delivered for a file with more than 200 distinct
+  addresses** (LOQ-17148 delivers dedupe *within* one run, above). The session cache
+  holds 200 entries and evicts oldest-first, so a second Check Data click or a second
+  import of a larger file re-bills essentially every row: a sequential scan through a
+  smaller FIFO cache has a ~0% hit rate. For a programmatic, CLI or cron-driven import
+  it is 0% **by construction** — each process starts a fresh session, so nothing one
+  run writes is ever found by the next.
+
+  Three apparent fixes were measured and rejected, so they are not quietly retried.
+  *Caching failures in the session store* is a regression on the target workload: at a
+  5% pass rate it takes a second run from 950 billed addresses to 1000 (1000 distinct
+  rows) and from 475 to 500 (500 rows), because failures crowd out the sparse passes
+  the bounded FIFO store manages to keep. *Freezing the store when full* would let one
+  Check Data click on a 200-row file fill it for the rest of that admin's browser
+  session, destroying the admin-order-create saving above. *Sizing the store to the
+  file* costs ~147 bytes per entry (~141 KB at 1000 entries, ~712 KB at 5000), and
+  Magento reads and writes the whole session on every request — ~1.4 MB of session I/O
+  on every unrelated admin page load, ~278 MB over 200 page loads, for a re-run that
+  may never happen.
+- The same address repeated **within one 100-row chunk** is still billed twice on that
+  address's first appearance in the run: nothing is remembered until the response
+  returns, so both copies miss. Every later appearance — in that chunk or any other —
+  is answered from memory, so the cost is bounded at one duplicate charge per distinct
+  address per run rather than one per occurrence. Tracked as LOQ-17015, separately from
+  LOQ-17148 and **not resolved by it**, because collapsing duplicates changes the
+  payload row arithmetic and has to be done together with the response-row-count guard.
 - `loqate_email`, `loqate_phone`, `loqate_email_to_validate` and
   `loqate_billing_errors` are still unbounded session stores and are not covered by
   the shopper-change flush (LOQ-17149).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,25 @@ predate it and are described by their git tags and commit history.
   accepting all of them.** The threshold is compared as a string, so any value
   sorting above `E` — a lowercase `c`, a `C+`, or any stray text — previously passed
   every address on the batch paths, including the worst grade Loqate returns. Valid
-  values are `A` to `E`; anything else is refused and logged. The setting has no
-  admin field, so this only affects installs that wrote it via a data patch,
-  `config:set`, or direct SQL.
+  values are `A` to `E`; anything else is refused and logged. Only installs that
+  wrote the value via a data patch, `config:set` or direct SQL can be affected — the
+  new admin field below cannot produce such a value.
+
+- **"Minimum Address Quality Index" is now configurable in the admin**, under
+  Stores → Configuration → Loqate → Address Verification - General (LOQ-17148). It
+  was previously reachable only through the shipped default, a data patch or
+  `bin/magento config:set`. It is a select over `A`–`E` ("Excellent" to "Bad"), whose
+  options are derived from the verifier's own accepted list so the two cannot drift,
+  and it is shown at **default scope only**: the setting is read by admin order create
+  and customer import, and neither names the store view of the order or the customers
+  it is judging — so a website or store-view override could not be relied on to be the
+  value applied, and offering one would be a knob whose effect the form could not
+  predict.
+
+  **The shipped default is unchanged (`A`, "Excellent") and no install's behaviour
+  changes on upgrade.** Loosening the threshold accepts addresses that were
+  previously rejected, so it is a deliberate merchant decision and not a default this
+  release makes for anybody.
 
 - **No change to which import rows are rejected.** `checkQualityIndex()` now
   distinguishes "readable quality index that misses the threshold" from "quality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ predate it and are described by their git tags and commit history.
   old check was reached only after a readable quality index had been found in the
   response.
 
+- **The broken-threshold log line has been reworded**, so anything matching on its
+  text needs updating. It reports the configuration fault only and no longer claims an
+  outcome, because it is now emitted once per batch and a batch can be answered
+  entirely by the captured-address bypass without a single row being refused. It ends
+  `…; no address can pass a quality bar that cannot be read. Set it to one of A, B, C,
+  D, E.` where it previously ended `…; rejecting the address. Set it to one of A, B,
+  C, D, E.`; the leading `Loqate: address_quality_index is not a recognised quality
+  index (<value> of type <type>)` is unchanged.
+
 - **A customer import can now fail where it previously continued silently.** The
   import plugin used to absorb every exception and hand back an untouched result,
   which meant a misconfiguration inside the module surfaced as an import reporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,23 @@ predate it and are described by their git tags and commit history.
   previously rejected, so it is a deliberate merchant decision and not a default this
   release makes for anybody.
 
+  **If you already set this path at website or store-view scope** (`bin/magento
+  config:set --scope=stores …`, a data patch or direct SQL), that row stays in effect
+  and keeps overriding the default for the scope it was written for — the new field is
+  default-scope only, so it can neither display nor clear it. Remove it with
+  `bin/magento config:set --scope=stores --scope-code=<code> …` set back to the value
+  you want, or by deleting the `core_config_data` row, and then set the value here.
+
 - **No change to which import rows are rejected.** `checkQualityIndex()` now
   distinguishes "readable quality index that misses the threshold" from "quality
   index or threshold that could not be read", because the first is a verdict worth
-  remembering and the second is a fault report. Both still reject the row, an
-  unreadable threshold still rejects every row including grade `E`, and it is still
-  logged every time.
+  remembering and the second is a fault report. Both still reject the row, and an
+  unreadable threshold still rejects every row including grade `E`. What did change is
+  the logging: the "not a recognised quality index" line is now emitted once per
+  verified batch, from the pre-flight check described under Fixed, instead of once per
+  verdict — and it is emitted for files that produced none of it before, because the
+  old check was reached only after a readable quality index had been found in the
+  response.
 
 - **A customer import can now fail where it previously continued silently.** The
   import plugin used to absorb every exception and hand back an untouched result,
@@ -76,13 +87,22 @@ predate it and are described by their git tags and commit history.
   single request, and the session cache holds passing verdicts only — so a REJECTED
   address was re-sent, and re-billed, in every chunk it appeared in, which on a
   default install (strictest threshold) is most of a file. Verdicts of both polarities
-  are now remembered for the length of the run, so every repeated address costs one
-  billed address however often it appears and however large the file: **29% fewer
-  billed addresses on a 1000-row file holding 700 distinct addresses, 58.8% on 1000
-  rows holding 400.** The run-scoped memory is never persisted — a rejection never
-  outlives the request, so correcting the file or loosening the threshold always
-  re-verifies — and a quality index or threshold that could not be READ is remembered
-  nowhere, so one connector fault cannot mark every matching row invalid.
+  are now remembered for the length of the run, so **an address repeated in a LATER
+  chunk of the same run costs nothing**, however large the file. Measured on the
+  branch's own acceptance fixture (260 rows, 210 distinct addresses, repeats across
+  chunk boundaries): **19.2% fewer billed addresses**. Two documented cases are not
+  covered and are listed under Known limitations below — copies of an address WITHIN
+  the chunk it first appears in, and a row whose quality index could not be read. The
+  run-scoped memory is never persisted — a rejection never outlives the request, so
+  correcting the file or loosening the threshold always re-verifies.
+- A customer import no longer pays for a verification whose answer is already
+  decided (LOQ-17148). When "Minimum Address Quality Index" holds a value that is not
+  a grade, every row is rejected whatever Loqate answers — so the threshold is now
+  checked BEFORE the request is assembled, every row is rejected without one being
+  made, and the "not a recognised quality index" line is logged once per batch. It
+  previously billed the whole file, on every Check Data click, for an answer that
+  could not change the outcome, and logged nothing at all when the responses were
+  themselves unreadable.
 - Multi-address verification results were collapsed onto the first row, so one
   address's verdict could be reported against another's (LOQ-16977).
 - A cached verify success could be replayed for a region that was never verified
@@ -102,10 +122,10 @@ predate it and are described by their git tags and commit history.
   holds 200 entries and evicts oldest-first, so a second Check Data click or a second
   import of a larger file re-bills essentially every row: a sequential scan through a
   smaller FIFO cache has a ~0% hit rate. For a programmatic, CLI or cron-driven import
-  it is 0% **by construction** — each process starts a fresh session, so nothing one
-  run writes is ever found by the next.
+  it is 0% — each process starts a fresh session, so nothing one run writes is ever
+  found by the next, and no cache *size* changes that.
 
-  Three apparent fixes were measured and rejected, so they are not quietly retried.
+  Four apparent fixes were considered and rejected, so they are not quietly retried.
   *Caching failures in the session store* is a regression on the target workload: at a
   5% pass rate it takes a second run from 950 billed addresses to 1000 (1000 distinct
   rows) and from 475 to 500 (500 rows), because failures crowd out the sparse passes
@@ -115,14 +135,36 @@ predate it and are described by their git tags and commit history.
   file* costs ~147 bytes per entry (~141 KB at 1000 entries, ~712 KB at 5000), and
   Magento reads and writes the whole session on every request — ~1.4 MB of session I/O
   on every unrelated admin page load, ~278 MB over 200 page loads, for a re-run that
-  may never happen.
-- The same address repeated **within one 100-row chunk** is still billed twice on that
-  address's first appearance in the run: nothing is remembered until the response
-  returns, so both copies miss. Every later appearance — in that chunk or any other —
-  is answered from memory, so the cost is bounded at one duplicate charge per distinct
-  address per run rather than one per occurrence. Tracked as LOQ-17015, separately from
-  LOQ-17148 and **not resolved by it**, because collapsing duplicates changes the
-  payload row arithmetic and has to be done together with the response-row-count guard.
+  may never happen. Those three are all session-store variants and none of them moves
+  the CLI/cron figure at all; the one option that would is a **non-session store**
+  (`Magento\Framework\App\CacheInterface`, keyed on the threshold- and
+  store-view-namespaced hash the module already builds). It is rejected here rather
+  than overlooked, and the risk being declined is stated plainly: a verdict held
+  outside the session is not shopper-specific, so it can be read and replayed for
+  another shopper, another admin user, or — on shared infrastructure — another install
+  using the same cache backend, which is the bypass-across-identities leak LOQ-16978
+  was raised to close. Doing it safely needs an identity in the key, a cache tag and
+  lifetime policy, and a decision on whether an address verdict may live outside the
+  session at all. That is its own ticket, raised separately — record its id here.
+- The same address repeated **within the chunk in which it first appears** is billed
+  once per copy: nothing is remembered until the response returns, so every copy in
+  that chunk misses and every copy is sent. The bound is therefore the **chunk size**
+  — 100 identical rows in one chunk cost 100 billed addresses — not one duplicate
+  charge per address. Every appearance in a LATER chunk is free. Tracked as LOQ-17015,
+  separately from LOQ-17148 and **not resolved by it**, because collapsing duplicates
+  changes the payload row arithmetic and has to be done together with the
+  response-row-count guard.
+- A row whose **quality index could not be read** is rejected and remembered nowhere,
+  so it is billed again on every occurrence, for the whole run and every run after it.
+  `'Matches' => []` is Loqate's ordinary answer for an address it cannot match, so on a
+  poorly-matching file that is most of the file. Deliberate: remembering it would let
+  one connector fault or one bad credential mark every matching row invalid for the
+  rest of the run, sending the merchant to correct rows Loqate never rejected.
+- Rows whose address columns are **empty or unusable** produce no identifiable
+  signature, and are deduplicated by neither memory — every occurrence is sent and
+  billed, with no bound. The alternative is worse: one shared key would file every
+  unidentifiable address under the same entry and replay one row's verdict for all of
+  them.
 - `loqate_email`, `loqate_phone`, `loqate_email_to_validate` and
   `loqate_billing_errors` are still unbounded session stores and are not covered by
   the shopper-change flush (LOQ-17149).

--- a/Helper/ShopperScopedAddressStores.php
+++ b/Helper/ShopperScopedAddressStores.php
@@ -107,6 +107,16 @@ use Magento\Customer\Model\Session;
  * getData()/setData() now REJECT any key missing from it so that an un-enrolled attribute
  * cannot quietly acquire the guard's appearance without its protection.
  *
+ * ADDING A STORE THAT IS NOT A SESSION ATTRIBUTE: use ownershipGeneration() (LOQ-17148).
+ * Verdict data does not have to live in the session to belong to one shopper -
+ * Validator::verifyMultipleAddresses() now also remembers batch verdicts in a PLAIN PHP MAP
+ * on the Validator instance, for the length of one import run - and a store this class
+ * cannot flush is a store that survives the flush, which re-opens exactly the hand-off the
+ * class exists to close. Such a store is enrolled by asking ownershipGeneration() before it
+ * is read or written and discarding its own contents when the answer has moved on: one
+ * ownership model, two mechanisms, rather than a second identity check written at a call
+ * site where it would rot independently of this one.
+ *
  * THE MODULE HAS OTHER SESSION ATTRIBUTES, and they are NOT enrolled here - named so the
  * next reader does not conclude there are only three. Out of scope for LOQ-16978, which is
  * about the ADDRESS stores. THIS IS TRACKED, NOT ACCEPTED: enrolling them is LOQ-17149,
@@ -204,6 +214,21 @@ class ShopperScopedAddressStores
     private $session;
 
     /**
+     * How many times THIS instance has flushed the stores because the identity changed.
+     *
+     * A COUNTER RATHER THAN A BOOLEAN, and per instance rather than per session: it is read
+     * by holders of data that is derived from these stores but does not live in them (see
+     * ownershipGeneration()), and such a holder has to be able to tell "no flush since I last
+     * looked" from "flushed twice since I last looked". A boolean cannot, and a flag that had
+     * to be cleared by its reader would be wrong the moment there were two readers.
+     *
+     * Not persisted anywhere, deliberately. It describes THIS request's view of the stores,
+     * which is the only lifetime the derived data it protects has; written to the session it
+     * would grow without bound and mean nothing to the next request.
+     */
+    private int $flushGeneration = 0;
+
+    /**
      * @param Session $session The per-shopper customer session the stores live in.
      */
     public function __construct(Session $session)
@@ -247,6 +272,54 @@ class ShopperScopedAddressStores
         $this->enforceOwnership();
 
         $this->session->setData($key, $value);
+    }
+
+    /**
+     * Enforce ownership NOW and report which generation of the stores the caller is looking
+     * at, so data DERIVED from them - held anywhere, not only in the session - can be
+     * discarded on the same identity change that flushes them (LOQ-17148).
+     *
+     * WHAT PROBLEM THIS SOLVES. Validator::verifyMultipleAddresses() remembers batch verdicts
+     * for the length of one import run in a plain map on the Validator instance, because a
+     * run chunks at 100 rows inside ONE request and the session store cannot serve it (it is
+     * bounded and holds passes only - see Validator::BATCH_VERIFY_CACHE_LIMIT). That map holds
+     * exactly the same kind of data as self::BATCH_VERIFY_CACHE_SESSION_KEY - licences to skip
+     * a billable verify - so it must have the same OWNERSHIP lifetime. A plain request-scoped
+     * map does not: one Validator can outlive a mid-request identity change (a login handled
+     * by the same PHP request), and the map would then answer the new shopper with the old
+     * shopper's verdicts while the three session stores beside it had just been flushed. That
+     * is precisely the hand-off this class exists to stop, arriving through a store this class
+     * could not see.
+     *
+     * WHY A GENERATION RATHER THAN A CALLBACK OR A FLUSH LIST. This class holds no reference
+     * to its holders and must not start holding one: it is constructed inside Controller's and
+     * Validator's constructors and reaching back into them would invert that dependency and
+     * make the flush order matter. A monotonic counter inverts the responsibility instead -
+     * the guard states a fact about the stores, and each holder decides what its own derived
+     * data means when that fact changes. It also composes: any number of holders can read it
+     * independently, and none of them can consume the signal from under another.
+     *
+     * ENFORCES OWNERSHIP ITSELF, and that is the load-bearing half. A caller that consulted
+     * its own map BEFORE touching any session attribute - which is exactly what the run map
+     * does on the import path, where the captured-address read is skipped - would otherwise
+     * read a generation from before the flush and serve a stale verdict on the first address
+     * of the request. Asking through this method makes the check happen at the moment the
+     * derived data is used, on the same terms as getData()/setData().
+     *
+     * NO KEY, AND THEREFORE NO assertEnrolled() CALL. There is no attribute to enrol: this
+     * reports on the whole flush unit named by self::SHOPPER_SCOPED_SESSION_KEYS, all of
+     * which are flushed together. The assertion still governs every attribute reachable
+     * through this class, which is what it is for.
+     *
+     * @return int Generation of the shopper-scoped stores as of this call. Compare it against
+     *             the value seen last time; any difference means the stores were flushed in
+     *             between and anything derived from them must be discarded.
+     */
+    public function ownershipGeneration(): int
+    {
+        $this->enforceOwnership();
+
+        return $this->flushGeneration;
     }
 
     /**
@@ -349,6 +422,12 @@ class ShopperScopedAddressStores
             foreach (self::SHOPPER_SCOPED_SESSION_KEYS as $key) {
                 $this->session->setData($key, null);
             }
+
+            // Counted AFTER the stores are actually cleared, and only in this branch: the
+            // ADOPTION path below flushes nothing, so it must not advance the generation or
+            // every first access of a session would throw away derived data that is still
+            // valid. See ownershipGeneration() for who reads this and why it is a counter.
+            $this->flushGeneration++;
         }
 
         $this->session->setData(self::SESSION_OWNER_KEY, $owner);

--- a/Helper/ShopperScopedAddressStores.php
+++ b/Helper/ShopperScopedAddressStores.php
@@ -55,20 +55,27 @@ use Magento\Customer\Model\Session;
  * unchanged, so the four test files that pin these names as literals keep passing and no
  * live session loses its stores at deploy time.
  *
- * ADOPTION, stated so it is not mistaken for a hole. When NOTHING has been recorded yet,
- * the current identity ADOPTS whatever is in the stores instead of flushing it. That case
- * is reachable only for data written BEFORE this class existed, because from now on the
- * marker is written on the first access of a session, long before anything can be stored.
- * Adopted data was, by definition, written in THIS session - though not necessarily by
- * whoever is at the browser NOW: a session that was already live at deploy time, in which
- * shopper A logged out before the module's first post-release access, lands in the
- * adoption branch and hands A's stores to the guest that follows. That is accepted rather
- * than defended against, on three grounds: it is exactly the pre-change behaviour, so it
- * is not a regression this ticket introduces; it is bounded to one release and to sessions
- * that were mid-flight during it; and it closes the moment ANY identity change is observed
- * after the marker is written. The alternative - flushing on first access - would buy
- * nothing for every session started after the deploy and would throw away every live
- * shopper's capture bypass at deploy time.
+ * ADOPTION, stated so it is not mistaken for a hole - and so its reach is not understated,
+ * which an earlier revision of this paragraph did (LOQ-17148 mutation review). When NOTHING
+ * has been recorded yet, the current identity ADOPTS whatever is in the SESSION stores
+ * instead of flushing them. Two things reach that branch, not one:
+ *  - data written BEFORE this class existed. A session that was already live at deploy time,
+ *    in which shopper A logged out before the module's first post-release access, hands A's
+ *    stores to the guest that follows. Accepted rather than defended against, on three
+ *    grounds: it is exactly the pre-change behaviour, so it is not a regression this ticket
+ *    introduces; it is bounded to one release and to sessions mid-flight during it; and it
+ *    closes the moment ANY identity change is observed after the marker is written. The
+ *    alternative - flushing on first access - would buy nothing for any session started
+ *    after the deploy and would throw away every live shopper's capture bypass at deploy
+ *    time;
+ *  - a session storage that is EMPTIED mid-flight, which erases the marker along with the
+ *    stores it describes (Magento\Framework\Session\SessionManager::clearStorage(), the
+ *    destroy() inside Magento\Customer\Model\Session::logout(), or another module doing
+ *    either). Nothing about that is bounded to a release: it is reachable at any time, and
+ *    the identity may well have changed in the same breath. For the three SESSION stores it
+ *    is harmless - they were emptied too, so there is nothing left to hand over - but for
+ *    data DERIVED from them and held elsewhere it is not, which is why adoption counts as a
+ *    new ownership epoch; see enforceOwnership() and ownershipGeneration().
  *
  * ACCEPTED LIMITS, stated (the style of Validator::verifyMultipleAddresses()):
  *  - THE GUARD SCOPES BY CUSTOMER IDENTITY ONLY. The marker tracks
@@ -214,19 +221,33 @@ class ShopperScopedAddressStores
     private $session;
 
     /**
-     * How many times THIS instance has flushed the stores because the identity changed.
+     * How many OWNERSHIP EPOCHS this instance has seen: the number of times ownership of the
+     * stores has been established or re-established since it was constructed.
+     *
+     * NOT A FLUSH COUNT, and the distinction is the whole point (LOQ-17148 mutation review).
+     * enforceOwnership() advances this whenever it WRITES the owner marker - on a flush, and
+     * equally on an ADOPTION, where the marker was absent and nothing was flushed. Both mean
+     * the same thing to a reader: the stores are now owned by an identity that is not
+     * demonstrably the one any previously derived data was earned under. Counting flushes only
+     * would miss the case where the session storage is emptied mid-request - see
+     * enforceOwnership() for the concrete mechanism - which erases the marker and so turns the
+     * NEXT identity change into an adoption that no flush is counted for.
      *
      * A COUNTER RATHER THAN A BOOLEAN, and per instance rather than per session: it is read
      * by holders of data that is derived from these stores but does not live in them (see
-     * ownershipGeneration()), and such a holder has to be able to tell "no flush since I last
-     * looked" from "flushed twice since I last looked". A boolean cannot, and a flag that had
-     * to be cleared by its reader would be wrong the moment there were two readers.
+     * ownershipGeneration()), and such a holder has to be able to tell "same epoch as when I
+     * last looked" from "two epochs have passed since I last looked". A boolean cannot, and a
+     * flag that had to be cleared by its reader would be wrong the moment there were two
+     * readers. A counter also beats reporting the OWNER ID itself, which was the other
+     * candidate: an A -> B -> A cycle inside one request returns to the same id while the
+     * stores were genuinely flushed in between, so an id would say "unchanged" where the
+     * counter says "two epochs on".
      *
      * Not persisted anywhere, deliberately. It describes THIS request's view of the stores,
      * which is the only lifetime the derived data it protects has; written to the session it
      * would grow without bound and mean nothing to the next request.
      */
-    private int $flushGeneration = 0;
+    private int $ownershipGeneration = 0;
 
     /**
      * @param Session $session The per-shopper customer session the stores live in.
@@ -275,9 +296,18 @@ class ShopperScopedAddressStores
     }
 
     /**
-     * Enforce ownership NOW and report which generation of the stores the caller is looking
-     * at, so data DERIVED from them - held anywhere, not only in the session - can be
-     * discarded on the same identity change that flushes them (LOQ-17148).
+     * Enforce ownership NOW and report which OWNERSHIP EPOCH the caller is looking at, so data
+     * DERIVED from these stores - held anywhere, not only in the session - can be discarded
+     * the moment the stores stop demonstrably belonging to the identity that earned it
+     * (LOQ-17148).
+     *
+     * WHAT THE NUMBER MEANS, stated first because it is the contract: it counts how many times
+     * ownership has been ESTABLISHED, not how many flushes have happened. enforceOwnership()
+     * advances it whenever it writes the owner marker - on an identity change, and equally on
+     * an adoption, where no marker was recorded and so nothing was flushed. "Unchanged" is
+     * therefore the strong statement (the stores have demonstrably belonged to one identity
+     * throughout), and that is the direction that must be strong, because it is the answer
+     * that licenses a caller to KEEP derived data.
      *
      * WHAT PROBLEM THIS SOLVES. Validator::verifyMultipleAddresses() remembers batch verdicts
      * for the length of one import run in a plain map on the Validator instance, because a
@@ -311,15 +341,17 @@ class ShopperScopedAddressStores
      * which are flushed together. The assertion still governs every attribute reachable
      * through this class, which is what it is for.
      *
-     * @return int Generation of the shopper-scoped stores as of this call. Compare it against
-     *             the value seen last time; any difference means the stores were flushed in
-     *             between and anything derived from them must be discarded.
+     * @return int The ownership epoch as of this call. Compare it against the value seen last
+     *             time; ANY difference means ownership was re-established in between - by a
+     *             flush or by an adoption - and anything derived from these stores must be
+     *             discarded. A caller with nothing recorded yet must treat that as a
+     *             difference too, which it gets for free by starting from null.
      */
     public function ownershipGeneration(): int
     {
         $this->enforceOwnership();
 
-        return $this->flushGeneration;
+        return $this->ownershipGeneration;
     }
 
     /**
@@ -379,12 +411,20 @@ class ShopperScopedAddressStores
 
     /**
      * Flush every shopper-scoped store if the logged-in identity is not the one they were
-     * written for, then record the current identity as their owner.
+     * written for, then record the current identity as their owner and open a new OWNERSHIP
+     * EPOCH.
      *
      * Costs TWO session reads on the hot path - the ownership marker here, and the
      * customer id inside resolveOwnerId() - and, when the marker matches, no writes at
      * all. That is cheap enough to run on EVERY access rather than once per request, which
      * is what makes it impossible to reach a store through a path that skipped the check.
+     *
+     * THREE OUTCOMES, and only the first is free. The marker matches, so nothing happens at
+     * all. The marker disagrees, so the stores are flushed. Or the marker is ABSENT, so there
+     * is nothing to flush and the current identity ADOPTS whatever is there. The last two both
+     * (re)establish ownership and both therefore advance self::$ownershipGeneration; see the
+     * comment on the increment below for why adoption has to count, and the class docblock's
+     * ADOPTION paragraph for what adoption means for the session stores themselves.
      *
      * NOTE THAT THIS WRITES ON A READ PATH: getData() reaches here, and a first access or
      * an identity change makes it store the owner marker (and possibly three nulls). That
@@ -422,13 +462,31 @@ class ShopperScopedAddressStores
             foreach (self::SHOPPER_SCOPED_SESSION_KEYS as $key) {
                 $this->session->setData($key, null);
             }
-
-            // Counted AFTER the stores are actually cleared, and only in this branch: the
-            // ADOPTION path below flushes nothing, so it must not advance the generation or
-            // every first access of a session would throw away derived data that is still
-            // valid. See ownershipGeneration() for who reads this and why it is a counter.
-            $this->flushGeneration++;
         }
+
+        // A NEW OWNERSHIP EPOCH, counted for the flush branch above AND for the adoption that
+        // falls straight through to here, because both end with ownership being (re)established
+        // by a write of the marker. Counting only the flush was a defect (LOQ-17148 mutation
+        // review), not a conservative choice: if anything EMPTIES the session storage
+        // mid-request - Magento\Framework\Session\SessionManager::clearStorage(), the
+        // destroy() inside Magento\Customer\Model\Session::logout(), or another module - the
+        // marker is erased along with the stores. The next access then finds no marker, so it
+        // is an ADOPTION rather than a flush; with the counter tied to the flush alone, a
+        // holder of derived data (see ownershipGeneration()) reads an unmoved generation and
+        // goes on serving the PREVIOUS identity's verdicts to the one that follows. Measured
+        // on the batch path as one billable call where two are owed - i.e. one shopper served
+        // a verdict earned under another identity, the exact hand-off this class exists to
+        // stop.
+        //
+        // AND IT COSTS NOTHING IT SHOULD NOT. The worry it replaces was that bumping on
+        // adoption would discard valid derived data on the first access of every session. It
+        // cannot: a holder starts out having recorded NO generation at all, so its first
+        // lookup fails the comparison and resets whatever it has regardless of this counter -
+        // and what it has at that point is empty, because a holder cannot have derived
+        // anything from stores it has not read yet. The only case that pays is a storage wipe
+        // under an UNCHANGED identity, which re-earns some verdicts of the run in progress:
+        // billing, not correctness, and the same price the wiped session stores already pay.
+        $this->ownershipGeneration++;
 
         $this->session->setData(self::SESSION_OWNER_KEY, $owner);
     }

--- a/Helper/ShopperScopedAddressStores.php
+++ b/Helper/ShopperScopedAddressStores.php
@@ -70,12 +70,11 @@ use Magento\Customer\Model\Session;
  *    time;
  *  - a session storage that is EMPTIED mid-flight, which erases the marker along with the
  *    stores it describes (Magento\Framework\Session\SessionManager::clearStorage(), the
- *    destroy() inside Magento\Customer\Model\Session::logout(), or another module doing
- *    either). Nothing about that is bounded to a release: it is reachable at any time, and
- *    the identity may well have changed in the same breath. For the three SESSION stores it
- *    is harmless - they were emptied too, so there is nothing left to hand over - but for
- *    data DERIVED from them and held elsewhere it is not, which is why adoption counts as a
- *    new ownership epoch; see enforceOwnership() and ownershipGeneration().
+ *    destroy() inside Magento\Customer\Model\Session::logout(), or another module). That is
+ *    not bounded to a release: it is reachable at any time and the identity may have changed
+ *    in the same breath. Harmless for the three SESSION stores, which were emptied too, but
+ *    NOT for data DERIVED from them and held elsewhere - which is why adoption opens a new
+ *    ownership epoch; see enforceOwnership() and ownershipGeneration().
  *
  * ACCEPTED LIMITS, stated (the style of Validator::verifyMultipleAddresses()):
  *  - THE GUARD SCOPES BY CUSTOMER IDENTITY ONLY. The marker tracks
@@ -224,28 +223,19 @@ class ShopperScopedAddressStores
      * How many OWNERSHIP EPOCHS this instance has seen: the number of times ownership of the
      * stores has been established or re-established since it was constructed.
      *
-     * NOT A FLUSH COUNT, and the distinction is the whole point (LOQ-17148 mutation review).
-     * enforceOwnership() advances this whenever it WRITES the owner marker - on a flush, and
-     * equally on an ADOPTION, where the marker was absent and nothing was flushed. Both mean
-     * the same thing to a reader: the stores are now owned by an identity that is not
-     * demonstrably the one any previously derived data was earned under. Counting flushes only
-     * would miss the case where the session storage is emptied mid-request - see
-     * enforceOwnership() for the concrete mechanism - which erases the marker and so turns the
-     * NEXT identity change into an adoption that no flush is counted for.
+     * NOT A FLUSH COUNT, and the distinction is the whole point (LOQ-17148 mutation review):
+     * enforceOwnership() advances it whenever it WRITES the owner marker - on a flush, and
+     * equally on an ADOPTION, where the marker was absent and nothing was flushed. The contract
+     * a reader depends on is stated on ownershipGeneration(); the mechanism, and why adoption
+     * has to count, at the increment in enforceOwnership().
      *
-     * A COUNTER RATHER THAN A BOOLEAN, and per instance rather than per session: it is read
-     * by holders of data that is derived from these stores but does not live in them (see
-     * ownershipGeneration()), and such a holder has to be able to tell "same epoch as when I
-     * last looked" from "two epochs have passed since I last looked". A boolean cannot, and a
-     * flag that had to be cleared by its reader would be wrong the moment there were two
-     * readers. A counter also beats reporting the OWNER ID itself, which was the other
-     * candidate: an A -> B -> A cycle inside one request returns to the same id while the
-     * stores were genuinely flushed in between, so an id would say "unchanged" where the
-     * counter says "two epochs on".
+     * A COUNTER RATHER THAN A BOOLEAN OR AN OWNER ID: a reader has to tell "same epoch as when
+     * I last looked" from "two epochs have passed", a flag cleared by its reader would be wrong
+     * as soon as there were two readers, and an A -> B -> A cycle within one request returns to
+     * the same owner id while the stores were genuinely flushed in between.
      *
      * Not persisted anywhere, deliberately. It describes THIS request's view of the stores,
-     * which is the only lifetime the derived data it protects has; written to the session it
-     * would grow without bound and mean nothing to the next request.
+     * which is the only lifetime the derived data it protects has.
      */
     private int $ownershipGeneration = 0;
 
@@ -310,36 +300,26 @@ class ShopperScopedAddressStores
      * that licenses a caller to KEEP derived data.
      *
      * WHAT PROBLEM THIS SOLVES. Validator::verifyMultipleAddresses() remembers batch verdicts
-     * for the length of one import run in a plain map on the Validator instance, because a
-     * run chunks at 100 rows inside ONE request and the session store cannot serve it (it is
-     * bounded and holds passes only - see Validator::BATCH_VERIFY_CACHE_LIMIT). That map holds
-     * exactly the same kind of data as self::BATCH_VERIFY_CACHE_SESSION_KEY - licences to skip
-     * a billable verify - so it must have the same OWNERSHIP lifetime. A plain request-scoped
-     * map does not: one Validator can outlive a mid-request identity change (a login handled
-     * by the same PHP request), and the map would then answer the new shopper with the old
-     * shopper's verdicts while the three session stores beside it had just been flushed. That
-     * is precisely the hand-off this class exists to stop, arriving through a store this class
-     * could not see.
+     * for one import run in a plain map on the Validator instance, and that map holds the same
+     * kind of data as self::BATCH_VERIFY_CACHE_SESSION_KEY - licences to skip a billable verify
+     * - so it must have the same OWNERSHIP lifetime, which a plain request-scoped map does not
+     * give it. See Validator::$runScopedBatchVerdicts and
+     * Validator::discardRunScopedVerdictsIfShopperChanged() for that side of it.
      *
-     * WHY A GENERATION RATHER THAN A CALLBACK OR A FLUSH LIST. This class holds no reference
-     * to its holders and must not start holding one: it is constructed inside Controller's and
-     * Validator's constructors and reaching back into them would invert that dependency and
-     * make the flush order matter. A monotonic counter inverts the responsibility instead -
-     * the guard states a fact about the stores, and each holder decides what its own derived
-     * data means when that fact changes. It also composes: any number of holders can read it
-     * independently, and none of them can consume the signal from under another.
+     * WHY A GENERATION RATHER THAN A CALLBACK OR A FLUSH LIST. This class holds no reference to
+     * its holders and must not start holding one: it is constructed inside Controller's and
+     * Validator's constructors, so reaching back into them would invert that dependency and make
+     * the flush order matter. A counter inverts the responsibility instead - the guard states a
+     * fact, each holder decides what its own derived data means when that fact changes - and it
+     * composes, since no reader can consume the signal from under another.
      *
-     * ENFORCES OWNERSHIP ITSELF, and that is the load-bearing half. A caller that consulted
-     * its own map BEFORE touching any session attribute - which is exactly what the run map
-     * does on the import path, where the captured-address read is skipped - would otherwise
-     * read a generation from before the flush and serve a stale verdict on the first address
-     * of the request. Asking through this method makes the check happen at the moment the
-     * derived data is used, on the same terms as getData()/setData().
+     * ENFORCES OWNERSHIP ITSELF, and that is the load-bearing half. A caller that consulted its
+     * own map BEFORE touching any session attribute - exactly what the run map does on the import
+     * path, where the captured-address read is skipped - would otherwise read a generation from
+     * before the flush and serve a stale verdict on the first address of the request.
      *
-     * NO KEY, AND THEREFORE NO assertEnrolled() CALL. There is no attribute to enrol: this
-     * reports on the whole flush unit named by self::SHOPPER_SCOPED_SESSION_KEYS, all of
-     * which are flushed together. The assertion still governs every attribute reachable
-     * through this class, which is what it is for.
+     * NO KEY, AND THEREFORE NO assertEnrolled() CALL: there is no attribute to enrol, this
+     * reports on the whole flush unit named by self::SHOPPER_SCOPED_SESSION_KEYS.
      *
      * @return int The ownership epoch as of this call. Compare it against the value seen last
      *             time; ANY difference means ownership was re-established in between - by a
@@ -467,25 +447,17 @@ class ShopperScopedAddressStores
         // A NEW OWNERSHIP EPOCH, counted for the flush branch above AND for the adoption that
         // falls straight through to here, because both end with ownership being (re)established
         // by a write of the marker. Counting only the flush was a defect (LOQ-17148 mutation
-        // review), not a conservative choice: if anything EMPTIES the session storage
-        // mid-request - Magento\Framework\Session\SessionManager::clearStorage(), the
-        // destroy() inside Magento\Customer\Model\Session::logout(), or another module - the
-        // marker is erased along with the stores. The next access then finds no marker, so it
-        // is an ADOPTION rather than a flush; with the counter tied to the flush alone, a
-        // holder of derived data (see ownershipGeneration()) reads an unmoved generation and
-        // goes on serving the PREVIOUS identity's verdicts to the one that follows. Measured
-        // on the batch path as one billable call where two are owed - i.e. one shopper served
-        // a verdict earned under another identity, the exact hand-off this class exists to
-        // stop.
+        // review): anything that EMPTIES the session storage mid-request - clearStorage(), the
+        // destroy() inside Magento\Customer\Model\Session::logout(), another module - erases the
+        // marker along with the stores, so the next access is an ADOPTION rather than a flush,
+        // and a holder of derived data (see ownershipGeneration()) would read an unmoved
+        // generation and go on serving the PREVIOUS identity's verdicts to the one that follows.
+        // Measured on the batch path as one billable call where two are owed.
         //
-        // AND IT COSTS NOTHING IT SHOULD NOT. The worry it replaces was that bumping on
-        // adoption would discard valid derived data on the first access of every session. It
-        // cannot: a holder starts out having recorded NO generation at all, so its first
-        // lookup fails the comparison and resets whatever it has regardless of this counter -
-        // and what it has at that point is empty, because a holder cannot have derived
-        // anything from stores it has not read yet. The only case that pays is a storage wipe
-        // under an UNCHANGED identity, which re-earns some verdicts of the run in progress:
-        // billing, not correctness, and the same price the wiped session stores already pay.
+        // AND IT COSTS NOTHING IT SHOULD NOT: a holder that has recorded no generation yet resets
+        // regardless of this counter, and what it holds then is empty. The only case that pays is
+        // a storage wipe under an UNCHANGED identity, which re-earns some verdicts of the run in
+        // progress - billing, not correctness, and the price the wiped stores already pay.
         $this->ownershipGeneration++;
 
         $this->session->setData(self::SESSION_OWNER_KEY, $owner);

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -600,7 +600,11 @@ class Validator
      * sent is answered false, no request is made and nothing is remembered. It is a PRE-FLIGHT
      * decision and only that: it depends on configuration alone, never on the response, so no
      * response-side judgement is moved forward. The captured-address guard still answers first,
-     * unchanged, because a captured address never consults the AQI at all.
+     * unchanged, because a captured address never consults the AQI at all - which is why the
+     * broken-threshold line reports the CONFIGURATION rather than a count of refusals: it is
+     * emitted once for any batch verified under an unreadable bar, including one whose rows are
+     * all captured and none of which is refused. See readableQualityIndexThreshold() for the
+     * wording and for why the alternative - staying quiet on such a batch - is worse.
      *
      * RETURN SHAPE - load-bearing in two ways, do not "simplify" either:
      *  - one entry per input address, under the INPUT's OWN KEY.
@@ -738,8 +742,11 @@ class Validator
         // PRE-FLIGHT, READ ONCE PER BATCH AND BEFORE ANY PAYLOAD IS ASSEMBLED: a threshold that
         // cannot be read as a grade decides every row before Loqate is asked, so asking is paying
         // per address for a refusal already made. Same rule and same log line as the response
-        // side, because readableQualityIndexThreshold() is the single site of both. See the
-        // docblock's "A BROKEN QUALITY BAR COSTS NOTHING" paragraph.
+        // side, because readableQualityIndexThreshold() is the single site of both - and reading
+        // it here LOGS, on every batch verified under a broken bar, whether or not this batch goes
+        // on to refuse anything (an all-captured batch refuses nothing). That is why the line
+        // reports the configuration and never an outcome. See the docblock's "A BROKEN QUALITY BAR
+        // COSTS NOTHING" paragraph.
         $thresholdIsReadable = $this->readableQualityIndexThreshold() !== null;
 
         $result = [];
@@ -1124,6 +1131,27 @@ class Validator
      * frequency - once per verified batch rather than once per verdict - and the CHANGELOG says
      * so.
      *
+     * WHY THE MESSAGE REPORTS THE CONFIGURATION AND NOT AN OUTCOME. It is written from what this
+     * method actually knows - that the configured value is not a grade, and that nothing can
+     * therefore clear the bar - and deliberately not as "rejecting the address", which is what it
+     * used to say. That older sentence was true of the RESPONSE-side caller, which always has an
+     * address in hand, and false of the batch pre-flight, which runs once per batch BEFORE any row
+     * is decided: a batch whose every row is a captured address is answered entirely by the
+     * captured guard, so the line was emitted while ZERO rows were rejected. Support reads this
+     * out of a log file, so a sentence that names an outcome that did not happen sends them
+     * looking for refused rows that do not exist. The wording holds at both call sites and at
+     * neither does it assert more than the configuration.
+     *
+     * AND WHY IT IS NOT INSTEAD EMITTED ONLY WHEN A ROW IS ACTUALLY REFUSED. That would make a
+     * CONFIGURATION diagnostic conditional on the composition of whatever batch happened to run:
+     * the all-captured batch above would go silent, and a merchant would keep a broken quality bar
+     * with nothing in the log until a row that is not captured happens along - the same shape of
+     * hole as the all-empty-'Matches' file this branch just closed, arriving through a different
+     * door. It would also need the readability rule to grow a second, non-logging entry point for
+     * the pre-flight to consult first, which is exactly the single-siting this method exists to
+     * hold. The fault is worth reporting on every batch that ran under it; only the sentence
+     * needed correcting.
+     *
      * REACHABLE FROM THE ADMIN UI SINCE LOQ-17148: etc/adminhtml/system.xml exposes
      * address_quality_index as a SELECT over Model\Config\Source\AddressQualityIndex, whose
      * option values are derived from self::VALID_QUALITY_INDEXES, so nothing a merchant can
@@ -1153,7 +1181,7 @@ class Validator
 
         $this->logger->info(sprintf(
             'Loqate: address_quality_index is not a recognised quality index (%s of type %s); '
-            . 'rejecting the address. Set it to one of %s.',
+            . 'no address can pass a quality bar that cannot be read. Set it to one of %s.',
             var_export($configIndex, true),
             gettype($configIndex),
             implode(', ', self::VALID_QUALITY_INDEXES)

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -290,8 +290,8 @@ class Validator
     private array $runScopedBatchVerdicts = [];
 
     /**
-     * The ShopperScopedAddressStores generation self::$runScopedBatchVerdicts was earned under,
-     * or null before this instance has asked (LOQ-17148, LOQ-16978).
+     * The ShopperScopedAddressStores ownership epoch self::$runScopedBatchVerdicts was earned
+     * under, or null before this instance has asked (LOQ-17148, LOQ-16978).
      *
      * The map holds the same kind of data as the session verdict stores - licences to skip a
      * billable verify - so it must have the same OWNERSHIP lifetime, not merely the same
@@ -301,6 +301,10 @@ class Validator
      * map is enrolled in the guard's own ownership model rather than checked ad hoc at the call
      * site: see ShopperScopedAddressStores::ownershipGeneration() and
      * discardRunScopedVerdictsIfShopperChanged().
+     *
+     * STARTS AT NULL, WHICH IS NOT AN EPOCH, and that is deliberate: the guard's counter is an
+     * int from its very first answer, so "I have not asked yet" has to be a value it can never
+     * report, or an instance that had never looked would compare equal to an epoch it never saw.
      *
      * @var int|null
      */
@@ -1842,8 +1846,14 @@ class Validator
     }
 
     /**
-     * Discard this run's remembered verdicts if the shopper-scoped stores have been flushed
-     * since they were earned (LOQ-17148, LOQ-16978).
+     * Discard this run's remembered verdicts unless the shopper-scoped stores have demonstrably
+     * belonged to one identity ever since they were earned (LOQ-17148, LOQ-16978).
+     *
+     * NOTE THE POLARITY, because it is the safe one and it is easy to invert by accident: the
+     * map is KEPT only on a positive answer from the guard - an unmoved ownership epoch - and
+     * discarded in every other case, including the ones that flushed nothing. See
+     * ShopperScopedAddressStores::ownershipGeneration() for what the epoch counts and why an
+     * adoption (no marker recorded, so nothing to flush) advances it just as a flush does.
      *
      * The map is verdict data, so it has the OWNERSHIP lifetime of the session verdict stores
      * and not merely the request's: one Validator can outlive a mid-request identity change,
@@ -1869,9 +1879,10 @@ class Validator
             return;
         }
 
-        // Either the first lookup of this instance (nothing to discard) or a genuine flush.
-        // Both are answered by starting from empty, which is why no special case is needed for
-        // the null the property starts out holding.
+        // The first lookup of this instance (nothing to discard), or ownership re-established
+        // since the last one - a flush, or an adoption after the session storage was emptied
+        // under us. All are answered by starting from empty, which is why no special case is
+        // needed for the null the property starts out holding.
         $this->runScopedBatchVerdicts = [];
         $this->runScopedVerdictsGeneration = $generation;
     }

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -53,7 +53,9 @@ class Validator
     private const COUNTY_FIELD = 'Address4';
 
     /**
-     * Every value address_quality_index is allowed to hold, worst ('E') to best ('A').
+     * Every value address_quality_index is allowed to hold, BEST ('A') to WORST ('E') - the
+     * Cleansing API's own grade order, and since LOQ-17148 the order the merchant's dropdown
+     * lists them in, so this is not a cosmetic ordering.
      *
      * checkQualityIndex() compares the response AQI against the threshold with <=, which is
      * a STRING comparison, so an unrecognised threshold does not fail closed - anything
@@ -180,60 +182,64 @@ class Validator
      * fits inside the limit; for a file LARGER than the limit it claims nothing, because
      * FIFO eviction leaves close to zero hits however the constant is chosen.
      *
-     * WHAT DEDUPES THE IMPORT PATH IS NOT THIS STORE (LOQ-17148). An import run chunks at 100
-     * rows and verifies every chunk INSIDE ONE PHP REQUEST, so the lifetime that matters there
-     * is the RUN, not the session. That is served by the run-scoped verdict map on this
-     * instance - see rememberBatchVerdict() and getRunScopedBatchVerdict() - which remembers
-     * BOTH polarities and is unbounded by this limit. Measured on the file shapes that showed
-     * the defect: 29% fewer billed addresses on a 1000-row file holding 700 distinct
-     * addresses, and 58.8% fewer on 1000 rows holding 400. Before it, a REJECTED address was
-     * re-sent - and so re-billed, the Cleansing API being billed per ADDRESS - in every chunk
-     * it appeared in, because this store caches PASSES ONLY (storeBatchVerifyResult()) and
-     * address_quality_index ships as 'A' (etc/config.xml), the strictest grade, so on a
-     * default install most rows fail and were never cacheable here in the first place.
+     * WHAT DEDUPES THE IMPORT PATH IS NOT THIS STORE (LOQ-17148): a run chunks at 100 rows and
+     * verifies every chunk INSIDE ONE PHP REQUEST, so the lifetime that matters there is the RUN,
+     * and that is served by the run-scoped map on this instance - self::$runScopedBatchVerdicts,
+     * both polarities, unbounded by this limit. Before it, a REJECTED address was re-sent, and
+     * re-billed (the Cleansing API bills per ADDRESS), in every chunk it appeared in, because
+     * this store caches PASSES ONLY (storeBatchVerifyResult()) and address_quality_index ships as
+     * 'A' (etc/config.xml), the strictest grade - so on a default install most rows fail and were
+     * never cacheable here at all. The saving is what the file's duplicate distribution makes it,
+     * so the only figure quoted here is one that can be re-run: on the acceptance fixture in
+     * ValidatorImportRunDedupeTest (260 rows, 210 distinct, repeats across chunk boundaries) it
+     * is 210 billed addresses instead of 260, i.e. 19.2%.
      *
-     * THIS STORE IS DELIBERATELY UNCHANGED BY LOQ-17148 - passes only, FIFO, 200 - and the
-     * measurements behind each rejected alternative are recorded here because every one of
-     * them looks like an obvious improvement:
-     *  - CACHING FAILURES HERE IS A REGRESSION on the target workload, not an omission.
-     *    Eviction is FIFO and bounded, so failures crowd out the sparse passes the store
-     *    currently manages to keep: for 1000 distinct rows at a 5% pass rate, a second run
-     *    goes from 950 billed addresses to 1000, and for 500 rows at 5% from 475 to 500. It is
-     *    never better for any file larger than this limit. (An earlier revision of this
-     *    docblock promised LOQ-17148 would deliver exactly that. It was wrong, and this
-     *    paragraph is the correction.) It would also strand a merchant: a rejection that
-     *    outlived the request would be replayed after they corrected the file or loosened the
-     *    threshold, with no request made and no way to clear it.
-     *  - "RETAIN ON FULL" (freeze the store instead of evicting) is rejected: one Check Data
-     *    click on a file of 200 rows or more would permanently fill the store for the rest of
-     *    that admin's browser session - adminhtml never flushes it, see
-     *    ShopperScopedAddressStores' ACCEPTED LIMITS - destroying the admin-order-create win
-     *    below, which is the win LOQ-16976 actually delivered.
-     *  - SIZING THE STORE TO THE FILE is rejected on measured cost: ~147 bytes per entry, so
-     *    1000 entries is ~141 KB and 5000 is ~712 KB of raw session data. Magento reads and
-     *    writes the WHOLE session on every request, so a 5000-entry store costs ~1.4 MB of
-     *    session I/O on EVERY unrelated admin page load for the life of the session (~278 MB
-     *    over 200 page loads) to serve a re-run the merchant may never perform.
+     * THIS STORE IS DELIBERATELY UNCHANGED BY LOQ-17148 - passes only, FIFO, 200. Four apparent
+     * improvements were considered and refused; every one of them looks obvious, so the
+     * DECISIONS are recorded here and the arithmetic behind them in CHANGELOG.md under
+     * LOQ-17148's known limitations, in ONE place rather than restated in two:
+     *  - CACHING FAILURES HERE IS A BILLING REGRESSION on the target workload, not an omission:
+     *    eviction is FIFO and bounded, so failures crowd out the sparse passes this store
+     *    manages to keep, and it is never better for a file larger than this limit. (An earlier
+     *    revision of this docblock promised LOQ-17148 would deliver exactly that. It was wrong,
+     *    and this line is the correction.) It would also strand a merchant whose corrected file
+     *    or loosened threshold kept being answered from a rejection that outlived the request.
+     *  - "RETAIN ON FULL" (freeze instead of evicting) is refused: one Check Data click on a
+     *    200-row file would fill the store for the rest of that admin's browser session -
+     *    adminhtml never flushes it, see ShopperScopedAddressStores' ACCEPTED LIMITS -
+     *    destroying the admin-order-create win below, which is what LOQ-16976 delivered.
+     *  - SIZING THE STORE TO THE FILE is refused on session I/O: Magento reads and writes the
+     *    WHOLE session on every request, so a store sized to a large import is paid for on
+     *    every unrelated admin page load, to serve a re-run that may never happen.
+     *  - A NON-SESSION STORE - Magento\Framework\App\CacheInterface, keyed on the same
+     *    threshold- and store-view-namespaced hash buildBatchVerifyCacheKey() already builds -
+     *    is named because it is the ONE option class that could move the CLI/cron/programmatic
+     *    figure below, which no session variant can. Refused, not overlooked, and here is the
+     *    risk being declined: a verdict in a shared cache is not shopper-specific, so it is
+     *    readable and replayable by any other shopper, any other admin user, and on shared
+     *    infrastructure any other install on the same backend - a bypass licence handed across
+     *    identities, the leak LOQ-16978 exists to close, through a store
+     *    ShopperScopedAddressStores cannot see. Doing it safely needs an identity in the key, a
+     *    tag and lifetime policy, and a decision on whether an address verdict may live outside
+     *    the session at all. Its own ticket, tracked separately - record the id here when it is
+     *    raised.
      *
      * RESIDUAL EXPOSURE, stated plainly rather than left to be rediscovered from an invoice.
-     * CROSS-RUN dedupe is not delivered for a file with more than this many distinct
-     * addresses: a re-run in the same browser session (a second Check Data click, a second
-     * import) re-bills essentially every row, because a sequential cyclic scan through a
-     * smaller FIFO cache has a ~0% hit rate. For a programmatic, CLI or cron-driven import it
-     * is 0% BY CONSTRUCTION and no cache size would change that - each process starts a fresh
-     * session id, so nothing one run writes is ever found by the next. Raising this constant
-     * does not fix either case; it is inherent to FIFO over a working set larger than the
-     * cache, and to session-scoped storage outside a browser session.
+     * CROSS-RUN dedupe is not delivered for a file with more than this many distinct addresses:
+     * a re-run in the same browser session re-bills essentially every row, a sequential cyclic
+     * scan through a smaller FIFO cache having a ~0% hit rate. For a programmatic, CLI or
+     * cron-driven import it is 0% and no cache SIZE changes that - each process starts a fresh
+     * session id - so only the non-session store refused above could help, at the price stated
+     * there. Raising this constant fixes neither case.
      *
      * NOT THE SAME TICKET AS INTRA-CHUNK DUPLICATES, AND LOQ-17015 IS NOT CLOSED BY THIS WORK.
-     * LOQ-17148 dedupes ACROSS the chunks of one run. Two copies of an address in ONE assembled
-     * payload are still both billed on that address's FIRST appearance in the run, because
-     * nothing is remembered until the response returns, so both copies miss; every LATER
-     * appearance is answered from the run map, two copies in one batch included. That residue
-     * is LOQ-17015 and it is riskier to fix - it changes the payload row arithmetic and must be
-     * done TOGETHER with the count($response) !== count($sentItems) guard in
-     * verifyMultipleAddresses(), never by comparing against the pre-dedupe count. See the
-     * ACCEPTED LIMITS on that method for the boundary stated exactly.
+     * LOQ-17148 dedupes ACROSS the chunks of one run and NOT WITHIN a chunk: EVERY COPY AFTER
+     * THE FIRST IS BILLED WITHIN THE CHUNK IN WHICH THE ADDRESS FIRST APPEARS (nothing is
+     * remembered until the response returns, so all of them miss in the same pre-flight pass),
+     * and every appearance in any LATER chunk is free. The residue is bounded by the CHUNK SIZE
+     * - 100 identical rows in one chunk bill 100 - not by one charge per distinct address,
+     * which an earlier revision of this docblock claimed. See the ACCEPTED LIMITS on
+     * verifyMultipleAddresses() for what fixing it must not break.
      *
      * Where this cache actually pays for itself is ADMIN ORDER CREATE: two addresses per
      * submission, re-submitted after a validation bounce or an unrelated form error, is
@@ -269,21 +275,26 @@ class Validator
      * and FIFO - on a file larger than self::BATCH_VERIFY_CACHE_LIMIT an early pass is evicted
      * before the file ends and would otherwise be re-billed within the same run.
      *
-     * NEVER SERIALISED AND NEVER PERSISTED. It dies with the request, by construction: it is a
-     * plain property, nothing writes it to the session, and it is deliberately NOT a static or
-     * a Registry entry (either would serve one shopper's verdicts to another - see
-     * self::VERIFY_CACHE_SESSION_KEY). That mortality is a FEATURE and is asserted: a rejection
-     * must never outlive the request, or a merchant who corrects the file or loosens the
-     * threshold keeps being told "invalid" with no request made and no way to clear it.
+     * NEVER SERIALISED AND NEVER PERSISTED: a plain property, written to no session, and
+     * deliberately not a static or a Registry entry (either would serve one shopper's verdicts to
+     * another - see self::VERIFY_CACHE_SESSION_KEY). That mortality is a FEATURE and is asserted:
+     * a rejection must never outlive the request, or a merchant who corrects the file or loosens
+     * the threshold keeps being told "invalid" with no request made and no way to clear it.
      *
-     * KEYED ON THE KEY, NOT ON THE RAW SIGNATURE. buildBatchVerifyCacheKey() is where the
-     * '' -"nothing identifiable" sentinel is honoured and where the store view and the AQI
-     * threshold fingerprint enter, so keying on the signature would remember verdicts across a
-     * threshold change and would file two unidentifiable addresses under one key.
+     * "THE RUN" IS THE INSTANCE'S LIFETIME, WHICH IS ONE REQUEST ON EVERY PATH THIS MODULE SHIPS
+     * - PHP-FPM, one CLI process per programmatic import. That is an assumption about the runtime
+     * rather than something this class enforces, so it is stated and not asserted "by
+     * construction": under a long-lived worker (queue consumer, RoadRunner, Swoole) one Validator
+     * spans many messages and this map grows for as long as the worker lives. The direction of
+     * that failure is memory growth, never a wrong verdict - an identity change still discards
+     * it, see discardRunScopedVerdictsIfShopperChanged(). No eviction policy is shipped for a
+     * process this module does not run; add one WITH that process, sized against its workload.
      *
-     * ONLY READABLE VERDICTS ARE IN HERE. An unreadable AQI or an unreadable threshold produces
-     * a rejection that is a FAULT REPORT, not a verdict, and is remembered nowhere - see
-     * rememberBatchVerdict(), which is the single gate for both lifetimes.
+     * KEYED ON THE KEY, NOT ON THE RAW SIGNATURE, so the '' - "nothing identifiable" sentinel,
+     * the store view and the AQI threshold fingerprint all govern it exactly as they govern the
+     * session store; see buildBatchVerifyCacheKey(). ONLY READABLE VERDICTS ARE IN HERE: an
+     * unreadable AQI or threshold is a FAULT REPORT, remembered nowhere, see
+     * rememberBatchVerdict().
      *
      * @var array<string, bool> Batch cache key => verdict.
      */
@@ -293,14 +304,10 @@ class Validator
      * The ShopperScopedAddressStores ownership epoch self::$runScopedBatchVerdicts was earned
      * under, or null before this instance has asked (LOQ-17148, LOQ-16978).
      *
-     * The map holds the same kind of data as the session verdict stores - licences to skip a
-     * billable verify - so it must have the same OWNERSHIP lifetime, not merely the same
-     * request. A request-scoped map does NOT get that for free: one Validator can outlive a
-     * mid-request identity change, and it would then answer the new shopper from the previous
-     * shopper's verdicts while the guard had just flushed the three stores beside it. So the
-     * map is enrolled in the guard's own ownership model rather than checked ad hoc at the call
-     * site: see ShopperScopedAddressStores::ownershipGeneration() and
-     * discardRunScopedVerdictsIfShopperChanged().
+     * The map holds licences to skip a billable verify, so it must have the same OWNERSHIP
+     * lifetime as the session verdict stores and not merely the same request - see
+     * discardRunScopedVerdictsIfShopperChanged() for why, and
+     * ShopperScopedAddressStores::ownershipGeneration() for what the epoch means.
      *
      * STARTS AT NULL, WHICH IS NOT AN EPOCH, and that is deliberate: the guard's counter is an
      * int from its very first answer, so "I have not asked yet" has to be a value it can never
@@ -571,29 +578,41 @@ class Validator
      *
      * TWO MEMORIES, TWO LIFETIMES, ONE KEY (LOQ-17148). The lookup before payload assembly
      * consults BOTH, in this order:
-     *  - self::$runScopedBatchVerdicts, this INSTANCE's map, holding BOTH polarities. Its
-     *    lifetime is one import RUN, because that is what one instance is here: an import file
-     *    is chunked at 100 rows and every chunk is verified against the same Validator inside
-     *    one PHP request. This is what stops a REJECTED address being re-billed in every chunk
-     *    it appears in, which the session store structurally could not do, and it is unbounded
-     *    by self::BATCH_VERIFY_CACHE_LIMIT so an evicted PASS is not re-billed mid-run either;
+     *  - self::$runScopedBatchVerdicts, this INSTANCE's map, holding BOTH polarities for one
+     *    import RUN - an import file is chunked at 100 rows and every chunk is verified against
+     *    the same Validator inside one PHP request. This is what stops a REJECTED address being
+     *    re-billed in every chunk it appears in, which the session store structurally could not
+     *    do, and it is unbounded by self::BATCH_VERIFY_CACHE_LIMIT so an evicted PASS is not
+     *    re-billed mid-run either;
      *  - the SESSION store, holding PASSES ONLY and bounded, which is what survives to a LATER
      *    REQUEST (the re-submitted admin order, a re-run import that fits inside the limit).
      * Both are keyed by buildBatchVerifyCacheKey(), so one address is one key in both and a
-     * threshold or store-view change invalidates both at once. A rejection is deliberately
-     * asymmetric - remembered for the run, never for the session - and
-     * self::BATCH_VERIFY_CACHE_LIMIT records the measurements behind that asymmetry, including
-     * why widening the session store is a REGRESSION rather than the obvious next step.
+     * threshold or store-view change invalidates both at once. The asymmetry - a rejection is
+     * remembered for the run and never for the session - is measured on
+     * self::BATCH_VERIFY_CACHE_LIMIT.
+     *
+     * A BROKEN QUALITY BAR COSTS NOTHING, BECAUSE ITS ANSWER IS KNOWN BEFORE THE REQUEST. If
+     * address_quality_index cannot be read as a grade, checkQualityIndex() can only reject, so
+     * every row is rejected whatever Loqate answers - and paying per address for that answer is
+     * paying for a refusal already decided, on every Check Data click, for the whole file. The
+     * threshold is therefore read ONCE, before payload assembly, through
+     * readableQualityIndexThreshold(); when it is unreadable every address that would have been
+     * sent is answered false, no request is made and nothing is remembered. It is a PRE-FLIGHT
+     * decision and only that: it depends on configuration alone, never on the response, so no
+     * response-side judgement is moved forward. The captured-address guard still answers first,
+     * unchanged, because a captured address never consults the AQI at all.
      *
      * RETURN SHAPE - load-bearing in two ways, do not "simplify" either:
-     *  - one entry per input address, under the INPUT's OWN KEY. OrderSave.php:51-57
+     *  - one entry per input address, under the INPUT's OWN KEY.
+     *    Plugin\Admin\OrderSave::aroundExecute()
      *    reports that key to the admin, and before LOQ-16977 the keys of a mixed batch
      *    were wrong: the original code recovered them with
      *    array_search(false, $addressesToCheck) over an array whose values were all
      *    truthy, so it always got false, coerced to key 0 - every response row overwrote
      *    $result[0], and the captured addresses' own verdicts were never merged into
      *    $result at all. The mapping is now an explicit parallel array, see $sentItems.
-     *  - in the INPUT's OWN ORDER, because ValidateImportAddress.php:94 array_merge()s the
+     *  - in the INPUT's OWN ORDER, because Plugin\Admin\ValidateImportAddress::
+     *    afterValidateData() array_merge()s the
      *    per-chunk arrays and then derives the import row number from the merged
      *    $index + 1. array_merge() renumbers integer keys BY INSERTION ORDER, not by key
      *    value, so a result that came back as [3 => .., 0 => .., 1 => .., 2 => ..] - which
@@ -607,7 +626,7 @@ class Validator
      * WHY THE ROW COUNT IS CHECKED BEFORE ANY ROW IS ATTRIBUTED, and why a mismatch fails the
      * whole batch. Verdicts are attributed POSITIONALLY - the Nth answer belongs to the Nth
      * address sent - and the connector makes that attribution unverifiable from the response
-     * itself: Verify::verifyAddress() (vendor/lqt/api-connector/src/Client/Verify.php:50-52)
+     * itself: the connector's Verify::verifyAddress() (vendor/lqt/api-connector)
      * ends in array_column($response, 'Matches'), and array_column() SILENTLY DROPS every
      * record that has no 'Matches' key and REINDEXES the survivors into a clean 0..N-1 list.
      * So a three-address batch whose MIDDLE record came back as a PER-RECORD error envelope
@@ -634,32 +653,25 @@ class Validator
      * WHAT IS NOT IN THAT CLASS, named explicitly so this justification is not widened back out
      * to faults that were never silent: an unparseable body and a TOP-LEVEL
      * {"Number":..,"Description":..} envelope. The first json_decode()s to null, so
-     * is_array() fails (vendor/lqt/api-connector/src/Client/Verify.php:50) and the connector
-     * returns ['error' => true, 'message' => 'Unexpected error occurred.'] (same file, :57). The
-     * second makes HttpClient::searchForError() report an error, so post() THROWS
-     * (vendor/lqt/api-connector/src/Client/Http/HttpClient.php:53-55 over :72-74) and
-     * Verify::verifyAddress() catches it into that same shape (Verify.php:53-55). Both were
+     * Verify::verifyAddress()'s is_array() test fails and it returns
+     * ['error' => true, 'message' => 'Unexpected error occurred.']. The
+     * second makes HttpClient::searchForError() report an error, so HttpClient::post() THROWS
+     * and Verify::verifyAddress() catches it into that same shape. Both were
      * therefore already answered by the isset($response['error']) branch below, before this
      * guard existed (all traced on PHP 8.3). Such an envelope does arrive as [] in two
      * corners, both of them just further instances of the class above rather than new ones,
-     * and both because searchForError()'s return is tested for TRUTHINESS rather than for
-     * false (HttpClient.php:53 over :72-74):
+     * and both because HttpClient::post() tests searchForError()'s return for TRUTHINESS
+     * rather than for false:
      *  - a FALSY 'Description' - '' and '0', but equally JSON null, 0 and false;
-     *  - an ABSENT 'Description' next to a present 'Number', which HttpClient.php:73 reads
-     *    UNGUARDED. This one is decided by the error handler in force, not by the body: PHP 8
-     *    raises "Undefined array key" and evaluates the read to null, so with no throwing
-     *    handler the return is falsy and the whole envelope reaches array_column() as [] -
-     *    the count guard's branch. Under Magento's own handler
-     *    (Magento\Framework\App\ErrorHandler, registered in Bootstrap::run() and throwing
-     *    for any level error_reporting() reports) the same warning becomes an \Exception,
-     *    which Verify::verifyAddress()'s catch (Throwable) converts into
-     *    ['error' => true, ...] - the OTHER branch. So one identical body is classified two
-     *    different ways depending on the entry point (a web request, which registers that
-     *    handler, versus a context that never calls Bootstrap::run()). NOT on
-     *    developer-versus-production mode: app/bootstrap.php sets error_reporting(E_ALL) and
-     *    Bootstrap::run() registers the handler, both irrespective of MAGE_MODE. Either
-     *    branch is safe - one returns false, the other returns false - which is why this is
-     *    documented rather than defended against here.
+     *  - an ABSENT 'Description' next to a present 'Number', which
+     *    HttpClient::searchForError() reads UNGUARDED. Which branch this takes is decided by the
+     *    error handler in force rather than by the body: with no throwing handler PHP 8 evaluates
+     *    the read to null, the return is falsy and the envelope reaches array_column() as [] -
+     *    the count guard's branch; under Magento\Framework\App\ErrorHandler (registered by
+     *    Bootstrap::run(), irrespective of MAGE_MODE) the warning becomes an \Exception that
+     *    Verify::verifyAddress() converts into ['error' => true, ...] - the other branch. Either
+     *    is safe - both end in this method returning false - which is why it is documented here
+     *    rather than defended against.
      *
      * TRADE-OFF, accepted deliberately: a genuinely TRUNCATED response (Loqate answering
      * fewer rows than it was sent) now fails the whole batch instead of reporting the rows it
@@ -674,41 +686,38 @@ class Validator
      *    and write are not atomic, so two genuinely concurrent submissions of the same
      *    batch can both miss and both be billed. Sequential replay - the re-submitted
      *    admin order, the re-run import - is what this de-duplicates.
-     *  - a row present in the response but carrying no readable AQI is answered INVALID and
-     *    is remembered NOWHERE - not in the session, and not for the rest of the run either.
-     *    That is a fail-closed rejection, decided by checkQualityIndex() answering null, and
-     *    reached for a record whose 'Matches' list is present but empty - the row-count guard
-     *    below cannot catch that shape, because array_column() PRESERVES such a record, see
-     *    the attribution loop for the demonstration. It is a deliberate rejection, not a gap:
-     *    it costs one re-attempt on a response we could not read, where the previous behaviour
-     *    reported "no match found" as VALID. The price of remembering it would be far higher -
-     *    ONE connector fault or one bad credential would brand every matching row in the file
-     *    invalid for the rest of the run, sending the merchant to edit rows Loqate never
-     *    rejected.
-     *  - LOQ-17015 IS NOT RESOLVED BY LOQ-17148, and here is the boundary stated exactly, so
-     *    that ticket is neither closed on a partial fix nor re-implemented for work already
-     *    done. VERIFIED against this implementation, not merely reasoned about: two copies of
-     *    an address in one batch, on that address's FIRST appearance in the run, are BOTH
-     *    billed - both copies miss both memories in the pre-flight pass, because nothing is
-     *    remembered until the response comes back. What LOQ-17148 does change is every LATER
-     *    appearance: once the run map holds a readable verdict for an address, every copy of it
-     *    in every subsequent batch is answered from memory, including two copies inside the
-     *    SAME batch. So the residue of LOQ-17015 is exactly "the first batch in which an
-     *    address appears more than once", and it is bounded by ONE duplicate charge per
-     *    distinct address per run rather than one per occurrence.
-     *    Whoever implements the rest MUST preserve the
-     *    ONE-RESPONSE-ROW-PER-SENT-ITEM assumption the row-count guard below and the
-     *    positional attribution loop after it both depend on: collapsing duplicates into a
-     *    single payload slot changes the row/address arithmetic, so that dedupe and this
-     *    guard have to be changed TOGETHER. Sending N slots and fanning one row out to
-     *    several caller keys, or sending N-k slots and re-deriving the expected row count
-     *    from the de-duplicated payload rather than from the caller's address count, are both
-     *    safe; silently comparing count($response) against the pre-dedupe count is not.
+     *  - A ROW WITH NO READABLE AQI is answered INVALID and remembered NOWHERE - not in the
+     *    session, not for the rest of the run. That is checkQualityIndex() answering null for a
+     *    record whose 'Matches' list is present but EMPTY, a shape the row-count guard cannot
+     *    catch because array_column() PRESERVES it (see the attribution loop). Its BILLING cost
+     *    is not "one re-attempt": remembered nowhere means EVERY OCCURRENCE of that address is
+     *    sent and billed again, all run and every run after, and 'Matches' => [] is Loqate's
+     *    ordinary answer for an address it cannot match - on a poorly-matching file, most of the
+     *    file. It is still the direction chosen rather than the direction missed: remembering it
+     *    would let ONE connector fault or one bad credential brand every matching row in the file
+     *    invalid for the rest of the run, sending the merchant to edit rows Loqate never rejected.
+     *  - LOQ-17015 IS NOT RESOLVED BY LOQ-17148, and here is the boundary exactly, so that ticket
+     *    is neither closed on a partial fix nor re-implemented for work already done. EVERY COPY
+     *    AFTER THE FIRST IS BILLED WITHIN THE CHUNK IN WHICH THE ADDRESS FIRST APPEARS: the
+     *    pre-flight loop runs to completion over the WHOLE chunk before the request is issued and
+     *    the only writer to either memory is rememberBatchVerdict(), which runs AFTER the
+     *    response, so k copies in that chunk all miss and all k go on the wire - 100 identical
+     *    rows in one chunk bill 100. EVERY APPEARANCE IN ANY LATER CHUNK IS FREE, however many
+     *    copies that chunk holds. The residue is therefore bounded by the CHUNK SIZE, not by one
+     *    charge per distinct address, which an earlier revision of this docblock claimed after
+     *    probing the two-copy case and generalising it to all n without testing it.
+     *    Whoever implements the rest MUST preserve the ONE-RESPONSE-ROW-PER-SENT-ITEM assumption
+     *    the row-count guard and the positional attribution loop both depend on: collapsing
+     *    duplicates into a single payload slot changes the row/address arithmetic, so that dedupe
+     *    and this guard have to change TOGETHER. Sending N slots and fanning one row out to
+     *    several caller keys, or sending N-k slots and re-deriving the expected row count from
+     *    the de-duplicated payload rather than from the caller's address count, are both safe;
+     *    silently comparing count($response) against the pre-dedupe count is not.
      *
      * @param $addresses
      * @param bool $checkForCaptured
-     * @return array|false THREE shapes, and every caller has to handle all three - see
-     *                     Plugin\Admin\ValidateImportAddress::afterValidateData():19-32:
+     * @return array|false THREE shapes, and every caller has to handle all three - see the
+     *                     docblock on Plugin\Admin\ValidateImportAddress::afterValidateData():
      *                     array<int|string, bool>, one verdict per input key in input order,
      *                     the normal case; ['noKeyFound' => true] when no API key is
      *                     configured, which is load-bearing and must NOT be merged into
@@ -725,6 +734,13 @@ class Validator
         $storedAddresses = $checkForCaptured
             ? $this->shopperSession->getData(Controller::CAPTURED_ADDRESSES_SESSION_KEY)
             : null;
+
+        // PRE-FLIGHT, READ ONCE PER BATCH AND BEFORE ANY PAYLOAD IS ASSEMBLED: a threshold that
+        // cannot be read as a grade decides every row before Loqate is asked, so asking is paying
+        // per address for a refusal already made. Same rule and same log line as the response
+        // side, because readableQualityIndexThreshold() is the single site of both. See the
+        // docblock's "A BROKEN QUALITY BAR COSTS NOTHING" paragraph.
+        $thresholdIsReadable = $this->readableQualityIndexThreshold() !== null;
 
         $result = [];
         $requestArray = [];
@@ -751,6 +767,18 @@ class Validator
                 continue;
             }
 
+            // THE QUALITY BAR IS BROKEN, SO THIS ROW IS ALREADY DECIDED - do not buy the answer.
+            // AFTER the captured guard, which never consults the AQI, and BEFORE the memories,
+            // which cannot hold anything for this row anyway: an unreadable threshold produces a
+            // fault report that rememberBatchVerdict() writes nowhere, and every readable verdict
+            // is keyed under the threshold that produced it (buildBatchVerifyCacheKey()). So the
+            // lookup would always miss, and skipping it skips two log lines that would both be
+            // untrue - no hit to report, and no billed address behind the miss.
+            if (!$thresholdIsReadable) {
+                $result[$index] = false;
+                continue;
+            }
+
             // The SAME builder verifyAddress() uses, and now the only one there is: the
             // region is in the key on the read exactly as on the write, so a region variant
             // Loqate was never asked about simply misses and is billed. (That is why the
@@ -764,12 +792,15 @@ class Validator
             $signature = $this->buildVerifyCacheSignature($parsedAddress);
 
             // BOTH memories, run-scoped first, and reported as ONE 'hit' either way (LOQ-17148).
-            // The run map is asked first because it is free (no session read, no unserialise),
-            // strictly newer than anything in the session store for the same key, and the only
-            // one of the two that can answer a REJECTION. The log line stays a single 'hit'
-            // token deliberately: it is what reconciles the drop in billed addresses against
-            // the invoice, and an operator counting hits against misses does not care which
-            // memory answered - see logBatchVerifyCacheOutcome().
+            // The run map is asked first because it is CHEAPER - no session read, no unserialise
+            // - strictly newer than anything in the session store for the same key, and the only
+            // one of the two that can answer a REJECTION. Cheaper, NOT free: reading it runs the
+            // ownership check, which costs two session reads and, on first access, a session
+            // write - and that check is exactly what makes answering from this map safe, see
+            // discardRunScopedVerdictsIfShopperChanged(). The log line stays a single 'hit'
+            // token deliberately: it reconciles the drop in billed addresses against the
+            // invoice, and an operator counting hits against misses does not care which memory
+            // answered - see logBatchVerifyCacheOutcome().
             $cachedVerdict = $this->getRunScopedBatchVerdict($signature)
                 ?? $this->getCachedBatchVerifyResult($signature);
             if ($cachedVerdict !== null) {
@@ -787,11 +818,14 @@ class Validator
         }
 
         if ($requestArray === []) {
-            // Nothing left to ask, because every address was captured or cached (or the
-            // batch was empty). Returning here is what makes an all-hit batch cost NO
-            // request, rather than sending an empty 'Addresses' payload to a billable
-            // endpoint and discarding the answer.
-            return $result;
+            // Nothing left to ask, because every address was captured, cached or decided by the
+            // pre-flight threshold guard (or the batch was empty). Returning here is what makes
+            // an all-hit batch cost NO request, rather than sending an empty 'Addresses' payload
+            // to a billable endpoint and discarding the answer. Through sealBatchVerdicts() like
+            // every other exit: this path used to return $result RAW, so the terminal guarantee
+            // held on one exit and not the other, and one future edit would have produced two
+            // different wrong behaviours depending on cache state.
+            return $this->sealBatchVerdicts($result);
         }
 
         $response = $this->apiConnector->verifyAddress(['Addresses' => $requestArray, 'source' => $this->version]);
@@ -804,24 +838,18 @@ class Validator
             return false;
         }
 
-        // THE PRECONDITION OF POSITIONAL ATTRIBUTION, checked before a single verdict is read
-        // or cached: exactly one answer per address sent. Everything below reads the Nth answer
-        // as the Nth address's verdict, and the connector's array_column($response, 'Matches')
-        // makes that unverifiable per row - it drops records with no 'Matches' key and
-        // reindexes the rest, so a gap arrives as a SHORTER CLEAN LIST that is indistinguishable
-        // from a truncated one and shifts every position after it. See the docblock above for
-        // the full mechanism and the accepted trade-off. Bailing out is therefore the only safe
-        // reading of a count mismatch, and it also gives the whole-response faults the connector
-        // collapses to [] - any 200 body that is not a list of records carrying 'Matches', such as
-        // {"Items": ...}, {"error":"Unauthorized"} or {} - a return value and a log line, where
-        // before they were completely silent. An unparseable body and a top-level error envelope
-        // are NOT among those: the connector reports both as ['error' => true, ...], so the branch
-        // directly above already returns for them and always did. See the docblock.
+        // THE PRECONDITION OF POSITIONAL ATTRIBUTION, checked before a single verdict is read or
+        // cached: exactly one answer per address sent. The connector's array_column($response,
+        // 'Matches') drops records with no 'Matches' key and reindexes the rest, so a gap arrives
+        // as a SHORTER CLEAN LIST indistinguishable from a truncated one, shifting every position
+        // after it - and the same call collapses the whole-response faults ({"Items": ...},
+        // {"error":"Unauthorized"}, {}) to [], which were previously silent. The docblock above
+        // has the full mechanism, the shapes this does NOT catch, and the accepted trade-off.
         //
-        // Returning false, not a partial array: the callers already treat false as "no verdict
-        // for this batch" and fail closed on it - Plugin\Admin\ValidateImportAddress.php:55-75
-        // reports one critical error and stops, Plugin\Admin\OrderSave.php:59-64 blocks the
-        // order with a message.
+        // Returning false, not a partial array: the callers treat false as "no verdict for this
+        // batch" and fail closed on it - Plugin\Admin\ValidateImportAddress::afterValidateData()
+        // reports one critical error and stops, Plugin\Admin\OrderSave::aroundExecute() blocks
+        // the order with a message.
         if (!is_array($response) || count($response) !== count($sentItems)) {
             $this->logger->info(sprintf(
                 'Loqate batch verify answered %d rows for %d addresses; verdicts not attributed.',
@@ -858,42 +886,33 @@ class Validator
             $qualityIndex = $addressResponse[0]['AQI'] ?? null;
 
             // FAILS CLOSED on an AQI we could not read, and the two guards on this path catch
-            // DISJOINT faults - neither one subsumes the other:
-            //  - the ROW-COUNT guard above catches records MISSING the 'Matches' key (the
-            //    connector's array_column($response, 'Matches') DROPS those, so the list is
-            //    shorter and the counts differ) plus the whole-response shapes that collapse
-            //    to [];
-            //  - checkQualityIndex()'s shape guard catches a record that IS PRESENT carrying
-            //    an empty or otherwise unreadable 'Matches' - semantically "Loqate found no
-            //    match for this address".
+            // DISJOINT faults - neither subsumes the other. The ROW-COUNT guard above catches
+            // records MISSING the 'Matches' key (array_column() DROPS those, so the counts
+            // differ) plus the whole-response shapes that collapse to []; checkQualityIndex()
+            // catches a record that IS PRESENT carrying an empty or unreadable 'Matches',
+            // semantically "Loqate found no match for this address".
             //
-            // The second case is FULLY REACHABLE past the count guard, and this is the
-            // correction of an earlier claim in these comments that it was not. Verified on
-            // PHP 8.3: array_column() only drops records missing the key; a record that HAS
+            // The second case is FULLY REACHABLE past the count guard - correcting an earlier
+            // claim in these comments that it was not. Verified on PHP 8.3: a record that HAS
             // 'Matches' whose value is [] SURVIVES as an empty element and the COUNT IS
-            // PRESERVED. Three records whose middle one is ['Matches' => []] therefore yield a
-            // three-element list that passes the count guard, position 1 arrives here as [],
-            // $addressResponse[0]['AQI'] ?? null is null, and null <= 'A' is true - so before
-            // this change that row was answered VALID. "No match found" being reported as
-            // "valid" is the maximally wrong answer, so this is a genuinely reachable hole
-            // being closed, not defence in depth.
-            //
-            // checkQualityIndex() now mirrors verifyAddress()'s AVC guard; see
-            // checkQualityIndex()'s own docblock for why the test is on the value's shape
-            // rather than on truthiness, for why an unrecognised THRESHOLD rejects rather
-            // than - as it once did - passing every address, and for why it answers THREE
-            // states rather than two.
+            // PRESERVED, so it reaches here as [], $addressResponse[0]['AQI'] ?? null is null,
+            // and null <= 'A' is true - that row used to be answered VALID. "No match found"
+            // reported as "valid" is the maximally wrong answer, so this is a reachable hole
+            // being closed, not defence in depth. See checkQualityIndex()'s docblock for why the
+            // test is on the value's SHAPE and why it answers three states rather than two.
             $verdict = $this->checkQualityIndex($qualityIndex);
 
             // THE STRICT BOOL COERCION IS LOAD-BEARING, AND THIS IS THE ONLY PLACE A null CAN
             // REACH $result (LOQ-17148). checkQualityIndex() answers null for "we could not
             // read this", which must still REJECT the row - it is only the REMEMBERING that
-            // differs - so it is coerced here rather than assigned. Assigning the null instead
-            // would leave the slot looking unfilled, the array_filter() below would DROP the
-            // row, and Plugin\Admin\ValidateImportAddress's array_merge() would then renumber
-            // every later row: an invalid row reported against a valid row's number, which is
-            // exactly the mis-attribution LOQ-16977 was raised to fix. Pinned by
-            // Test\Unit\Plugin\Admin\ValidateImportAddressRowAttributionTest.
+            // differs - so it is coerced here rather than assigned. It is coerced HERE and not
+            // left to sealBatchVerdicts() because the rejection must be visible at the point it
+            // is decided; the terminal coercion is a containment guard, not this row's verdict.
+            // Pinned by Test\Unit\Plugin\Admin\ValidateImportAddressRowAttributionTest, which is
+            // where the cost of getting it wrong is stated: a slot that is not filled here would
+            // let Plugin\Admin\ValidateImportAddress::afterValidateData()'s array_merge()
+            // renumber every later row - an invalid row reported against a valid row's number,
+            // the mis-attribution LOQ-16977 was raised to fix.
             $isValid = $verdict === true;
             $result[$sentItem['key']] = $isValid;
 
@@ -905,19 +924,38 @@ class Validator
             $this->rememberBatchVerdict($sentItem['signature'], $verdict);
         }
 
-        // With the count guard in place this filter is a NO-OP by construction, and that is
-        // worth stating rather than deleting: every reserved slot is now necessarily filled -
-        // captured, remembered verdict (either memory), or sent and therefore answered, since a
-        // mismatched row count returned above - so no null can survive to here. The one edit
-        // that could have broken that claim is the readability split above, and it does not: an
-        // unreadable answer is coerced to false before it is assigned, never left as null. It
-        // is kept as the enforcement of the documented return shape ("no null verdicts, ever"),
-        // so that a future edit which adds a further way of leaving a slot unfilled degrades to
-        // a missing key, which callers already read as "nothing to report", instead of shipping
-        // a null that ValidateImportAddress would report as an invalid row. array_filter()
-        // preserves both keys and order, so the return-shape guarantees above survive it
-        // either way.
-        return array_filter($result, static fn ($verdict) => $verdict !== null);
+        return $this->sealBatchVerdicts($result);
+    }
+
+    /**
+     * The ONE exit every verdict array leaves verifyMultipleAddresses() through: coerce each
+     * slot to a strict bool, keeping every key, in order.
+     *
+     * A NO-OP TODAY, and stated rather than deleted. Every reserved slot is necessarily filled
+     * by the time it gets here - captured, decided by the pre-flight threshold guard, answered
+     * from either memory, or sent and therefore answered, a mismatched row count having returned
+     * false earlier - so no null can reach this. It exists to CONTAIN the edit that changes that.
+     *
+     * IT FAILS CLOSED, WHICH IS THE CORRECTION OF WHAT USED TO BE HERE: array_filter($result,
+     * fn ($v) => $v !== null), justified as degrading an unfilled slot to a MISSING KEY "which
+     * callers already read as nothing to report". True of
+     * Plugin\Admin\ValidateImportAddress::afterValidateData(), which reports only the keys it
+     * receives - and the UNSAFE direction for Plugin\Admin\OrderSave::aroundExecute(), whose
+     * loop raises an error only for keys that are PRESENT, so a dropped key puts that address on
+     * the order UNVERIFIED and SILENTLY. Coercing keeps the slot and reports it INVALID, which is
+     * the fail-closed stance the rest of this class takes.
+     *
+     * '=== true' rather than a cast, so no future truthy value is promoted to "verified".
+     * array_map() over a SINGLE array preserves keys and order (verified on PHP 8.3), so
+     * OrderSave's 'billing_address'/'shipping_address' keys and the import's 0..N-1 ordering
+     * survive unchanged.
+     *
+     * @param array<int|string, bool|null> $result One slot per input address, in input order.
+     * @return array<int|string, bool> The same keys in the same order, every value a bool.
+     */
+    private function sealBatchVerdicts(array $result): array
+    {
+        return array_map(static fn ($verdict): bool => $verdict === true, $result);
     }
 
     /**
@@ -993,31 +1031,27 @@ class Validator
      * Check if response quality index matches the quality customer has set.
      *
      * THREE STATES, NOT TWO, AND THAT IS THE WHOLE OF THE READABILITY RULE (LOQ-17148):
-     *  - true  - the AQI is readable, the threshold is readable, and the AQI meets it;
-     *  - false - both are readable and the AQI MISSES the threshold. A VERDICT: Loqate judged
-     *            this address and this merchant's quality bar refused it;
-     *  - null  - the AQI could not be read, or the threshold could not be read. NOT A VERDICT
-     *            but a FAULT REPORT, about the response or about the configuration.
-     * The row is REJECTED for false and for null alike - the caller coerces null to false, see
-     * the attribution loop in verifyMultipleAddresses() - so nothing about which rows an import
-     * rejects changes. What the third state buys is the ability to remember the second one:
-     * rememberBatchVerdict() remembers a readable verdict of either polarity and remembers a
-     * null NOWHERE, so one connector fault, one "no match for this address" or one bad
-     * credential cannot brand every matching row in a file invalid for the rest of the run.
-     * Before the split, "readable rejection" and "unreadable, therefore rejected" were the same
-     * false and could not be told apart at all.
+     *  - true  - AQI and threshold both readable, and the AQI meets it;
+     *  - false - both readable and the AQI MISSES it. A VERDICT: Loqate judged this address and
+     *            the merchant's quality bar refused it;
+     *  - null  - one of them could not be read. A FAULT REPORT about the response or the
+     *            configuration, not a verdict.
+     * The row is REJECTED for false and null alike (the caller coerces), so which rows an import
+     * rejects does not change. What the third state buys is the ability to remember the second:
+     * rememberBatchVerdict() remembers a readable verdict of either polarity and a null nowhere,
+     * so one connector fault or one bad credential cannot brand every matching row in a file
+     * invalid for the rest of the run. Before the split the two were the same false.
      *
-     * THE RULE LIVES IN ONE PLACE. This method decides READABILITY; rememberBatchVerdict()
-     * decides what a null means for memory. Neither the call site nor storeBatchVerifyResult()
-     * repeats the test, which is what the previous arrangement got wrong in the other direction
-     * (it delegated the whole rule to this method's fail-closed guard, so "never remember an
-     * unreadable verdict" was true only as a side effect of failures not being cached - and it
-     * would have silently stopped being true the moment any failure was).
+     * THE RULE LIVES IN ONE PLACE: this method decides READABILITY, rememberBatchVerdict()
+     * decides what a null means for memory, and neither the call site nor storeBatchVerifyResult()
+     * repeats either test. The previous arrangement got that wrong in the other direction - it
+     * left "never remember an unreadable verdict" true only as a side effect of failures not
+     * being cached, which would have stopped being true the moment one lifetime cached them.
      *
      * FAILS CLOSED on an AQI it cannot read. The guard is on the value's SHAPE - "is this a
      * non-empty string" - and deliberately not on truthiness or emptiness, because the
      * comparison below is a STRING comparison in which 'A' is the strongest grade
-     * (etc/config.xml:20 defaults the threshold to 'A' and 'A' <= 'A' is true). Anything
+     * (etc/config.xml defaults address_quality_index to 'A' and 'A' <= 'A' is true). Anything
      * looser would over-reject:
      *  - empty()/falsy would reject '0', and would reject nothing this guard does not
      *    already catch;
@@ -1028,44 +1062,16 @@ class Validator
      *
      * WHY THIS IS NOT COSMETIC. Under PHP 8's comparison rules null <= 'A', '' <= 'A',
      * false <= 'A' and 0 <= 'A' are ALL true (verified on 8.3), so before this guard an
-     * unreadable AQI was answered VALID. The single call site - the positional attribution
-     * loop in verifyMultipleAddresses() - reads
-     * $addressResponse[0]['AQI'] ?? null, which is null for a response record whose
-     * 'Matches' list is present but EMPTY - i.e. Loqate saying "no match for this address",
-     * the case where "valid" is the maximally wrong answer. See the comment at that call
-     * site for why the row-count guard does not catch that shape.
+     * unreadable AQI was answered VALID. The single call site - the positional attribution loop
+     * in verifyMultipleAddresses() - reads $addressResponse[0]['AQI'] ?? null, which is null for
+     * a response record whose 'Matches' list is present but EMPTY, i.e. Loqate saying "no match
+     * for this address", the case where "valid" is the maximally wrong answer. See that call
+     * site for why the row-count guard does not catch that shape. It mirrors verifyAddress()'s
+     * AVC guard, so both verify paths draw the "readable verdict" line in the same place.
      *
-     * This mirrors verifyAddress()'s AVC guard, so both verify paths now draw the
-     * "readable verdict" line in exactly the same place.
-     *
-     * BOTH SIDES ARE NOW GUARDED EXPLICITLY, and the threshold side had to be.
-     *
-     * An earlier revision guarded only the AQI side and reasoned about the threshold side
-     * being unset: 'A' <= null and 'A' <= '' are both false on 8.3, so a blank threshold
-     * rejects every address. True, and the safe direction - but it is the wrong case. The
-     * dangerous value is not a blank threshold, it is an UNREADABLE one. Under the same
-     * string comparison, 'A' <= 'zzz' and 'E' <= 'zzz' are both TRUE (verified on 8.3), so a
-     * threshold of any text sorting above 'E' passes EVERY address, including the worst AQI
-     * Loqate can return. That is a total bypass of the merchant's configured quality bar,
-     * arrived at silently, and no amount of guarding the response side detects it.
-     *
-     * So the threshold is required to be one of self::VALID_QUALITY_INDEXES and anything
-     * else fails closed and is logged - EVERY time, once per verdict, not once per run. That
-     * log line is the only signal a merchant has that their quality bar is broken, so it is
-     * emitted from here rather than hoisted anywhere a remembered verdict could skip it.
-     * Rejecting is the only safe answer: the whole point of the setting is to bar addresses,
-     * and a threshold nobody can read cannot be said to admit any of them.
-     *
-     * REACHABLE FROM THE ADMIN UI SINCE LOQ-17148: etc/adminhtml/system.xml now exposes
-     * address_quality_index as a SELECT over Model\Config\Source\AddressQualityIndex, whose
-     * option values are derived from self::VALID_QUALITY_INDEXES - so nothing a merchant can
-     * choose in the form can reach the branch below. The guard is not thereby redundant, and
-     * this is why it was written before the field existed: the value is a plain
-     * core_config_data row, and a data patch, a CLI config:set, direct SQL or an env.php
-     * override can still put anything into it. The guard costs one in_array() per verdict.
-     *
-     * resolveQualityIndexThreshold() still returns the value RAW and uncast, so the batch
-     * cache key keeps fingerprinting exactly what was compared; see its docblock.
+     * THE THRESHOLD SIDE LIVES IN readableQualityIndexThreshold(), because
+     * verifyMultipleAddresses() asks the same question before it assembles a payload; read that
+     * method for why an unreadable threshold is the dangerous case rather than a blank one.
      *
      * @param $qualityIndex The AQI from the response row, of any type - it is unvalidated
      *                      connector output, so this method must not assume a string.
@@ -1082,21 +1088,78 @@ class Validator
             return null;
         }
 
-        $configIndex = $this->resolveQualityIndexThreshold();
-
-        if (!is_string($configIndex) || !in_array($configIndex, self::VALID_QUALITY_INDEXES, true)) {
-            $this->logger->info(sprintf(
-                'Loqate: address_quality_index is not a recognised quality index (%s of type %s); '
-                . 'rejecting the address. Set it to one of %s.',
-                var_export($configIndex, true),
-                gettype($configIndex),
-                implode(', ', self::VALID_QUALITY_INDEXES)
-            ));
-
+        $configIndex = $this->readableQualityIndexThreshold();
+        if ($configIndex === null) {
             return null;
         }
 
         return $qualityIndex <= $configIndex;
+    }
+
+    /**
+     * The configured quality bar, or null if it cannot be read as a grade - and the log line
+     * that says so.
+     *
+     * THE SINGLE SITE OF THE THRESHOLD READABILITY RULE. Two callers ask, for two different
+     * reasons, and neither repeats the test: checkQualityIndex() cannot judge a response against
+     * a threshold it cannot read, and verifyMultipleAddresses() will not BUY a response whose
+     * verdict is already settled (see its pre-flight guard). One rule, one in_array(), one
+     * message.
+     *
+     * WHY THE TEST HAD TO EXIST AT ALL. checkQualityIndex() compares with <=, a STRING
+     * comparison, and the dangerous value is not a blank threshold but an UNREADABLE one:
+     * 'A' <= 'zzz' and 'E' <= 'zzz' are both TRUE on 8.3, so any text sorting above 'E' passed
+     * EVERY address, including the worst AQI Loqate returns - a silent, total bypass of the
+     * merchant's configured quality bar that no amount of guarding the response side detects.
+     * (A blank threshold already failed closed: 'A' <= null and 'A' <= '' are both false.)
+     * Rejecting is the only safe answer: the whole point of the setting is to bar addresses, and
+     * a threshold nobody can read cannot be said to admit any of them.
+     *
+     * WHY IT LOGS FROM HERE. That line is the only signal a merchant has that their quality bar
+     * is broken, so it must not sit anywhere a remembered verdict could skip it - and the batch
+     * pre-flight does not: it runs before both memories and before payload assembly, so no cache
+     * hit can skip it. It also now fires on a file that comes back ALL-EMPTY, which used to
+     * produce zero threshold-broken lines while rejecting every row, because checkQualityIndex()
+     * returned on the unreadable AQI before it ever read the threshold. What did change is the
+     * frequency - once per verified batch rather than once per verdict - and the CHANGELOG says
+     * so.
+     *
+     * REACHABLE FROM THE ADMIN UI SINCE LOQ-17148: etc/adminhtml/system.xml exposes
+     * address_quality_index as a SELECT over Model\Config\Source\AddressQualityIndex, whose
+     * option values are derived from self::VALID_QUALITY_INDEXES, so nothing a merchant can
+     * choose in the form reaches the null branch. Not thereby redundant: the value is a plain
+     * core_config_data row, and a data patch, a CLI config:set, direct SQL or an env.php
+     * override can still put anything into it.
+     *
+     * resolveQualityIndexThreshold() still returns the value RAW and uncast, so the batch cache
+     * key keeps fingerprinting exactly what was compared; this method narrows it to the five
+     * grades or nothing, which is why what it returns is safe to compare with. One consequence,
+     * so it is not mistaken for dead code: checkQualityIndex()'s "threshold unreadable" branch is
+     * no longer reached THROUGH verifyMultipleAddresses(), which returns before the request. It
+     * stays because a method that judges a response may not assume its caller checked the
+     * configuration first.
+     *
+     * @return string|null One of self::VALID_QUALITY_INDEXES, or null when the configured value
+     *                     is not one of them - which is a configuration fault report, never a
+     *                     verdict about an address.
+     */
+    private function readableQualityIndexThreshold(): ?string
+    {
+        $configIndex = $this->resolveQualityIndexThreshold();
+
+        if (is_string($configIndex) && in_array($configIndex, self::VALID_QUALITY_INDEXES, true)) {
+            return $configIndex;
+        }
+
+        $this->logger->info(sprintf(
+            'Loqate: address_quality_index is not a recognised quality index (%s of type %s); '
+            . 'rejecting the address. Set it to one of %s.',
+            var_export($configIndex, true),
+            gettype($configIndex),
+            implode(', ', self::VALID_QUALITY_INDEXES)
+        ));
+
+        return null;
     }
 
     /**
@@ -1758,28 +1821,23 @@ class Validator
      * Remember one batch verdict - in BOTH memories, or in NEITHER (LOQ-17148).
      *
      * THE SINGLE GATE FOR "NEVER REMEMBER A VERDICT WE COULD NOT READ". It takes
-     * checkQualityIndex()'s three-state answer, not a bool, precisely so that the decision is
-     * made where the distinction still exists: null is an unreadable AQI or an unreadable
-     * threshold, which is a FAULT REPORT and not a verdict, so it is written nowhere and the
-     * identical address is billed again - within this run as well as in any later request. One
-     * connector fault, one "no match for this address" or one bad credential must not brand
-     * every matching row in an import file invalid for the rest of the run, reported to the
-     * merchant as rows to go and fix with nothing on the server saying otherwise.
+     * checkQualityIndex()'s three-state answer, not a bool, so the decision is made where the
+     * distinction still exists: null is a FAULT REPORT and not a verdict, so it is written
+     * nowhere and the identical address is billed again on every occurrence, this run and every
+     * later one. That cost is accepted because one connector fault, one "no match for this
+     * address" or one bad credential must not brand every matching row in an import file invalid
+     * for the rest of the run - see the ACCEPTED LIMITS on verifyMultipleAddresses().
      *
      * WHY THE RULE IS HERE AND NOWHERE ELSE. It used to be delegated to checkQualityIndex()
      * failing closed plus storeBatchVerifyResult() storing no failures: true at the time, but
      * true only as a SIDE EFFECT of failures never being remembered, so it stopped being true
      * the moment one lifetime started remembering them. Stating it once, at the only place both
-     * memories are written, is what keeps the two lifetimes from drifting apart - and it is
-     * always the readability half that gets relaxed when they do. The call site holds no
-     * readability test, and neither does storeBatchVerifyResult(), which keeps its own
+     * memories are written, is what keeps the two lifetimes from drifting apart. The call site
+     * holds no readability test, and neither does storeBatchVerifyResult(), which keeps its own
      * PASSES-ONLY guard for its own separate reason (see its docblock).
      *
      * THE TWO POLARITIES ARE ASYMMETRIC BY DESIGN: a readable rejection is remembered for the
-     * RUN and never for the SESSION. self::BATCH_VERIFY_CACHE_LIMIT records the measurements
-     * behind that - caching failures in the session store is a regression on the target
-     * workload, and a rejection that outlived the request would strand a merchant who had
-     * corrected the file or loosened the threshold.
+     * RUN and never for the SESSION, measured on self::BATCH_VERIFY_CACHE_LIMIT.
      *
      * @param string $signature Signature the verdict was earned under.
      * @param bool|null $verdict checkQualityIndex()'s answer, passed through UNCOERCED.
@@ -1823,10 +1881,12 @@ class Validator
      * Remember one readable verdict for the rest of this run.
      *
      * Deliberately UNBOUNDED, unlike the session store. It holds one array entry per distinct
-     * address in one import file, it is never serialised and it dies with the request, so the
-     * cost is bounded by the file the merchant chose to import - whereas the session store is
-     * re-read and re-written on every subsequent request of the browser session, which is the
-     * whole reason THAT one has a limit (see self::BATCH_VERIFY_CACHE_LIMIT).
+     * address in one import file and is never serialised, so on every runtime this module ships
+     * on the cost is bounded by the file the merchant chose to import - whereas the session
+     * store is re-read and re-written on every subsequent request of the browser session, which
+     * is the whole reason THAT one has a limit (see self::BATCH_VERIFY_CACHE_LIMIT). What
+     * "unbounded" costs under a long-lived worker, and why no eviction policy is shipped for
+     * one, is stated on self::$runScopedBatchVerdicts.
      *
      * @param string $signature
      * @param bool $verdict Readable verdict of either polarity; nulls are stopped by
@@ -1863,12 +1923,11 @@ class Validator
      * cannot see. Pinned by
      * ShopperScopedAddressStoresTest::testABatchVerdictDoesNotSurviveALogin().
      *
-     * ASKING IS WHAT ENFORCES IT. ShopperScopedAddressStores::ownershipGeneration() runs the
-     * ownership check itself and then reports the generation, so this is correct even on the
-     * import path, where $checkForCaptured is false and the run map is consulted before any
-     * session attribute is touched at all. Enrolling the map in the guard's own model, rather
-     * than comparing customer ids at this call site, is what keeps ONE definition of "the
-     * shopper changed" in the codebase.
+     * ASKING IS WHAT ENFORCES IT: ownershipGeneration() runs the ownership check itself before
+     * reporting, so this is correct even on the import path, where $checkForCaptured is false
+     * and the run map is consulted before any session attribute is touched. Enrolling the map in
+     * the guard's own model, rather than comparing customer ids here, keeps ONE definition of
+     * "the shopper changed".
      *
      * @return void
      */

--- a/Helper/Validator.php
+++ b/Helper/Validator.php
@@ -59,8 +59,19 @@ class Validator
      * a STRING comparison, so an unrecognised threshold does not fail closed - anything
      * sorting above 'E' passes every address. This list is what makes that comparison
      * meaningful; see checkQualityIndex() for the failure it prevents.
+     *
+     * PUBLIC BECAUSE THE ADMIN FIELD'S OPTION LIST IS DERIVED FROM IT (LOQ-17148).
+     * Model\Config\Source\AddressQualityIndex - the source_model behind the
+     * address_quality_index select in etc/adminhtml/system.xml - reads its option VALUES from
+     * here and supplies only the labels. It used to spell A-E out itself, which was a second
+     * copy of this list free to drift: a grade added here but not there would be honoured by
+     * the verifier and unreachable in the form, and a grade added there but not here would be
+     * selectable and would then reject EVERY address, reported to the merchant row by row as
+     * invalid data rather than as a bad setting. Deriving one from the other makes both
+     * directions impossible rather than merely tested (they are tested too, in
+     * Test\Unit\Model\Config\Source\AddressQualityIndexTest).
      */
-    private const VALID_QUALITY_INDEXES = ['A', 'B', 'C', 'D', 'E'];
+    public const VALID_QUALITY_INDEXES = ['A', 'B', 'C', 'D', 'E'];
 
     /**
      * Version of the verify caches' KEY SCHEME. Stamped into every verdict written by
@@ -156,8 +167,8 @@ class Validator
      *
      * Deliberately larger than self::VERIFY_CACHE_LIMIT because this path is BATCHED:
      * customer import verifies in chunks of 100 rows
-     * (Plugin\Admin\ValidateImportAddress.php:50), so any limit below 100 could not hold
-     * even one chunk - the eviction would discard a chunk's earliest rows before the
+     * (Plugin\Admin\ValidateImportAddress::afterValidateData()), so any limit below 100 could
+     * not hold even one chunk - the eviction would discard a chunk's earliest rows before the
      * chunk finished, and re-running a file that FITS WITHIN THIS LIMIT would re-bill them.
      * 200 holds two full chunks while still bounding the session payload, which is the whole
      * point of having a limit at all (see self::VERIFY_CACHE_LIMIT and
@@ -167,25 +178,62 @@ class Validator
      * READ THAT PARAGRAPH AS A FLOOR ON THE CONSTANT, NOT AS A SAVING ON THE IMPORT PATH.
      * It is why >= 100 is asserted, and it holds only for a file whose whole working set
      * fits inside the limit; for a file LARGER than the limit it claims nothing, because
-     * FIFO eviction leaves close to zero hits however the constant is chosen. The paragraph
-     * below is the one to quote when crediting this cache with a saving.
+     * FIFO eviction leaves close to zero hits however the constant is chosen.
      *
-     * DO NOT MEASURE THIS AGAINST THE IMPORT PATH - state the consequence plainly so the
-     * saving is not credited to the wrong place. Eviction is FIFO, so re-running a file
-     * LARGER than this limit yields close to ZERO cache hits: chunk 1's entries are already
-     * evicted by the time run 1 finishes, and re-fetching them during run 2 evicts exactly
-     * what chunk 2 would have needed. Two further facts compound it: only PASSING verdicts
-     * are cached at all (storeBatchVerifyResult()), and address_quality_index defaults to
-     * 'A' (etc/config.xml:20), the strictest value, so on a default install most rows fail
-     * and are therefore never cacheable in the first place. The practical dedupe on the
-     * import path is consequently near nil, and raising this constant would not change that
-     * - it is inherent to FIFO over a working set larger than the cache.
+     * WHAT DEDUPES THE IMPORT PATH IS NOT THIS STORE (LOQ-17148). An import run chunks at 100
+     * rows and verifies every chunk INSIDE ONE PHP REQUEST, so the lifetime that matters there
+     * is the RUN, not the session. That is served by the run-scoped verdict map on this
+     * instance - see rememberBatchVerdict() and getRunScopedBatchVerdict() - which remembers
+     * BOTH polarities and is unbounded by this limit. Measured on the file shapes that showed
+     * the defect: 29% fewer billed addresses on a 1000-row file holding 700 distinct
+     * addresses, and 58.8% fewer on 1000 rows holding 400. Before it, a REJECTED address was
+     * re-sent - and so re-billed, the Cleansing API being billed per ADDRESS - in every chunk
+     * it appeared in, because this store caches PASSES ONLY (storeBatchVerifyResult()) and
+     * address_quality_index ships as 'A' (etc/config.xml), the strictest grade, so on a
+     * default install most rows fail and were never cacheable here in the first place.
      *
-     * THIS IS TRACKED, NOT ACCEPTED. LOQ-16976 was raised for admin order create AND customer
-     * import; this cache delivers the first. The import half is LOQ-17148, which is where the
-     * two fixable causes belong - caching failed verdicts on that path, where a failure costs
-     * a re-verify rather than a bypass, and exposing address_quality_index in
-     * etc/adminhtml/system.xml so the default cannot silently fail every row.
+     * THIS STORE IS DELIBERATELY UNCHANGED BY LOQ-17148 - passes only, FIFO, 200 - and the
+     * measurements behind each rejected alternative are recorded here because every one of
+     * them looks like an obvious improvement:
+     *  - CACHING FAILURES HERE IS A REGRESSION on the target workload, not an omission.
+     *    Eviction is FIFO and bounded, so failures crowd out the sparse passes the store
+     *    currently manages to keep: for 1000 distinct rows at a 5% pass rate, a second run
+     *    goes from 950 billed addresses to 1000, and for 500 rows at 5% from 475 to 500. It is
+     *    never better for any file larger than this limit. (An earlier revision of this
+     *    docblock promised LOQ-17148 would deliver exactly that. It was wrong, and this
+     *    paragraph is the correction.) It would also strand a merchant: a rejection that
+     *    outlived the request would be replayed after they corrected the file or loosened the
+     *    threshold, with no request made and no way to clear it.
+     *  - "RETAIN ON FULL" (freeze the store instead of evicting) is rejected: one Check Data
+     *    click on a file of 200 rows or more would permanently fill the store for the rest of
+     *    that admin's browser session - adminhtml never flushes it, see
+     *    ShopperScopedAddressStores' ACCEPTED LIMITS - destroying the admin-order-create win
+     *    below, which is the win LOQ-16976 actually delivered.
+     *  - SIZING THE STORE TO THE FILE is rejected on measured cost: ~147 bytes per entry, so
+     *    1000 entries is ~141 KB and 5000 is ~712 KB of raw session data. Magento reads and
+     *    writes the WHOLE session on every request, so a 5000-entry store costs ~1.4 MB of
+     *    session I/O on EVERY unrelated admin page load for the life of the session (~278 MB
+     *    over 200 page loads) to serve a re-run the merchant may never perform.
+     *
+     * RESIDUAL EXPOSURE, stated plainly rather than left to be rediscovered from an invoice.
+     * CROSS-RUN dedupe is not delivered for a file with more than this many distinct
+     * addresses: a re-run in the same browser session (a second Check Data click, a second
+     * import) re-bills essentially every row, because a sequential cyclic scan through a
+     * smaller FIFO cache has a ~0% hit rate. For a programmatic, CLI or cron-driven import it
+     * is 0% BY CONSTRUCTION and no cache size would change that - each process starts a fresh
+     * session id, so nothing one run writes is ever found by the next. Raising this constant
+     * does not fix either case; it is inherent to FIFO over a working set larger than the
+     * cache, and to session-scoped storage outside a browser session.
+     *
+     * NOT THE SAME TICKET AS INTRA-CHUNK DUPLICATES, AND LOQ-17015 IS NOT CLOSED BY THIS WORK.
+     * LOQ-17148 dedupes ACROSS the chunks of one run. Two copies of an address in ONE assembled
+     * payload are still both billed on that address's FIRST appearance in the run, because
+     * nothing is remembered until the response returns, so both copies miss; every LATER
+     * appearance is answered from the run map, two copies in one batch included. That residue
+     * is LOQ-17015 and it is riskier to fix - it changes the payload row arithmetic and must be
+     * done TOGETHER with the count($response) !== count($sentItems) guard in
+     * verifyMultipleAddresses(), never by comparing against the pre-dedupe count. See the
+     * ACCEPTED LIMITS on that method for the boundary stated exactly.
      *
      * Where this cache actually pays for itself is ADMIN ORDER CREATE: two addresses per
      * submission, re-submitted after a validation bounce or an unrelated form error, is
@@ -207,6 +255,56 @@ class Validator
      *      the guard - see ShopperScopedAddressStores.
      */
     private ShopperScopedAddressStores $shopperSession;
+
+    /**
+     * Batch verdicts earned by THIS instance, keyed exactly as the session store is
+     * (buildBatchVerifyCacheKey()) and holding BOTH polarities (LOQ-17148).
+     *
+     * THE LIFETIME IS THE RUN, and that is the whole point: an import file is chunked at 100
+     * rows by Plugin\Admin\ValidateImportAddress::afterValidateData() and every chunk is
+     * verified inside ONE PHP request against ONE Validator, so "this instance" IS "this import
+     * run". A rejected address repeated in a later chunk used to be re-sent and re-billed in
+     * every chunk it appeared in, because the session store holds passes only; this map is what
+     * answers it instead. Passes are remembered here too, because the session store is bounded
+     * and FIFO - on a file larger than self::BATCH_VERIFY_CACHE_LIMIT an early pass is evicted
+     * before the file ends and would otherwise be re-billed within the same run.
+     *
+     * NEVER SERIALISED AND NEVER PERSISTED. It dies with the request, by construction: it is a
+     * plain property, nothing writes it to the session, and it is deliberately NOT a static or
+     * a Registry entry (either would serve one shopper's verdicts to another - see
+     * self::VERIFY_CACHE_SESSION_KEY). That mortality is a FEATURE and is asserted: a rejection
+     * must never outlive the request, or a merchant who corrects the file or loosens the
+     * threshold keeps being told "invalid" with no request made and no way to clear it.
+     *
+     * KEYED ON THE KEY, NOT ON THE RAW SIGNATURE. buildBatchVerifyCacheKey() is where the
+     * '' -"nothing identifiable" sentinel is honoured and where the store view and the AQI
+     * threshold fingerprint enter, so keying on the signature would remember verdicts across a
+     * threshold change and would file two unidentifiable addresses under one key.
+     *
+     * ONLY READABLE VERDICTS ARE IN HERE. An unreadable AQI or an unreadable threshold produces
+     * a rejection that is a FAULT REPORT, not a verdict, and is remembered nowhere - see
+     * rememberBatchVerdict(), which is the single gate for both lifetimes.
+     *
+     * @var array<string, bool> Batch cache key => verdict.
+     */
+    private array $runScopedBatchVerdicts = [];
+
+    /**
+     * The ShopperScopedAddressStores generation self::$runScopedBatchVerdicts was earned under,
+     * or null before this instance has asked (LOQ-17148, LOQ-16978).
+     *
+     * The map holds the same kind of data as the session verdict stores - licences to skip a
+     * billable verify - so it must have the same OWNERSHIP lifetime, not merely the same
+     * request. A request-scoped map does NOT get that for free: one Validator can outlive a
+     * mid-request identity change, and it would then answer the new shopper from the previous
+     * shopper's verdicts while the guard had just flushed the three stores beside it. So the
+     * map is enrolled in the guard's own ownership model rather than checked ad hoc at the call
+     * site: see ShopperScopedAddressStores::ownershipGeneration() and
+     * discardRunScopedVerdictsIfShopperChanged().
+     *
+     * @var int|null
+     */
+    private ?int $runScopedVerdictsGeneration = null;
 
     /** @var RegionFactory */
     private $regionFactory;
@@ -454,8 +552,8 @@ class Validator
     /**
      * Verify multiple addresses using Loqate API
      *
-     * Used by admin order create (Plugin\Admin\OrderSave.php:49) and customer import
-     * (Plugin\Admin\ValidateImportAddress.php:53).
+     * Used by admin order create (Plugin\Admin\OrderSave::aroundExecute()) and customer import
+     * (Plugin\Admin\ValidateImportAddress::afterValidateData()).
      *
      * BILLING (LOQ-16976): the Cleansing API is billable PER ADDRESS, not per request, so
      * the verdict cache is consulted PER ADDRESS, before the address is added to the
@@ -466,6 +564,22 @@ class Validator
      * before considering merging the two. Only PASSING verdicts are cached, see
      * storeBatchVerifyResult(). The pre-existing captured-address guard is applied first
      * and is likewise free.
+     *
+     * TWO MEMORIES, TWO LIFETIMES, ONE KEY (LOQ-17148). The lookup before payload assembly
+     * consults BOTH, in this order:
+     *  - self::$runScopedBatchVerdicts, this INSTANCE's map, holding BOTH polarities. Its
+     *    lifetime is one import RUN, because that is what one instance is here: an import file
+     *    is chunked at 100 rows and every chunk is verified against the same Validator inside
+     *    one PHP request. This is what stops a REJECTED address being re-billed in every chunk
+     *    it appears in, which the session store structurally could not do, and it is unbounded
+     *    by self::BATCH_VERIFY_CACHE_LIMIT so an evicted PASS is not re-billed mid-run either;
+     *  - the SESSION store, holding PASSES ONLY and bounded, which is what survives to a LATER
+     *    REQUEST (the re-submitted admin order, a re-run import that fits inside the limit).
+     * Both are keyed by buildBatchVerifyCacheKey(), so one address is one key in both and a
+     * threshold or store-view change invalidates both at once. A rejection is deliberately
+     * asymmetric - remembered for the run, never for the session - and
+     * self::BATCH_VERIFY_CACHE_LIMIT records the measurements behind that asymmetry, including
+     * why widening the session store is a REGRESSION rather than the obvious next step.
      *
      * RETURN SHAPE - load-bearing in two ways, do not "simplify" either:
      *  - one entry per input address, under the INPUT's OWN KEY. OrderSave.php:51-57
@@ -557,15 +671,28 @@ class Validator
      *    batch can both miss and both be billed. Sequential replay - the re-submitted
      *    admin order, the re-run import - is what this de-duplicates.
      *  - a row present in the response but carrying no readable AQI is answered INVALID and
-     *    is never cached. That is a fail-closed verdict, decided by checkQualityIndex()'s
-     *    shape guard, and reached for a record whose 'Matches' list is present but empty -
-     *    the row-count guard below cannot catch that shape, because array_column()
-     *    PRESERVES such a record, see the attribution loop for the demonstration. It is a
-     *    deliberate rejection, not a gap: it costs one re-attempt on a response we could
-     *    not read, where the previous behaviour reported "no match found" as VALID.
-     *  - the same address twice in ONE batch is billed twice: both copies miss the cache in
-     *    the pre-flight pass, since nothing is written until the response comes back.
-     *    Tracked as LOQ-17015. Whoever implements it MUST preserve the
+     *    is remembered NOWHERE - not in the session, and not for the rest of the run either.
+     *    That is a fail-closed rejection, decided by checkQualityIndex() answering null, and
+     *    reached for a record whose 'Matches' list is present but empty - the row-count guard
+     *    below cannot catch that shape, because array_column() PRESERVES such a record, see
+     *    the attribution loop for the demonstration. It is a deliberate rejection, not a gap:
+     *    it costs one re-attempt on a response we could not read, where the previous behaviour
+     *    reported "no match found" as VALID. The price of remembering it would be far higher -
+     *    ONE connector fault or one bad credential would brand every matching row in the file
+     *    invalid for the rest of the run, sending the merchant to edit rows Loqate never
+     *    rejected.
+     *  - LOQ-17015 IS NOT RESOLVED BY LOQ-17148, and here is the boundary stated exactly, so
+     *    that ticket is neither closed on a partial fix nor re-implemented for work already
+     *    done. VERIFIED against this implementation, not merely reasoned about: two copies of
+     *    an address in one batch, on that address's FIRST appearance in the run, are BOTH
+     *    billed - both copies miss both memories in the pre-flight pass, because nothing is
+     *    remembered until the response comes back. What LOQ-17148 does change is every LATER
+     *    appearance: once the run map holds a readable verdict for an address, every copy of it
+     *    in every subsequent batch is answered from memory, including two copies inside the
+     *    SAME batch. So the residue of LOQ-17015 is exactly "the first batch in which an
+     *    address appears more than once", and it is bounded by ONE duplicate charge per
+     *    distinct address per run rather than one per occurrence.
+     *    Whoever implements the rest MUST preserve the
      *    ONE-RESPONSE-ROW-PER-SENT-ITEM assumption the row-count guard below and the
      *    positional attribution loop after it both depend on: collapsing duplicates into a
      *    single payload slot changes the row/address arithmetic, so that dedupe and this
@@ -631,7 +758,16 @@ class Validator
             // ValidatorBatchVerifyCacheTest::testAnUnverifiedCountyVariantIsNeverServedACachedBatchPass()
             // and ::testChangingOnlyTheCountyCostsASecondBillableAddress().
             $signature = $this->buildVerifyCacheSignature($parsedAddress);
-            $cachedVerdict = $this->getCachedBatchVerifyResult($signature);
+
+            // BOTH memories, run-scoped first, and reported as ONE 'hit' either way (LOQ-17148).
+            // The run map is asked first because it is free (no session read, no unserialise),
+            // strictly newer than anything in the session store for the same key, and the only
+            // one of the two that can answer a REJECTION. The log line stays a single 'hit'
+            // token deliberately: it is what reconciles the drop in billed addresses against
+            // the invoice, and an operator counting hits against misses does not care which
+            // memory answered - see logBatchVerifyCacheOutcome().
+            $cachedVerdict = $this->getRunScopedBatchVerdict($signature)
+                ?? $this->getCachedBatchVerifyResult($signature);
             if ($cachedVerdict !== null) {
                 $this->logBatchVerifyCacheOutcome('hit', $signature);
                 $result[$index] = $cachedVerdict;
@@ -740,28 +876,43 @@ class Validator
             //
             // checkQualityIndex() now mirrors verifyAddress()'s AVC guard; see
             // checkQualityIndex()'s own docblock for why the test is on the value's shape
-            // rather than on truthiness, and for why an unrecognised THRESHOLD rejects rather
-            // than - as it once did - passing every address.
-            $isValid = $this->checkQualityIndex($qualityIndex);
+            // rather than on truthiness, for why an unrecognised THRESHOLD rejects rather
+            // than - as it once did - passing every address, and for why it answers THREE
+            // states rather than two.
+            $verdict = $this->checkQualityIndex($qualityIndex);
+
+            // THE STRICT BOOL COERCION IS LOAD-BEARING, AND THIS IS THE ONLY PLACE A null CAN
+            // REACH $result (LOQ-17148). checkQualityIndex() answers null for "we could not
+            // read this", which must still REJECT the row - it is only the REMEMBERING that
+            // differs - so it is coerced here rather than assigned. Assigning the null instead
+            // would leave the slot looking unfilled, the array_filter() below would DROP the
+            // row, and Plugin\Admin\ValidateImportAddress's array_merge() would then renumber
+            // every later row: an invalid row reported against a valid row's number, which is
+            // exactly the mis-attribution LOQ-16977 was raised to fix. Pinned by
+            // Test\Unit\Plugin\Admin\ValidateImportAddressRowAttributionTest.
+            $isValid = $verdict === true;
             $result[$sentItem['key']] = $isValid;
 
-            // NEVER CACHE A VERDICT WE COULD NOT READ still holds, and it no longer needs a
-            // separate readability test here: an unreadable AQI is now a FALSE verdict, and
-            // storeBatchVerifyResult() caches nothing but passes. One test, one place - the
-            // previous arrangement had the readability rule stated twice (once for the verdict,
-            // once for the cache) and could drift.
-            $this->storeBatchVerifyResult($sentItem['signature'], $isValid);
+            // NEVER REMEMBER A VERDICT WE COULD NOT READ, in ONE place for BOTH lifetimes:
+            // rememberBatchVerdict() is the single gate, and it is handed the three-state
+            // answer rather than the coerced bool precisely so that "unreadable" is still
+            // distinguishable when the decision is made. No readability test here, none in
+            // storeBatchVerifyResult(); one rule, one site.
+            $this->rememberBatchVerdict($sentItem['signature'], $verdict);
         }
 
         // With the count guard in place this filter is a NO-OP by construction, and that is
         // worth stating rather than deleting: every reserved slot is now necessarily filled -
-        // captured, cache hit, or sent and therefore answered, since a mismatched row count
-        // returned above - so no null can survive to here. It is kept as the enforcement of the
-        // documented return shape ("no null verdicts, ever"), so that a future edit which adds
-        // a fourth way of leaving a slot unfilled degrades to a missing key, which callers
-        // already read as "nothing to report", instead of shipping a null that
-        // ValidateImportAddress would report as an invalid row. array_filter() preserves both
-        // keys and order, so the return-shape guarantees above survive it either way.
+        // captured, remembered verdict (either memory), or sent and therefore answered, since a
+        // mismatched row count returned above - so no null can survive to here. The one edit
+        // that could have broken that claim is the readability split above, and it does not: an
+        // unreadable answer is coerced to false before it is assigned, never left as null. It
+        // is kept as the enforcement of the documented return shape ("no null verdicts, ever"),
+        // so that a future edit which adds a further way of leaving a slot unfilled degrades to
+        // a missing key, which callers already read as "nothing to report", instead of shipping
+        // a null that ValidateImportAddress would report as an invalid row. array_filter()
+        // preserves both keys and order, so the return-shape guarantees above survive it
+        // either way.
         return array_filter($result, static fn ($verdict) => $verdict !== null);
     }
 
@@ -837,6 +988,28 @@ class Validator
     /**
      * Check if response quality index matches the quality customer has set.
      *
+     * THREE STATES, NOT TWO, AND THAT IS THE WHOLE OF THE READABILITY RULE (LOQ-17148):
+     *  - true  - the AQI is readable, the threshold is readable, and the AQI meets it;
+     *  - false - both are readable and the AQI MISSES the threshold. A VERDICT: Loqate judged
+     *            this address and this merchant's quality bar refused it;
+     *  - null  - the AQI could not be read, or the threshold could not be read. NOT A VERDICT
+     *            but a FAULT REPORT, about the response or about the configuration.
+     * The row is REJECTED for false and for null alike - the caller coerces null to false, see
+     * the attribution loop in verifyMultipleAddresses() - so nothing about which rows an import
+     * rejects changes. What the third state buys is the ability to remember the second one:
+     * rememberBatchVerdict() remembers a readable verdict of either polarity and remembers a
+     * null NOWHERE, so one connector fault, one "no match for this address" or one bad
+     * credential cannot brand every matching row in a file invalid for the rest of the run.
+     * Before the split, "readable rejection" and "unreadable, therefore rejected" were the same
+     * false and could not be told apart at all.
+     *
+     * THE RULE LIVES IN ONE PLACE. This method decides READABILITY; rememberBatchVerdict()
+     * decides what a null means for memory. Neither the call site nor storeBatchVerifyResult()
+     * repeats the test, which is what the previous arrangement got wrong in the other direction
+     * (it delegated the whole rule to this method's fail-closed guard, so "never remember an
+     * unreadable verdict" was true only as a side effect of failures not being cached - and it
+     * would have silently stopped being true the moment any failure was).
+     *
      * FAILS CLOSED on an AQI it cannot read. The guard is on the value's SHAPE - "is this a
      * non-empty string" - and deliberately not on truthiness or emptiness, because the
      * comparison below is a STRING comparison in which 'A' is the strongest grade
@@ -873,28 +1046,36 @@ class Validator
      * arrived at silently, and no amount of guarding the response side detects it.
      *
      * So the threshold is required to be one of self::VALID_QUALITY_INDEXES and anything
-     * else fails closed and is logged. Rejecting is the only safe answer: the whole point of
-     * the setting is to bar addresses, and a threshold nobody can read cannot be said to
-     * admit any of them.
+     * else fails closed and is logged - EVERY time, once per verdict, not once per run. That
+     * log line is the only signal a merchant has that their quality bar is broken, so it is
+     * emitted from here rather than hoisted anywhere a remembered verdict could skip it.
+     * Rejecting is the only safe answer: the whole point of the setting is to bar addresses,
+     * and a threshold nobody can read cannot be said to admit any of them.
      *
-     * Not reachable from the admin UI today - etc/config.xml:20 supplies the default and
-     * etc/adminhtml/system.xml exposes no field for it - but "unreachable" here rests on the
-     * absence of a form field, and the value is a plain core_config_data row that a data
-     * patch, a CLI config:set, or an admin field added later can put anything into. The
-     * guard costs one in_array() per verdict.
+     * REACHABLE FROM THE ADMIN UI SINCE LOQ-17148: etc/adminhtml/system.xml now exposes
+     * address_quality_index as a SELECT over Model\Config\Source\AddressQualityIndex, whose
+     * option values are derived from self::VALID_QUALITY_INDEXES - so nothing a merchant can
+     * choose in the form can reach the branch below. The guard is not thereby redundant, and
+     * this is why it was written before the field existed: the value is a plain
+     * core_config_data row, and a data patch, a CLI config:set, direct SQL or an env.php
+     * override can still put anything into it. The guard costs one in_array() per verdict.
      *
      * resolveQualityIndexThreshold() still returns the value RAW and uncast, so the batch
      * cache key keeps fingerprinting exactly what was compared; see its docblock.
      *
      * @param $qualityIndex The AQI from the response row, of any type - it is unvalidated
      *                      connector output, so this method must not assume a string.
-     * @return bool True only when the AQI is readable, the threshold is readable, AND the
-     *              AQI meets it.
+     * @return bool|null true when the AQI is readable, the threshold is readable and the AQI
+     *                   meets it; false when both are readable and it does not; null when
+     *                   either could not be read, which is a fault report and not a verdict.
+     *                   NOTE for callers: null is FALSY, so a bare truthiness test still
+     *                   rejects correctly - but it must never be stored or compared as a
+     *                   verdict. See rememberBatchVerdict().
      */
-    private function checkQualityIndex($qualityIndex): bool
+    private function checkQualityIndex($qualityIndex): ?bool
     {
         if (!is_string($qualityIndex) || $qualityIndex === '') {
-            return false;
+            return null;
         }
 
         $configIndex = $this->resolveQualityIndexThreshold();
@@ -908,7 +1089,7 @@ class Validator
                 implode(', ', self::VALID_QUALITY_INDEXES)
             ));
 
-            return false;
+            return null;
         }
 
         return $qualityIndex <= $configIndex;
@@ -1570,6 +1751,132 @@ class Validator
     }
 
     /**
+     * Remember one batch verdict - in BOTH memories, or in NEITHER (LOQ-17148).
+     *
+     * THE SINGLE GATE FOR "NEVER REMEMBER A VERDICT WE COULD NOT READ". It takes
+     * checkQualityIndex()'s three-state answer, not a bool, precisely so that the decision is
+     * made where the distinction still exists: null is an unreadable AQI or an unreadable
+     * threshold, which is a FAULT REPORT and not a verdict, so it is written nowhere and the
+     * identical address is billed again - within this run as well as in any later request. One
+     * connector fault, one "no match for this address" or one bad credential must not brand
+     * every matching row in an import file invalid for the rest of the run, reported to the
+     * merchant as rows to go and fix with nothing on the server saying otherwise.
+     *
+     * WHY THE RULE IS HERE AND NOWHERE ELSE. It used to be delegated to checkQualityIndex()
+     * failing closed plus storeBatchVerifyResult() storing no failures: true at the time, but
+     * true only as a SIDE EFFECT of failures never being remembered, so it stopped being true
+     * the moment one lifetime started remembering them. Stating it once, at the only place both
+     * memories are written, is what keeps the two lifetimes from drifting apart - and it is
+     * always the readability half that gets relaxed when they do. The call site holds no
+     * readability test, and neither does storeBatchVerifyResult(), which keeps its own
+     * PASSES-ONLY guard for its own separate reason (see its docblock).
+     *
+     * THE TWO POLARITIES ARE ASYMMETRIC BY DESIGN: a readable rejection is remembered for the
+     * RUN and never for the SESSION. self::BATCH_VERIFY_CACHE_LIMIT records the measurements
+     * behind that - caching failures in the session store is a regression on the target
+     * workload, and a rejection that outlived the request would strand a merchant who had
+     * corrected the file or loosened the threshold.
+     *
+     * @param string $signature Signature the verdict was earned under.
+     * @param bool|null $verdict checkQualityIndex()'s answer, passed through UNCOERCED.
+     * @return void
+     */
+    private function rememberBatchVerdict(string $signature, ?bool $verdict): void
+    {
+        if ($verdict === null) {
+            return;
+        }
+
+        $this->rememberRunScopedBatchVerdict($signature, $verdict);
+
+        // Passes only, and its own guard decides that - see storeBatchVerifyResult().
+        $this->storeBatchVerifyResult($signature, $verdict);
+    }
+
+    /**
+     * Read this RUN's verdict for the given address signature, of either polarity.
+     *
+     * @param string $signature
+     * @return bool|null The remembered verdict, or null when this run holds none - which is
+     *                   the same "ask Loqate" answer getCachedBatchVerifyResult() gives, so
+     *                   the two compose with a plain ?? at the call site.
+     */
+    private function getRunScopedBatchVerdict(string $signature): ?bool
+    {
+        $key = $this->buildBatchVerifyCacheKey($signature);
+        if ($key === '') {
+            // The '' sentinel: an address carrying nothing identifiable is kept out of every
+            // memory rather than sharing one with every other unidentifiable address.
+            return null;
+        }
+
+        $this->discardRunScopedVerdictsIfShopperChanged();
+
+        return $this->runScopedBatchVerdicts[$key] ?? null;
+    }
+
+    /**
+     * Remember one readable verdict for the rest of this run.
+     *
+     * Deliberately UNBOUNDED, unlike the session store. It holds one array entry per distinct
+     * address in one import file, it is never serialised and it dies with the request, so the
+     * cost is bounded by the file the merchant chose to import - whereas the session store is
+     * re-read and re-written on every subsequent request of the browser session, which is the
+     * whole reason THAT one has a limit (see self::BATCH_VERIFY_CACHE_LIMIT).
+     *
+     * @param string $signature
+     * @param bool $verdict Readable verdict of either polarity; nulls are stopped by
+     *                      rememberBatchVerdict(), which is the only caller.
+     * @return void
+     */
+    private function rememberRunScopedBatchVerdict(string $signature, bool $verdict): void
+    {
+        $key = $this->buildBatchVerifyCacheKey($signature);
+        if ($key === '') {
+            return;
+        }
+
+        $this->discardRunScopedVerdictsIfShopperChanged();
+
+        $this->runScopedBatchVerdicts[$key] = $verdict;
+    }
+
+    /**
+     * Discard this run's remembered verdicts if the shopper-scoped stores have been flushed
+     * since they were earned (LOQ-17148, LOQ-16978).
+     *
+     * The map is verdict data, so it has the OWNERSHIP lifetime of the session verdict stores
+     * and not merely the request's: one Validator can outlive a mid-request identity change,
+     * and a plain request-scoped map would then answer the new shopper out of the previous
+     * shopper's verdicts while the guard had just flushed the three stores beside it - reopening
+     * exactly the leak ShopperScopedAddressStores exists to close, through a store that class
+     * cannot see. Pinned by
+     * ShopperScopedAddressStoresTest::testABatchVerdictDoesNotSurviveALogin().
+     *
+     * ASKING IS WHAT ENFORCES IT. ShopperScopedAddressStores::ownershipGeneration() runs the
+     * ownership check itself and then reports the generation, so this is correct even on the
+     * import path, where $checkForCaptured is false and the run map is consulted before any
+     * session attribute is touched at all. Enrolling the map in the guard's own model, rather
+     * than comparing customer ids at this call site, is what keeps ONE definition of "the
+     * shopper changed" in the codebase.
+     *
+     * @return void
+     */
+    private function discardRunScopedVerdictsIfShopperChanged(): void
+    {
+        $generation = $this->shopperSession->ownershipGeneration();
+        if ($generation === $this->runScopedVerdictsGeneration) {
+            return;
+        }
+
+        // Either the first lookup of this instance (nothing to discard) or a genuine flush.
+        // Both are answered by starting from empty, which is why no special case is needed for
+        // the null the property starts out holding.
+        $this->runScopedBatchVerdicts = [];
+        $this->runScopedVerdictsGeneration = $generation;
+    }
+
+    /**
      * Read a previously stored batch verdict for the given address signature.
      *
      * Only ever returns true or null, because only passing verdicts are stored: null means
@@ -1621,21 +1928,30 @@ class Validator
      * Store a batch verdict against the given address signature - if, and only if, it
      * PASSED.
      *
-     * NEVER CACHING A FAILURE is load-bearing, not tidiness. Two things rest on it: an admin
-     * or an import can never be stranded on a replayed rejection, because there is none to
-     * replay; and the stored shape stays 'valid'-only, which is the second guard against
-     * this store and the single-address one being read for each other (see
-     * getCachedBatchVerifyResult()). The guard therefore lives HERE rather than at the call
-     * site, so a future caller cannot reintroduce cached failures by forgetting it.
+     * NEVER CACHING A FAILURE IN THE SESSION is load-bearing, not tidiness. Three things rest
+     * on it: an admin or an import can never be stranded on a replayed rejection in a LATER
+     * REQUEST, because there is none to replay; the stored shape stays 'valid'-only, which is
+     * the second guard against this store and the single-address one being read for each other
+     * (see getCachedBatchVerifyResult()); and the bounded FIFO store keeps spending its 200
+     * slots on the sparse PASSES, which is what makes it worth having at all on a default
+     * install where most rows fail. self::BATCH_VERIFY_CACHE_LIMIT carries the measurements,
+     * including why caching failures here would make a second run cost MORE. The guard
+     * therefore lives HERE rather than at the call site, so a future caller cannot reintroduce
+     * cached failures by forgetting it.
      *
-     * WHAT THIS GUARD RELIES ON, and where that half lives: "$valid === true" only means
-     * checkQualityIndex() said so, and this method cannot audit that - by the time it is
-     * called the response value is gone. It is safe because checkQualityIndex() itself now
-     * FAILS CLOSED on an AQI it cannot read (its opening shape guard): an unreadable value
-     * can no longer arrive here as a genuine-looking pass to be replayed all session. Do
-     * not relax that guard without adding a readability test at this method's call site -
-     * the positional attribution loop in verifyMultipleAddresses() - or unreadable
-     * responses start being cached as passes again.
+     * NOTE THE SCOPE OF THAT WORD "NEVER": it is about THIS store. A readable rejection IS
+     * remembered for the length of one import RUN, in self::$runScopedBatchVerdicts, which is
+     * what LOQ-17148 delivers and what this store structurally could not - see
+     * rememberBatchVerdict(), the one caller of this method.
+     *
+     * WHAT THIS GUARD NO LONGER RELIES ON, since the reasoning changed and the old note would
+     * now be actively misleading. It used to lean on checkQualityIndex() failing closed: an
+     * unreadable AQI became false, and a false was not cached, so unreadable answers were kept
+     * out of this store as a side effect. That delegation is gone. checkQualityIndex() now
+     * answers null for anything it could not read, and rememberBatchVerdict() drops a null
+     * before either memory is touched - so "no unreadable verdict is ever remembered" is now an
+     * explicit rule with one site, and this method's own guard means only what it says: this
+     * store holds passes.
      *
      * Bounding and eviction mirror storeVerifyResult() exactly - unset-then-append so a
      * refreshed entry does not cost an unrelated address its verdict, FIFO array_shift()
@@ -1739,6 +2055,14 @@ class Validator
      * reason: that method hashes buildVerifyCacheKey(), the AVC-namespaced key, which for
      * an address on this path names a cache entry that does not exist - the log line would
      * correlate with the wrong cache.
+     *
+     * ONE 'hit' TOKEN FOR BOTH MEMORIES (LOQ-17148). A verdict remembered for the run and one
+     * replayed from the session store are logged identically, and deliberately so: what this
+     * instrumentation is for is reconciling billed addresses against the invoice, misses map
+     * one-to-one onto billed addresses either way, and splitting the token would break every
+     * existing counter for a distinction no operator is counting. The two are still
+     * distinguishable where it matters - a run-scoped hit leaves no entry in the session store,
+     * which is what the tests read.
      *
      * The literal "family=strict" segment is a vestige of the single-address cache once
      * having had two key shapes. There is one signature builder now, so it distinguishes

--- a/Model/Config/Source/AddressQualityIndex.php
+++ b/Model/Config/Source/AddressQualityIndex.php
@@ -14,10 +14,11 @@ use Magento\Framework\Data\OptionSourceInterface;
  * configured threshold to be in - and only the LABELS live here. This class used to spell A-E
  * out itself, which was a second copy of that list, free to drift in either direction, and both
  * directions are merchant-facing defects:
- *  - a value offered here that the verifier does not accept makes checkQualityIndex() refuse to
- *    judge at all, so EVERY address is rejected. The merchant sets a quality bar, watches every
- *    import row come back "Invalid address at row #N", and finds nothing anywhere saying the
- *    value they just chose was the problem;
+ *  - a value offered here that the verifier does not accept makes Validator::
+ *    readableQualityIndexThreshold() refuse to judge at all, so EVERY address is rejected. The
+ *    merchant sets a quality bar and watches every import row come back "Invalid address at row
+ *    #N", with only a log line - which merchants do not read - saying the value they chose was
+ *    the problem;
  *  - a value the verifier accepts but this class does not offer is a threshold only a data
  *    patch, direct SQL or bin/magento config:set can select - which is the state the setting
  *    was in before LOQ-17148, when etc/adminhtml/system.xml exposed no field for it.
@@ -66,7 +67,12 @@ class AddressQualityIndex implements OptionSourceInterface
     }
 
     /**
-     * Get options in "key-value" format
+     * Get options as a LIST of single-entry [grade => label] maps.
+     *
+     * NOT a grade-keyed lookup, despite the name Magento's own source models give this method:
+     * the outer array is a 0..N-1 list, so toArray()[$grade] finds nothing. The shape is
+     * deliberately identical to the module's sibling sources (Model\Config\Source\*), because
+     * anything that iterates them iterates this one too; do not "fix" it here alone.
      *
      * @return array<int, array<string, \Magento\Framework\Phrase>>
      */

--- a/Model/Config/Source/AddressQualityIndex.php
+++ b/Model/Config/Source/AddressQualityIndex.php
@@ -2,42 +2,96 @@
 
 namespace Loqate\ApiIntegration\Model\Config\Source;
 
+use Loqate\ApiIntegration\Helper\Validator;
 use Magento\Framework\Data\OptionSourceInterface;
 
 /**
- * AddressQualityIndex class
+ * Option source for the "Minimum Address Quality Index" admin field
+ * (loqate_settings/address_settings/address_quality_index).
+ *
+ * WHY THE VALUES ARE DERIVED AND NOT WRITTEN OUT (LOQ-17148). The option VALUES come from
+ * Helper\Validator::VALID_QUALITY_INDEXES - the list Validator::checkQualityIndex() requires the
+ * configured threshold to be in - and only the LABELS live here. This class used to spell A-E
+ * out itself, which was a second copy of that list, free to drift in either direction, and both
+ * directions are merchant-facing defects:
+ *  - a value offered here that the verifier does not accept makes checkQualityIndex() refuse to
+ *    judge at all, so EVERY address is rejected. The merchant sets a quality bar, watches every
+ *    import row come back "Invalid address at row #N", and finds nothing anywhere saying the
+ *    value they just chose was the problem;
+ *  - a value the verifier accepts but this class does not offer is a threshold only a data
+ *    patch, direct SQL or bin/magento config:set can select - which is the state the setting
+ *    was in before LOQ-17148, when etc/adminhtml/system.xml exposed no field for it.
+ * Deriving one list from the other makes both impossible by construction rather than merely
+ * unlikely. Test\Unit\Model\Config\Source\AddressQualityIndexTest asserts the correspondence in
+ * both directions anyway, because "derived" is only true until somebody edits it.
+ *
+ * A SELECT, NOT A TEXT FIELD, for the same reason: checkQualityIndex() compares the threshold
+ * with <=, a STRING comparison, so free text sorting above 'E' ('zzz', a lowercase 'c', a 'C+')
+ * would pass EVERY address - a silent total bypass of the merchant's own quality bar - and text
+ * sorting below 'A' would reject every one. A select over this list cannot hold either.
  */
 class AddressQualityIndex implements OptionSourceInterface
 {
     /**
+     * Human label per quality index, in the Cleansing API's grade order (best to worst).
+     *
+     * The merchant chooses a quality bar, not a letter out of a response format, so the letters
+     * are never offered bare. Keyed by grade rather than listed in order because the ORDER and
+     * the SET both come from Validator::VALID_QUALITY_INDEXES; this is a lookup, not a
+     * second list. A grade added to that constant without a label here degrades to showing the
+     * grade itself (see optionLabel()), which keeps every accepted threshold selectable - the
+     * invariant that matters - and shows up as an unlabelled option rather than as a missing one.
+     */
+    private const LABELS = [
+        'A' => 'Excellent',
+        'B' => 'Good',
+        'C' => 'Average',
+        'D' => 'Poor',
+        'E' => 'Bad',
+    ];
+
+    /**
      * Options getter
      *
-     * @return array
+     * @return array<int, array{value: string, label: \Magento\Framework\Phrase}>
      */
     public function toOptionArray()
     {
-        return [
-            ['value' => 'A', 'label' => __('Excellent')],
-            ['value' => 'B', 'label' => __('Good')],
-            ['value' => 'C', 'label' => __('Average')],
-            ['value' => 'D', 'label' => __('Poor')],
-            ['value' => 'E', 'label' => __('Bad')],
-        ];
+        $options = [];
+        foreach (Validator::VALID_QUALITY_INDEXES as $qualityIndex) {
+            $options[] = ['value' => $qualityIndex, 'label' => $this->optionLabel($qualityIndex)];
+        }
+
+        return $options;
     }
 
     /**
      * Get options in "key-value" format
      *
-     * @return array
+     * @return array<int, array<string, \Magento\Framework\Phrase>>
      */
     public function toArray()
     {
-        return [
-            ['A' => __('Excellent')],
-            ['B' => __('Good')],
-            ['C' => __('Average')],
-            ['D' => __('Poor')],
-            ['E' => __('Bad')],
-        ];
+        $options = [];
+        foreach (Validator::VALID_QUALITY_INDEXES as $qualityIndex) {
+            $options[] = [$qualityIndex => $this->optionLabel($qualityIndex)];
+        }
+
+        return $options;
+    }
+
+    /**
+     * The label one quality index is offered under.
+     *
+     * Falls back to the grade itself for a grade with no label yet, so that adding a value to
+     * Validator::VALID_QUALITY_INDEXES can never make it UNSELECTABLE - an unlabelled option is
+     * a cosmetic defect, an unreachable threshold is the defect this class exists to prevent.
+     *
+     * @param string $qualityIndex One value of Validator::VALID_QUALITY_INDEXES.
+     * @return \Magento\Framework\Phrase
+     */
+    private function optionLabel(string $qualityIndex)
+    {
+        return __(self::LABELS[$qualityIndex] ?? $qualityIndex);
     }
 }

--- a/Test/Support/ProductionSerializerDouble.php
+++ b/Test/Support/ProductionSerializerDouble.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Support;
+
+use Magento\Framework\Serialize\SerializerInterface;
+
+/**
+ * The ONE SerializerInterface double for the whole suite, failing the way the PRODUCTION
+ * serializer fails.
+ *
+ * WHY IT IS SHARED RATHER THAN COPIED. Four harnesses drive code that reads a serialised
+ * session payload back, and the double each of them installs decides whether the recovery
+ * paths in that code are reachable at all. Written out per file, they drifted: two mirrored
+ * the production failure mode and two were the lenient `fn ($v) => json_decode($v, true)`,
+ * which silently makes every catch block unreachable from the harness that installs it. One
+ * definition, used everywhere, is what stops that happening again.
+ *
+ * WHAT "THE PRODUCTION SERIALIZER" IS. etc/di.xml leaves SerializerInterface at Magento's
+ * default, Magento\Framework\Serialize\Serializer\Json, whose unserialize() does NOT answer
+ * null on bad input. It has two distinct failure modes and this double reproduces BOTH, because
+ * the module's readers guard them separately:
+ *
+ *  1. \InvalidArgumentException, thrown for the values it rejects outright (false, null, the
+ *     empty string) and for anything json_decode() reports through json_last_error(). This is
+ *     what Helper\Validator::getCachedBatchVerifyResult(), ::getCachedVerifyResult() and
+ *     ::checkForCapturedAddress(), and Helper\Controller::capturedEntrySignature(), all wrap in
+ *     `try { ... } catch (\InvalidArgumentException $e)`. Against a lenient double NONE of those
+ *     catch blocks can ever run, so deleting one would leave the suite green while a truncated
+ *     or half-migrated session payload became a fatal in the middle of a checkout, an import or
+ *     an admin order save.
+ *
+ *  2. TypeError, raised when the argument is not a string at all: json_decode()'s first
+ *     parameter is declared `string $json`, so an array or object element raises an \Error,
+ *     which the \InvalidArgumentException catch does NOT cover. That one is answered by the
+ *     READERS' own is_string() guards, and this double must keep raising it or a reader that
+ *     lost its guard would look safe here while production fatalled. Hence no cast to string
+ *     below: the production serializer does not cast either.
+ *
+ * @see \Loqate\ApiIntegration\Test\Unit\Helper\CapturedAddressStoreTest
+ * @see \Loqate\ApiIntegration\Test\Unit\Helper\ValidatorBatchVerifyCacheTest
+ * @see \Loqate\ApiIntegration\Test\Unit\Helper\ValidatorImportRunDedupeTest
+ * @see \Loqate\ApiIntegration\Test\Unit\Helper\ShopperScopedAddressStoresTest
+ * @see \Loqate\ApiIntegration\Test\Unit\Plugin\Admin\ValidateImportAddressRowAttributionTest
+ */
+trait ProductionSerializerDouble
+{
+    /**
+     * A SerializerInterface mock behaving as Magento\Framework\Serialize\Serializer\Json does.
+     *
+     * @return SerializerInterface&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createSerializerDouble()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
+        $serializer->method('unserialize')->willReturnCallback(
+            static function ($value) {
+                // Magento\Framework\Serialize\Serializer\Json::unserialize(), verbatim in
+                // behaviour: the values it rejects outright first, then a decode whose failure
+                // is reported by json_last_error() rather than by a null return - null being a
+                // legitimately decodable value.
+                if ($value === false || $value === null || $value === '') {
+                    throw new \InvalidArgumentException('Unable to unserialize value.');
+                }
+
+                // NOT cast to string first - see failure mode 2 on this trait.
+                $decoded = json_decode($value, true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    throw new \InvalidArgumentException('Unable to unserialize value, string is corrupted.');
+                }
+
+                return $decoded;
+            }
+        );
+
+        return $serializer;
+    }
+}

--- a/Test/Unit/Helper/CapturedAddressStoreTest.php
+++ b/Test/Unit/Helper/CapturedAddressStoreTest.php
@@ -8,12 +8,12 @@ use Loqate\ApiIntegration\Helper\Data;
 use Loqate\ApiIntegration\Helper\ShopperScopedAddressStores;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
+use Loqate\ApiIntegration\Test\Support\ProductionSerializerDouble;
 use Magento\Customer\Model\Session;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Module\ModuleListInterface;
-use Magento\Framework\Serialize\SerializerInterface;
 use ArrayObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -102,6 +102,16 @@ use stdClass;
  */
 class CapturedAddressStoreTest extends TestCase
 {
+    /**
+     * The serializer double, shared with every other harness that reads a serialised payload
+     * back. What it buys THIS class specifically: the production serializer's
+     * \InvalidArgumentException is what makes
+     * testAnUnreadableEntryInTheStoreCostsADeDuplicationRatherThanAFatal() a real test, and its
+     * TypeError on a non-string is what makes
+     * testAForeignElementInTheStoreCostsABypassRatherThanAFatalInEitherReader() one.
+     */
+    use ProductionSerializerDouble;
+
     /** Any non-empty key lets both helpers build their API connectors. */
     private const API_KEY = 'TEST-API-KEY-0000';
 
@@ -295,60 +305,6 @@ class CapturedAddressStoreTest extends TestCase
             'requests' => $requests,
             'session' => $sessionStore,
         ];
-    }
-
-    /**
-     * A SerializerInterface double that fails the way the production serializer fails.
-     *
-     * The configured serializer for this module is Magento\Framework\Serialize\Serializer\Json,
-     * and its unserialize() THROWS \InvalidArgumentException on anything it cannot decode -
-     * including the empty string and null - rather than answering null. A double written as
-     * `fn ($v) => json_decode($v, true)` therefore makes the whole
-     * "an entry in the store cannot be read back" family of paths unreachable from the
-     * harness: Controller::capturedEntrySignature() and Validator::checkForCapturedAddress()
-     * both wrap the call in `try { ... } catch (\InvalidArgumentException $e)`, and against a
-     * lenient double those catch blocks can never run, so deleting either of them would leave
-     * the suite green while a truncated session payload became a fatal mid-checkout
-     * (LOQ-16978 review). Mirroring the real failure mode here is what makes
-     * testAnUnreadableEntryInTheStoreCostsADeDuplicationRatherThanAFatal() a real test.
-     *
-     * The SECOND failure mode it has to mirror is the TypeError, and that one is answered by
-     * the READER's is_string() guard: json_decode()'s first parameter is declared
-     * `string $json`, so an array or object element raises an \Error, which the
-     * \InvalidArgumentException catch above does NOT cover. A lenient double swallows that as
-     * well, and testAForeignElementInTheStoreCostsABypassRatherThanAFatalInEitherReader() would
-     * then pass against a build that fatals in front of a shopper. Hence the note below.
-     *
-     * @return SerializerInterface&MockObject
-     */
-    private function createSerializerDouble()
-    {
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
-        $serializer->method('unserialize')->willReturnCallback(
-            static function ($value) {
-                // Magento\Framework\Serialize\Serializer\Json::unserialize(), verbatim in
-                // behaviour: the two rejected-outright values first, then a decode whose
-                // failure is reported by json_last_error() rather than by a null return -
-                // null being a legitimately decodable value.
-                if ($value === false || $value === null || $value === '') {
-                    throw new \InvalidArgumentException('Unable to unserialize value.');
-                }
-
-                // NOT cast to string first, because the production serializer does not cast
-                // either: an array or an object reaching json_decode() is a TypeError there
-                // and must be one here, or this double would quietly make a caller that hands
-                // it a non-string look safe when production would fatal.
-                $decoded = json_decode($value, true);
-                if (json_last_error() !== JSON_ERROR_NONE) {
-                    throw new \InvalidArgumentException('Unable to unserialize value, string is corrupted.');
-                }
-
-                return $decoded;
-            }
-        );
-
-        return $serializer;
     }
 
     /**

--- a/Test/Unit/Helper/ShopperScopedAddressStoresTest.php
+++ b/Test/Unit/Helper/ShopperScopedAddressStoresTest.php
@@ -1151,6 +1151,78 @@ class ShopperScopedAddressStoresTest extends TestCase
     }
 
     /**
+     * The same identity change on the IMPORT shape of the call - verifyMultipleAddresses($batch,
+     * FALSE) - where NOTHING else in the request touches a shopper-scoped attribute first.
+     *
+     * NOT A DUPLICATE OF THE TEST ABOVE, and the difference is the whole point. That one passes
+     * $checkForCaptured at its default of true, so the captured-address read happens BEFORE any
+     * verdict is looked up, and that read runs the ownership check as a side effect. Every later
+     * lookup in the request therefore sees a generation taken AFTER the flush no matter how the
+     * generation is obtained - which means it cannot distinguish a guard that enforces ownership
+     * from one that merely reports a stale counter.
+     *
+     * Plugin\Admin\ValidateImportAddress::afterValidateData() passes FALSE. On that path the
+     * run-scoped verdict map is consulted before a single session attribute is read, so the
+     * ownership check has to happen INSIDE the generation lookup itself; if it does not, the
+     * first address of the request is answered out of the previous shopper's verdicts, and
+     * because a hit short-circuits before the session store is read, no attribute is touched and
+     * NO flush ever happens - the whole chunk is served from the old identity's memory.
+     *
+     * That is a licence to skip a billable verify being handed to a shopper who never earned it,
+     * which is precisely what ShopperScopedAddressStores exists to prevent, arriving through a
+     * store this class cannot see. Asserted here because the batch tests one layer up cannot see
+     * it either: the run map answers them identically either way.
+     */
+    public function testABatchVerdictDoesNotSurviveALoginOnTheImportPathThatReadsNoCapturedStore(): void
+    {
+        $shopper = $this->createShopper();
+        $batch = [0 => self::ADDRESS];
+
+        $first = $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            [0 => true],
+            $first,
+            'The address must pass on its own AQI first, or this test is measuring a rejection rather than a '
+            . 'remembered verdict.'
+        );
+        $this->assertSame(1, $this->apiCallCount($shopper), 'The first chunk must be billed.');
+
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'A repeated address must be remembered for the shopper who earned it, or the flush asserted '
+            . 'below is indistinguishable from a memory that never answers.'
+        );
+
+        $shopper['identity']['customerId'] = 7;
+        $afterLogin = $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'On the import shape of the call NOTHING touches a shopper-scoped attribute before the verdict '
+            . 'is looked up, so the identity change must be detected by the lookup itself. A generation '
+            . 'reported without enforcing ownership hands the new identity the previous one\'s verdict, and '
+            . 'the hit short-circuits before any session attribute is read - so the stores are never '
+            . 'flushed either, and the entire chunk is answered from the old shopper\'s memory.'
+        );
+        $this->assertSame([0 => true], $afterLogin, 'The re-verified chunk stands on its own verdict.');
+
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'And the new shopper\'s own verdicts must then be remembered as usual: a guard that discarded '
+            . 'the map on every lookup would re-bill every repeated row of every import, which is the '
+            . 'saving LOQ-17148 exists to deliver.'
+        );
+    }
+
+    /**
      * THE ACCEPTED LIMIT, pinned as documented behaviour rather than left implicit: on the
      * only path that writes the batch cache in production, the flush is a NO-OP.
      *

--- a/Test/Unit/Helper/ShopperScopedAddressStoresTest.php
+++ b/Test/Unit/Helper/ShopperScopedAddressStoresTest.php
@@ -8,6 +8,7 @@ use Loqate\ApiIntegration\Helper\Data;
 use Loqate\ApiIntegration\Helper\ShopperScopedAddressStores;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
+use Loqate\ApiIntegration\Test\Support\ProductionSerializerDouble;
 use Magento\Customer\Model\Session;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\App\RequestInterface;
@@ -106,6 +107,9 @@ use stdClass;
  */
 class ShopperScopedAddressStoresTest extends TestCase
 {
+    /** The serializer double, shared with every other harness that reads a payload back. */
+    use ProductionSerializerDouble;
+
     /** Any non-empty key lets both helpers build their API connectors. */
     private const API_KEY = 'TEST-API-KEY-0000';
 
@@ -1760,9 +1764,11 @@ class ShopperScopedAddressStoresTest extends TestCase
         );
         $helper->method('getCurrentStore')->willReturn(0);
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
-        $serializer->method('unserialize')->willReturnCallback(static fn ($value) => json_decode($value, true));
+        // Fails the way the PRODUCTION serializer fails - see the trait. It matters here because
+        // the flush this class exists to perform writes null over the three stores, and null is
+        // one of the values the production serializer REJECTS outright rather than decoding: a
+        // lenient double would let a reader that lost its guard look safe.
+        $serializer = $this->createSerializerDouble();
 
         $validator = new Validator(
             $this->createMock(Logger::class),

--- a/Test/Unit/Helper/ShopperScopedAddressStoresTest.php
+++ b/Test/Unit/Helper/ShopperScopedAddressStoresTest.php
@@ -70,7 +70,21 @@ use stdClass;
  *  - the ENROLMENT assertion: an attribute missing from the flush list is refused by both
  *    getData() and setData() rather than quietly reached through the guard without ever
  *    being flushed, see testAnUnenrolledAttributeIsRejectedByBothGetDataAndSetData() and
- *    its mirror testEveryEnrolledAttributeIsAcceptedByBothGetDataAndSetData().
+ *    its mirror testEveryEnrolledAttributeIsAcceptedByBothGetDataAndSetData();
+ *  - a session storage EMPTIED mid-request, which is the one door the owner marker cannot
+ *    hold shut, because the wipe takes the marker with the stores it describes - the
+ *    destroy() inside Magento\Customer\Model\Session::logout() and
+ *    Magento\Framework\Session\SessionManager::clearStorage() both do it. Three tests, and
+ *    all three are needed. The verdicts of the run in progress must not cross the wipe into
+ *    the identity that follows it, see
+ *    testAVerdictSurvivesNeitherTheStorageWipeNorTheIdentityChangeThatFollowsIt(); the price
+ *    of that - one re-bill when the identity did NOT change - is asserted deliberately in
+ *    testEmptyingTheStorageUnderOneIdentityRebillsWhatThatRunHadRemembered() rather than
+ *    left to be met later as a "regression"; and, in the opposite direction, an unmarked
+ *    session must still be able to report an UNCHANGED epoch twice running, see
+ *    testConsecutiveLookupsOnAnUnmarkedSessionReportOneUnchangedOwnershipEpoch(), because
+ *    "unchanged" is the answer that licenses a caller to keep derived data and a guard that
+ *    can never give it re-bills every repeated row of every import.
  *
  * The end of the chain - that the two helpers really do reach those attributes only through
  * this class - is asserted behaviourally for all three stores
@@ -1220,6 +1234,250 @@ class ShopperScopedAddressStoresTest extends TestCase
             . 'the map on every lookup would re-bill every repeated row of every import, which is the '
             . 'saving LOQ-17148 exists to deliver.'
         );
+    }
+
+    /**
+     * THE SAME HAND-OFF, arriving through the one door the owner marker cannot hold shut: a
+     * session storage EMPTIED between the two identities. A verdict earned by customer 7 must
+     * not be served to the guest that follows, even though the marker that would have proved
+     * the identity changed was erased in the same breath.
+     *
+     * WHY THIS IS REACHABLE, and not a thought experiment.
+     * Magento\Customer\Model\Session::logout() calls destroy(), whose default 'clear_storage'
+     * option is TRUE, so a logout empties EVERY attribute of the session storage - the three
+     * shopper-scoped stores and, sitting beside them, the ownership marker that names who they
+     * belonged to. Magento\Framework\Session\SessionManager::clearStorage() does the same for
+     * any other module that calls it. The next access therefore finds NO marker, which is the
+     * ADOPTION branch, not the flush branch: nothing is flushed, because the storage the flush
+     * would have cleared is already empty.
+     *
+     * WHY THAT IS NOT HARMLESS. It is harmless for the three SESSION stores - they went with
+     * the marker - but Validator::verifyMultipleAddresses() also remembers this run's batch
+     * verdicts in a plain map on the Validator INSTANCE, which the storage wipe does not
+     * touch. That map is a set of licences to skip a billable Cleansing call, so its lifetime
+     * has to be the ownership one; if the guard counts only FLUSHES, the wipe-then-change
+     * sequence moves no counter, the map is kept, and the guest is answered out of customer
+     * 7's verdicts. What that measures ON THE WIRE is one billable call where two are owed:
+     * one identity served a verdict another identity paid for, which is the hand-off
+     * LOQ-16978 exists to stop, reaching a store LOQ-16978's flush cannot see.
+     *
+     * WHY $checkForCaptured IS FALSE, and why the test is worthless without it. That is the
+     * import shape of the call (Plugin\Admin\ValidateImportAddress::afterValidateData() passes
+     * false), and on it NOTHING reads the captured-address store first. With the default true,
+     * that read runs the ownership check as a side effect and re-establishes ownership before
+     * a single verdict is looked up, so the run map is discarded for a reason that has nothing
+     * to do with what this test is about - and the assertion below would pass with the counter
+     * tied to flushes alone.
+     *
+     * THE FIRST TWO CALLS ARE THE PRECONDITION, not decoration: they prove the run map really
+     * does answer a repeat for the identity that earned it. Without that, "billed again after
+     * the wipe" is indistinguishable from a memory that never answers anything.
+     */
+    public function testAVerdictSurvivesNeitherTheStorageWipeNorTheIdentityChangeThatFollowsIt(): void
+    {
+        $shopper = $this->createShopper();
+        $batch = [0 => self::ADDRESS];
+
+        $shopper['identity']['customerId'] = 7;
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'Customer 7 must pay once and have the repeat answered from this run\'s memory, or everything '
+            . 'asserted below is measuring a memory that never answers rather than one that stops answering '
+            . 'across an identity change.'
+        );
+
+        // The logout: destroy() empties the storage - stores AND owner marker - and the
+        // identity becomes the guest.
+        $this->emptyTheSessionStorage($shopper);
+        $shopper['identity']['customerId'] = null;
+
+        $afterTheWipe = $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'The guest left at the browser after the wipe must be BILLED for this address rather than handed '
+            . 'the verdict customer 7 paid for. The wipe erased the owner marker along with the stores, so '
+            . 'the next access is an ADOPTION and flushes nothing - which means a guard that opened a new '
+            . 'ownership epoch only on a FLUSH reports an unmoved epoch here, the run-scoped verdict map is '
+            . 'kept, and the identity that follows is served out of the identity that preceded it. That is '
+            . 'the hand-off LOQ-16978 exists to stop, arriving through a store its flush cannot reach.'
+        );
+        $this->assertSame(
+            [0 => true],
+            $afterTheWipe,
+            'The re-verified address stands on its own freshly earned verdict.'
+        );
+
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'And from there the guest\'s OWN repeats must be free again: the epoch moved once, when ownership '
+            . 'was re-established, and not on every lookup - or every repeated row of every import is '
+            . 're-billed and the saving LOQ-17148 delivers is gone.'
+        );
+    }
+
+    /**
+     * THE PRICE OF THE RULE ABOVE, asserted deliberately rather than left to be discovered as a
+     * "regression": emptying the session storage under an UNCHANGED identity costs that identity
+     * one re-bill of everything the run had remembered.
+     *
+     * This is the case where the wipe is NOT accompanied by an identity change - a module
+     * calling Magento\Framework\Session\SessionManager::clearStorage() mid-request, say - and
+     * the run map is discarded anyway, because the marker that PROVED ownership was continuous
+     * went with it. The licence to skip a billable Cleansing call is only valid while ownership
+     * is demonstrably unbroken; after a wipe the guard cannot tell this from the logout in the
+     * test above, and the two are indistinguishable from inside the class by construction, so
+     * paying is the only safe reading. Correctness is not affected in either direction: the row
+     * is asked about again and answered on its own merits.
+     *
+     * PINNED SO IT CANNOT BE "FIXED" QUIETLY. The obvious way to make this one call cheaper is
+     * to stop opening a new epoch on adoption - and that is exactly the defect the test above
+     * exists to catch, so the two must be read together. The same price is already paid by the
+     * three session stores the wipe emptied; this only says the derived map pays it too.
+     */
+    public function testEmptyingTheStorageUnderOneIdentityRebillsWhatThatRunHadRemembered(): void
+    {
+        $shopper = $this->createShopper();
+        $batch = [0 => self::ADDRESS];
+
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($shopper),
+            'The repeat must be free while the storage is intact, or the extra call asserted below is not '
+            . 'the price of the wipe but the price of a memory that never worked.'
+        );
+
+        // No login, no logout: the same shopper throughout, with the storage emptied under them.
+        $this->emptyTheSessionStorage($shopper);
+
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'ACCEPTED COST, asserted so it cannot change unnoticed: a storage wipe re-bills the run\'s '
+            . 'remembered verdicts even when the identity did not change. The wipe erased the ownership '
+            . 'marker, so the guard can no longer show the stores have belonged to one identity throughout - '
+            . 'and a licence to skip a BILLABLE call is only valid while it can. Making this call free again '
+            . 'means not opening an epoch on adoption, which is precisely what lets a wipe followed by a '
+            . 'logout hand one identity\'s verdicts to the next: read this test with '
+            . 'testAVerdictSurvivesNeitherTheStorageWipeNorTheIdentityChangeThatFollowsIt().'
+        );
+
+        $shopper['validator']->verifyMultipleAddresses($batch, false);
+
+        $this->assertSame(
+            2,
+            $this->apiCallCount($shopper),
+            'And the cost is ONE re-bill, not a permanent one: ownership is re-established by the access '
+            . 'that noticed, so the run remembers again from there.'
+        );
+    }
+
+    /**
+     * The structural half of the epoch contract, and the one the billing tests above cannot
+     * see: with NO marker recorded and NO identity change, two consecutive lookups must report
+     * the SAME epoch.
+     *
+     * WHY THIS NEEDS ITS OWN TEST. "Open a new epoch on adoption" is satisfiable by simply
+     * bumping the counter whenever no marker is found - without RECORDING the identity that
+     * adopted. Every wipe test above still passes: the epoch moves after the wipe, so the run
+     * map is discarded and the address is billed. What such an implementation loses is the
+     * ability to ever say "unchanged" on a session that started life unmarked, because every
+     * subsequent lookup finds no marker and opens yet another epoch - so every derived memory
+     * is thrown away on every access, and every repeated row of every import is re-billed.
+     * That is the LOQ-17148 saving itself, and it is invisible to a test that only asks whether
+     * data is over-shared.
+     *
+     * ADOPTION MUST THEREFORE END OWNERSHIP BEING OPEN: the epoch is stable exactly because the
+     * adopting identity is written to the marker, which is what the second assertion pins.
+     * "Unchanged" is the strong statement in this contract - it is the answer that licenses a
+     * caller to KEEP derived data - so an implementation that can never make it is not a
+     * conservative one, it is one that has no contract left.
+     *
+     * The guest case is not academic: on the adminhtml import path, the only path that reads
+     * this epoch in anger, the customer session carries no customer id at all.
+     *
+     * @param int|string|null $customerId Identity at the browser for the whole test.
+     */
+    #[DataProvider('unmarkedSessionIdentityProvider')]
+    public function testConsecutiveLookupsOnAnUnmarkedSessionReportOneUnchangedOwnershipEpoch(
+        $customerId,
+        int $expectedOwner
+    ): void {
+        $harness = $this->createGuard($this->seededStores(), $customerId);
+
+        $first = $harness['guard']->ownershipGeneration();
+        $second = $harness['guard']->ownershipGeneration();
+
+        $this->assertSame(
+            $first,
+            $second,
+            'Two lookups in a row, with nothing whatever happening in between, must report the same '
+            . 'ownership epoch. A guard that opens a new epoch on every unmarked lookup can never report '
+            . '"unchanged", so every holder of derived data discards it on every access - which re-bills '
+            . 'every repeated row of every import while every over-sharing test in this file stays green.'
+        );
+        $this->assertSame(
+            $expectedOwner,
+            $harness['session'][$this->ownerKey()] ?? null,
+            'The adopting identity must be RECORDED, which is what makes the epoch above stable: an adoption '
+            . 'that opens an epoch without writing the marker leaves the session unmarked forever, so the '
+            . 'next lookup adopts all over again.'
+        );
+
+        $harness['guard']->getData(self::VERIFY_CACHE_SESSION_KEY);
+
+        $this->assertSame(
+            $first,
+            $harness['guard']->ownershipGeneration(),
+            'Reaching a store in between must not move the epoch either: for one identity with the marker '
+            . 'in place, every access is the same epoch, whichever method it arrives through.'
+        );
+    }
+
+    /**
+     * Both identities a session with no owner marker can be adopted by.
+     *
+     * @return array<string, array{0: int|string|null, 1: int}>
+     */
+    public static function unmarkedSessionIdentityProvider(): array
+    {
+        return [
+            // The adminhtml/import case: no customer id for the whole of the session.
+            'a guest' => [null, 0],
+            'a logged-in customer' => [7, 7],
+        ];
+    }
+
+    /**
+     * Empty the session storage the way Magento does, in place and behind the guard's back.
+     *
+     * Magento\Framework\Session\SessionManager::clearStorage() and the destroy() inside
+     * Magento\Customer\Model\Session::logout() (whose 'clear_storage' option defaults to true)
+     * both remove EVERY attribute, so the ownership marker goes with the stores it describes -
+     * which is the whole point of the tests that call this. Removing the keys rather than
+     * nulling them matters: a null marker is what the guard reads as "never marked", and
+     * writing one would model the wipe by hand instead of reproducing it.
+     *
+     * @param array $shopper Harness from createShopper().
+     */
+    private function emptyTheSessionStorage(array $shopper): void
+    {
+        foreach (array_keys($shopper['session']->getArrayCopy()) as $key) {
+            unset($shopper['session'][$key]);
+        }
     }
 
     /**

--- a/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
@@ -6,14 +6,15 @@ use Loqate\ApiConnector\Client\Verify;
 use Loqate\ApiIntegration\Helper\Data;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
+use Loqate\ApiIntegration\Test\Support\ProductionSerializerDouble;
 use Magento\Customer\Model\Session;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Module\ModuleListInterface;
-use Magento\Framework\Serialize\SerializerInterface;
 use ArrayObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use ReflectionProperty;
 
 /**
@@ -28,9 +29,9 @@ use ReflectionProperty;
  * values were all truthy, so the search always returned false, which coerces to the array
  * key 0: every response row overwrote $result[0], the captured addresses' own verdicts were
  * never merged in at all, and a mixed batch came back as a single entry. That matters to
- * two callers - Plugin\Admin\OrderSave.php:51-57 reports the key to the admin
+ * two callers - Plugin\Admin\OrderSave::aroundExecute() reports the key to the admin
  * ("The provided address is invalid: #billing_address"), and
- * Plugin\Admin\ValidateImportAddress.php:94 array_merge()s the per-chunk arrays and derives
+ * Plugin\Admin\ValidateImportAddress::afterValidateData() array_merge()s the per-chunk arrays and derives
  * the import row number from the merged $index + 1. The ORDER half is what the import
  * depends on: array_merge() renumbers integer keys BY INSERTION ORDER, not by key value, so
  * a chunk returned as [1, 3, 0, 2, 4] - precisely what filling cache hits during the first
@@ -69,6 +70,19 @@ use ReflectionProperty;
  * "simplify" those second requests back onto $this->validator: it makes the test measure the
  * other memory and every one of them would still be green.
  *
+ * WHICH REPLAY HALVES ARE NOW ANSWERED BY THE RUN MAP, listed so the next reader does not
+ * mistake them for session-store evidence. These five replay on $this->validator, so their
+ * second lookup is answered by the run-scoped map and not by the session store:
+ * testOnlyTheAddressesNotAlreadyVerifiedAreSentToTheApi(),
+ * testADuplicatedAddressInOneBatchIsAnsweredUnderBothKeys(),
+ * testAnUnverifiedCountyVariantIsNeverServedACachedBatchPass(),
+ * testChangingOnlyTheCountyCostsASecondBillableAddress() and
+ * testALegitimateQualityIndexStillPassesAndIsStillCached(). Every invariant they state still
+ * holds and is still worth holding - what the key does and does not conflate, what is billed,
+ * what is answered under which input key - because each of those is a property of the KEY or of
+ * the billing, which both memories share. What they are NOT is evidence about the session
+ * store's contents; where a test needs that, it reads the store or builds a second request.
+ *
  * THE KEY ITSELF IS THE SAME RULE AS THE SINGLE-ADDRESS ONE: an address shares a verdict
  * with another submission only when the two ask Loqate about the same address, the
  * region/county included, on the read as well as on the write. So a county variant nobody
@@ -84,7 +98,7 @@ use ReflectionProperty;
  *
  * POSITIONAL ATTRIBUTION is the precondition both tickets rest on, and it is the third thing
  * pinned here, because the connector makes it unverifiable per row:
- * Verify::verifyAddress() (vendor/lqt/api-connector/src/Client/Verify.php:50-52) ends in
+ * Verify::verifyAddress(), in the api-connector package, ends in
  * array_column($response, 'Matches'), which SILENTLY DROPS every record with no 'Matches' key
  * and REINDEXES the survivors into a clean 0..N-1 list. A three-address batch whose middle
  * record came back as an error envelope therefore arrives as a TWO-element list in which
@@ -100,8 +114,8 @@ use ReflectionProperty;
  *    partly reported, see testATruncatedResponseIsRejectedRatherThanReportingTheRowsItHolds().
  *
  * READABLE VERDICTS is the fourth property pinned here, on the AQI side of the same method.
- * checkQualityIndex() (Helper/Validator.php:841-843) FAILS CLOSED on an AQI it cannot read,
- * mirroring verifyAddress()'s AVC guard (Helper/Validator.php:377). Under PHP 8's <= rules null,
+ * checkQualityIndex() FAILS CLOSED on an AQI it cannot read, mirroring the unreadable-AVC guard
+ * in verifyAddress(). Under PHP 8's <= rules null,
  * '', false and 0 all compare as BETTER than any letter threshold, so an unreadable AQI used to
  * be answered VALID - including Loqate's own "no match for this address" ("Matches":[]), which
  * the row-count guard above cannot see, because array_column() preserves the row count for it.
@@ -120,6 +134,15 @@ use ReflectionProperty;
  */
 class ValidatorBatchVerifyCacheTest extends TestCase
 {
+    /**
+     * The serializer double, shared with every other harness that reads a serialised payload
+     * back. What it buys THIS class: the production serializer's \InvalidArgumentException is
+     * what makes testAnUnreadableBatchCacheDegradesToOneExtraBilledAddress() and
+     * testRefreshingAnEntryWhileTheCacheIsFullEvictsNoUnrelatedVerdict() - both of which plant
+     * an undecodable payload and claim the read must "not throw" - claims that can be false.
+     */
+    use ProductionSerializerDouble;
+
     /** Any non-empty key makes the batch path reach the billable call. */
     private const API_KEY = 'TEST-API-KEY-0000';
 
@@ -342,9 +365,18 @@ class ValidatorBatchVerifyCacheTest extends TestCase
                     return self::API_KEY;
                 }
 
-                // Anything not explicitly configured reads as empty, which is what the
-                // admin form leaves behind for an untouched field.
-                return $configStore[$configPath] ?? '';
+                // offsetExists(), NOT '??'. A '??' reader cannot deliver a CONFIGURED null: it
+                // sees the null and substitutes '', so the "an unset threshold" case of
+                // unreadableThresholdProvider() silently became the "a blank threshold" case -
+                // two data sets running one fixture, while the justification on each described
+                // a comparison the test never performed. null and '' are genuinely different
+                // inputs here (buildBatchVerifyCacheKey() fingerprints gettype(), and
+                // 'A' <= null and 'A' <= '' are different comparisons), so the harness must be
+                // able to express both. Mirrors ValidatorImportRunDedupeTest::createRequest().
+                //
+                // A path the store does not hold still reads as '', which is what an untouched
+                // admin field leaves behind.
+                return $configStore->offsetExists($configPath) ? $configStore[$configPath] : '';
             }
         );
         // Verdicts are namespaced per STORE VIEW, because the AQI threshold behind them is
@@ -473,11 +505,21 @@ class ValidatorBatchVerifyCacheTest extends TestCase
     /**
      * The half of the mapping that is easiest to lose silently: a FAILING verdict.
      *
-     * false is what every caller acts on, and the result array is filtered on the way out
-     * (rows Loqate did not answer are dropped), so a filter written as array_filter($result)
-     * would discard exactly the verdicts that matter and report a batch of invalid addresses
-     * as entirely clean. Asserted with the failure in the LAST position of a mixed batch,
-     * which is where the pre-fix single-slot bug hid it.
+     * false is what every caller acts on, and every verdict array leaves
+     * verifyMultipleAddresses() through one terminal pass over the whole result - so a pass
+     * written as array_filter($result) would discard exactly the verdicts that matter and
+     * report a batch of invalid addresses as entirely clean. Asserted with the failure in the
+     * LAST position of a mixed batch, which is where the pre-fix single-slot bug hid it.
+     *
+     * THE FILTER THIS TEST IS NAMED AFTER NO LONGER EXISTS, and the correction matters to
+     * anyone reading the name. That terminal pass used to be array_filter($result, fn ($v) =>
+     * $v !== null), which DROPPED rows Loqate did not answer; it is now sealBatchVerdicts(),
+     * which keeps every slot and coerces it with '=== true', so an unanswered row reports
+     * INVALID instead of vanishing. The name is kept because the guarantee it pins - a false
+     * survives the terminal pass under its own key - is unchanged and is the one that matters
+     * to Plugin\Admin\OrderSave. What CHANGED is the direction the terminal pass fails in, and
+     * that is pinned separately by
+     * testAnUnfilledVerdictSlotSurvivesTheTerminalSealAsFalseRatherThanBeingDropped().
      */
     public function testAFailingVerdictSurvivesTheResultFilterUnderItsOwnKey(): void
     {
@@ -501,6 +543,162 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             $result,
             'The failing address must keep its own key, or the admin is told the wrong address is invalid.'
         );
+    }
+
+    /**
+     * THE TERMINAL SEAL FAILS CLOSED: a slot nobody filled leaves verifyMultipleAddresses() as
+     * the key it came in under, carrying false - it is NOT dropped.
+     *
+     * WHY THE DIRECTION IS LOAD-BEARING, and it is the whole of this test. The terminal pass
+     * used to be array_filter($result, fn ($v) => $v !== null), justified on the grounds that a
+     * dropped slot degrades to a MISSING KEY "which callers already read as nothing to report".
+     * That is true of Plugin\Admin\ValidateImportAddress::afterValidateData(), which reports
+     * only the keys it receives. It is the exact opposite of true for
+     * Plugin\Admin\OrderSave::aroundExecute(), whose loop raises its error only for keys that
+     * are PRESENT: a dropped 'billing_address' puts that address on the order UNVERIFIED and
+     * SILENTLY, which is the one outcome the whole verification exists to prevent. Coercing
+     * keeps the slot and reports INVALID, so the two callers fail the same way and both fail
+     * safe.
+     *
+     * ASSERTED THROUGH THE PRIVATE METHOD, deliberately, and this is the one place in this file
+     * that does so. No input can produce an unfilled slot today - every reserved slot is
+     * captured, decided by the pre-flight threshold guard, answered from a memory, or sent and
+     * therefore answered - which is precisely why the guarantee needs pinning HERE: it exists to
+     * contain the edit that changes that, so there is no behavioural route to it until the day
+     * the bug it guards against is written, at which point a test that could only reach it
+     * behaviourally would already be too late. The routing half - that both of the method's
+     * exits really do go through this seal - has no behavioural signature either, for the two
+     * reasons set out on testBothVerdictExitsReturnThroughTheTerminalSeal(), which is where it
+     * is pinned.
+     */
+    public function testAnUnfilledVerdictSlotSurvivesTheTerminalSealAsFalseRatherThanBeingDropped(): void
+    {
+        $seal = new ReflectionMethod(Validator::class, 'sealBatchVerdicts');
+        $seal->setAccessible(true);
+
+        // OrderSave's own key shape, with the unfilled slot between two answered ones so a drop
+        // is visible as a lost key AND as a re-ordering.
+        $sealed = $seal->invoke($this->validator, [
+            'shipping_address' => true,
+            'billing_address' => null,
+            2 => false,
+        ]);
+
+        $this->assertSame(
+            ['shipping_address', 'billing_address', 2],
+            array_keys($sealed),
+            'EVERY key must survive the terminal pass, in order. Plugin\Admin\OrderSave::aroundExecute() '
+            . 'raises its error only for keys that are PRESENT, so a dropped key is an address accepted '
+            . 'onto an order with no verification and no message; and '
+            . 'Plugin\Admin\ValidateImportAddress::afterValidateData() array_merge()s the per-chunk '
+            . 'results, which renumbers by INSERTION order, so a dropped key shifts every import row '
+            . 'number after it.'
+        );
+        $this->assertSame(
+            ['shipping_address' => true, 'billing_address' => false, 2 => false],
+            $sealed,
+            'An unfilled slot must report INVALID. This is the fail-closed correction of the '
+            . 'array_filter() that used to sit here: filtering answered "nothing to report" for a row '
+            . 'nobody had judged, which is the fail-OPEN direction on the admin order path.'
+        );
+    }
+
+    /**
+     * ...and BOTH exits of verifyMultipleAddresses() must go through that seal, so one future
+     * edit cannot produce two different behaviours depending on cache state.
+     *
+     * The all-hit exit used to return $result RAW while the post-response exit was coerced, so
+     * whatever guarantee the terminal pass made - dropping unfilled slots then, coercing them
+     * now - simply did not apply to a batch that happened to be fully cached, and which
+     * behaviour a batch got depended on nothing more than whether its addresses had been asked
+     * about before.
+     *
+     * THIS IS THE ONE TEST IN THE SUITE THAT READS PRODUCTION SOURCE, and the justification has
+     * to be exact, because the technique is otherwise a bad one. THERE IS NO BEHAVIOURAL ROUTE
+     * TO THIS PROPERTY. Two independent facts close every one of them, and both were established
+     * by execution rather than by reading:
+     *
+     *  - NO SLOT CAN BE UNFILLED. Every branch of the pre-flight loop either fills its slot
+     *    (captured, threshold-refused, answered from a memory) or appends to $requestArray, and
+     *    a request is issued unless $requestArray is empty; a response of a different length
+     *    returns false before the attribution loop. So sealing or not sealing makes no
+     *    difference to any reachable input.
+     *  - NO NON-BOOLEAN CAN REACH A SLOT EITHER, which is what defeats the obvious trick of
+     *    writing a non-boolean into the run map by reflection and watching whether it survives.
+     *    It cannot: getRunScopedBatchVerdict() and getCachedBatchVerifyResult() are both
+     *    declared ': ?bool', this file is not under strict_types, and PHP therefore coerces the
+     *    return on the way out - an injected int 1 arrives at the call site as true. That was
+     *    tried, it produced a test that passed identically with the seal removed, and it is
+     *    recorded here so it is not tried again.
+     *
+     * So the guarantee is a CONTAINMENT one with no observable signature, and the code is the
+     * only artefact that can carry it. Asserted on the method's own tokens with comments
+     * stripped, so the prose about the old raw return in the production comments cannot satisfy
+     * or break it.
+     *
+     * IF THIS FAILS BECAUSE YOU ADDED AN EXIT: seal it. The count is asserted, not merely the
+     * absence of a raw return, so a new exit has to be looked at rather than absorbed.
+     */
+    public function testBothVerdictExitsReturnThroughTheTerminalSeal(): void
+    {
+        $code = self::verifyMultipleAddressesCode();
+
+        $this->assertSame(
+            0,
+            preg_match_all('/\breturn\s+\$result\s*;/', $code),
+            'verifyMultipleAddresses() must not return its verdict array RAW from any exit. The all-hit '
+            . 'exit did exactly that while the post-response exit was coerced, so the terminal guarantee '
+            . 'held on one exit and not the other and one edit would have produced two different wrong '
+            . 'behaviours depending on cache state. See this test\'s docblock for why the property has no '
+            . 'behavioural signature and is asserted on the source.'
+        );
+        $this->assertSame(
+            2,
+            preg_match_all('/\breturn\s+\$this->sealBatchVerdicts\(\$result\)\s*;/', $code),
+            'verifyMultipleAddresses() must have exactly TWO verdict-array exits and both must be sealed: '
+            . 'the all-hit short-circuit (every address captured, refused by the pre-flight threshold guard '
+            . 'or answered from a memory) and the post-response one. A third would be a new way for a '
+            . 'result array to leave this method, and it needs the same fail-closed pass rather than this '
+            . 'assertion being raised to 3 to make the suite green.'
+        );
+    }
+
+    /**
+     * The source of Validator::verifyMultipleAddresses(), comments stripped.
+     *
+     * Comments MUST go: the production comments beside both exits discuss the raw return that
+     * used to be there, so a check run over the raw text would match the prose describing the
+     * defect instead of the code, and would keep matching after the defect was fixed. Tokenising
+     * is what makes the assertion about code; the whitespace is left as it is, and the patterns
+     * above allow for it.
+     *
+     * @return string
+     */
+    private static function verifyMultipleAddressesCode(): string
+    {
+        $method = new ReflectionMethod(Validator::class, 'verifyMultipleAddresses');
+        $lines = explode("\n", (string)file_get_contents((string)$method->getFileName()));
+        $body = implode("\n", array_slice(
+            $lines,
+            $method->getStartLine() - 1,
+            $method->getEndLine() - $method->getStartLine() + 1
+        ));
+
+        $code = '';
+        foreach (token_get_all('<?php ' . $body) as $token) {
+            if (!is_array($token)) {
+                $code .= $token;
+                continue;
+            }
+
+            if ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT) {
+                continue;
+            }
+
+            $code .= $token[1];
+        }
+
+        return $code;
     }
 
     /**
@@ -531,7 +729,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
     /**
      * THE return-ORDER regression, and the property the customer import actually depends on.
      *
-     * Plugin\Admin\ValidateImportAddress.php:94 array_merge()s the per-chunk result arrays
+     * Plugin\Admin\ValidateImportAddress::afterValidateData() array_merge()s the per-chunk result arrays
      * and reports ($index + 1) of the MERGED array as the import row number. array_merge()
      * renumbers integer keys BY INSERTION ORDER, not by key value, so a chunk that came back
      * as [1, 3, 0, 2, 4] - which is exactly what filling cache hits during the first pass
@@ -592,7 +790,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             'Each merged position must still carry the verdict of the row that occupied it.'
         );
 
-        // The arithmetic ValidateImportAddress.php:107-117 performs on that merged array.
+        // The arithmetic ValidateImportAddress::afterValidateData() performs on that merged array.
         $reportedRows = [];
         foreach ($merged as $index => $validAddress) {
             if (!$validAddress) {
@@ -959,16 +1157,16 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * envelope) into a row nothing can be read out of, and Loqate's own "no match for this
      * address" arrives the same way, as "Matches":[]. Reporting either as "valid" is the
      * maximally wrong answer, so checkQualityIndex()'s shape guard
-     * (Helper/Validator.php:841-843) rejects it, exactly as verifyAddress() already rejected an
-     * unreadable AVC (Helper/Validator.php:377): both verify paths now draw the "readable
+     * in checkQualityIndex() rejects it, exactly as verifyAddress() already rejected an
+     * unreadable AVC: both verify paths now draw the "readable
      * verdict" line in the same place. A TOP-LEVEL error envelope is NOT in this class - it makes
      * HttpClient::searchForError() throw, Verify::verifyAddress() catches it into
-     * ['error' => true, ...], and the branch at Helper/Validator.php:616-623 answers it instead.
+     * ['error' => true, ...], and verifyMultipleAddresses()' transport-failure branch answers it instead.
      *
      * EVERY shape asserted here survives the connector's array_column($response, 'Matches') with
      * the ROW COUNT PRESERVED (see self::UNREADABLE_ROW_SHAPES), so the row-count guard
-     * (Helper/Validator.php:643-651) catches none of them and they all reach the attribution loop
-     * (Helper/Validator.php:703-711) as an AQI of null. This guard is the only thing between them
+     * in verifyMultipleAddresses() catches none of them and they all reach that method's
+     * attribution loop as an AQI of null. This guard is the only thing between them
      * and a PASS. That includes "Matches":null, which was missing from this taxonomy until the
      * guard was written and is a survivor of array_column() just like [] is (verified on 8.3).
      *
@@ -994,7 +1192,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         // reach the attribution loop, because the connector's array_column($response, 'Matches')
         // keeps a record whose 'Matches' is [] or null instead of dropping it. Were that not so,
         // the row count would differ and this test would silently be exercising the count guard
-        // (Helper/Validator.php:643-651) rather than the AQI shape guard it is written for.
+        // in verifyMultipleAddresses() rather than the AQI shape guard it is written for.
         $this->assertSame(
             [self::UNREADABLE_ROW_SHAPES[$token]],
             array_column([['Matches' => self::UNREADABLE_ROW_SHAPES[$token]]], 'Matches'),
@@ -1010,7 +1208,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             'An AQI the module could not read is NOT a verdict, so it must fail CLOSED. Answering true - '
             . 'which is what null <= any letter threshold used to produce - let ONE malformed or '
             . 'match-less response row PASS an address: admin order create went straight through '
-            . '(Plugin\Admin\OrderSave.php:50-58 sees true and raises no error) and the import row was '
+            . '(Plugin\Admin\OrderSave::aroundExecute() sees true and raises no error) and the import row was '
             . 'accepted unverified. For the "Matches":[] shape that meant reporting Loqate\'s own "no '
             . 'match for this address" as VALID.'
         );
@@ -1220,14 +1418,29 @@ class ValidatorBatchVerifyCacheTest extends TestCase
 
     /**
      * The bound must be a bound, not a cliff: every one of the BATCH_VERIFY_CACHE_LIMIT
-     * verdicts the cache claims to hold has to be genuinely replayable.
+     * verdicts the SESSION STORE claims to hold has to be genuinely replayable on a LATER
+     * REQUEST.
      *
-     * Asserted by filling the cache to exactly the limit and then re-submitting the whole
-     * batch with no further BILLED ADDRESS, which is what distinguishes a real FIFO cache of
-     * LIMIT entries from one that keeps only the newest verdict (or one whose effective limit
-     * is far smaller than advertised) - both of which satisfy a bare "count <= limit"
-     * assertion. It also pins the property the limit was chosen for: two full import chunks
-     * of 100 rows must fit at once, or a re-run import re-bills rows the cache had room for.
+     * Asserted by filling the store to exactly the limit and then re-submitting the whole batch
+     * with no further BILLED ADDRESS, which is what distinguishes a real FIFO store of LIMIT
+     * entries from one that keeps only the newest verdict (or one whose effective limit is far
+     * smaller than advertised) - both of which satisfy a bare "count <= limit" assertion. It
+     * also pins the property the limit was chosen for: two full import chunks of 100 rows must
+     * fit at once, or a RE-RUN IMPORT re-bills rows the store had room for.
+     *
+     * THE REPLAY IS A SECOND REQUEST, AND ONLY A SECOND REQUEST CAN MAKE THIS CLAIM. Every
+     * assertion here is about what the session store retained, and since LOQ-17148 the run map
+     * answers first - so a replay on $this->validator is answered out of the map, which is
+     * unbounded and holds all LIMIT verdicts whatever the store did with them. This test was
+     * left on $this->validator when its six siblings were moved, and the proof of what that
+     * cost is a one-line mutation: make getCachedBatchVerifyResult() `return null;`
+     * unconditionally - deleting the session store's every answer - and the pre-repair version
+     * still passed. A re-run import is by definition a later request in the same browser
+     * session, so this fixture is also the one the docblock above always claimed to describe.
+     *
+     * The order the second request asks in is deliberate: the whole batch first, then every
+     * address individually OLDEST FIRST, because the oldest entries are the ones a store that
+     * silently evicted below its bound has lost.
      */
     public function testEveryVerdictUpToTheBatchCacheLimitIsRetainedAndReplayable(): void
     {
@@ -1247,22 +1460,35 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $this->assertCount(
             $limit,
             $this->batchStore($this->shopper),
-            'A cache bounded to ' . $limit . ' entries must actually be able to hold ' . $limit . ' verdicts.'
+            'A store bounded to ' . $limit . ' entries must actually be able to hold ' . $limit . ' verdicts.'
         );
 
-        // Re-submit the whole batch, and then every address individually, oldest first.
-        $replayed = $this->validator->verifyMultipleAddresses($batch, false);
+        // The re-run: a fresh Validator over the same session double, so nothing but the
+        // session store can answer it. Re-submit the whole batch, then every address
+        // individually, oldest first.
+        $rerun = $this->createShopper($this->sessionStore);
+        $replayed = $rerun['validator']->verifyMultipleAddresses($batch, false);
         for ($i = 1; $i <= $limit; $i++) {
-            $this->validator->verifyMultipleAddresses([$this->distinctAddress($i)], false);
+            $rerun['validator']->verifyMultipleAddresses([$this->distinctAddress($i)], false);
         }
 
         $this->assertSame(
+            0,
+            $this->addressesBilledBy($rerun),
+            'Every verdict up to the limit must have survived in the SESSION STORE: a re-run import must '
+            . 'replay all ' . $limit . ' addresses without one further billed address. Measured on the '
+            . 'RE-RUN\'s own connector, because that is the only invoice the session store decides.'
+        );
+        $this->assertSame(
+            0,
+            $this->shopperCallCount($rerun),
+            'And not a single request either: an all-hit batch must not reach the billable endpoint at all.'
+        );
+        $this->assertSame(
             $limit,
             $this->addressesBilled(),
-            'Every verdict up to the limit must still be cached: replaying all ' . $limit
-            . ' addresses must not cost a single further billed address.'
+            'The first request\'s invoice must be unchanged - ' . $limit . ' addresses, billed once.'
         );
-        $this->assertSame(1, $this->apiCallCount(), 'And not a single further request either.');
         $this->assertSame(
             array_fill(0, $limit, true),
             array_values($replayed),
@@ -1270,8 +1496,8 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         );
         $this->assertCount(
             $limit,
-            $this->batchStore($this->shopper),
-            'Replaying cached verdicts must not grow the cache.'
+            $this->batchStore($rerun),
+            'Replaying cached verdicts must not grow the store past its bound.'
         );
     }
 
@@ -1281,9 +1507,15 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * merchant tightens or loosens that threshold, verdicts computed under the old one must
      * not be replayed.
      *
-     * The threshold is showInStore="1" and read at SCOPE_STORE, so the store view has to be
-     * part of the namespace too - one session can span store views (?___store=, a language
-     * switcher) - and that half is asserted here as well.
+     * The store view is part of the namespace too, and that half is asserted here as well -
+     * but for the reason etc/adminhtml/system.xml gives, which is NOT the one an earlier
+     * revision of this docblock gave. The field ships showInDefault="1" showInWebsite="0"
+     * showInStore="0", so a merchant CANNOT set it per store view; the namespace is there
+     * because Helper\Data::getConfigValue() is a SCOPE_STORE read with no store named, and one
+     * browser session can span store views (?___store=, a language switcher), so the value the
+     * verdict was judged under is whatever store the request resolved as current. The key
+     * accommodates a per-view threshold if the field is ever widened; it does not claim one
+     * exists today.
      */
     public function testChangingTheQualityIndexThresholdInvalidatesCachedVerdicts(): void
     {
@@ -1327,6 +1559,65 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             'The fingerprint must be 12 hex characters: hex so it can never contain the "|" the signature '
             . 'parts are joined with, and truncated so the session payload does not carry 64 characters '
             . 'per entry.'
+        );
+    }
+
+    /**
+     * The threshold fingerprint is taken over the value's TYPE as well as its text, so null, the
+     * empty string, the INT 0 and the STRING '0' get four different namespaces.
+     *
+     * WHAT WOULD COLLIDE WITHOUT THE TYPE. buildBatchVerifyCacheKey() hashes
+     * gettype($threshold) . ':' . $threshold. Drop the gettype() and the four values collapse
+     * into two: null and '' both stringify to '', and the int 0 and the string '0' both
+     * stringify to '0'. Those are not academic pairs - they are exactly the pairs
+     * resolveQualityIndexThreshold()'s docblock refuses to cast between, because 0 <= null is
+     * TRUE (numeric comparison) while 0 <= '' is FALSE (string comparison), so two thresholds
+     * sharing a namespace would replay each other's verdicts while disagreeing about them.
+     *
+     * ASSERTED THROUGH THE KEY BUILDER, and the reason is worth recording because it is a change
+     * in what this fingerprint is FOR. None of these four values can produce a cache key
+     * behaviourally any more: every one of them is unreadable, and since LOQ-17148's pre-flight
+     * guard an unreadable threshold returns before the memories are consulted or written, so
+     * there is no entry, no log line and no lookup to observe. The type segment is therefore no
+     * longer load-bearing for any reachable configuration - it is what stops the collision
+     * coming back if the pre-flight guard is ever narrowed, moved or removed, which is precisely
+     * when nobody would think to re-derive this. Pinning it at the builder is the only way to
+     * hold it at all.
+     */
+    public function testTheThresholdFingerprintTellsTheseFourApart(): void
+    {
+        $signature = 'ONE ADDRESS|SIGNATURE';
+        $builder = new ReflectionMethod(Validator::class, 'buildBatchVerifyCacheKey');
+        $builder->setAccessible(true);
+
+        $keys = [];
+        foreach (['null' => null, 'blank' => '', 'int zero' => 0, 'string zero' => '0'] as $label => $value) {
+            $shopper = $this->createShopper(
+                null,
+                0,
+                new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => $value]))
+            );
+
+            $keys[$label] = (string)$builder->invoke($shopper['validator'], $signature);
+        }
+
+        $fingerprints = array_map(static fn (string $key): string => self::fingerprintSegment($key), $keys);
+
+        $this->assertSame(
+            $fingerprints,
+            array_unique($fingerprints),
+            'Four thresholds of three different types must produce four different namespaces. Hashing the '
+            . 'text alone makes null indistinguishable from "" and the int 0 indistinguishable from the '
+            . 'string "0" - the very pairs PHP compares by DIFFERENT rules - so a merchant moving between '
+            . 'two of them would be served verdicts earned under a threshold that answers differently. '
+            . 'Fingerprints: ' . json_encode($fingerprints)
+        );
+        $this->assertSame(
+            array_fill_keys(array_keys($keys), $signature),
+            array_map(static fn (string $key): string => self::signatureSegment($key), $keys),
+            'And the threshold must NAMESPACE the key rather than leak into the address signature: one '
+            . 'address must project to one signature under every threshold, or the fingerprint above is '
+            . 'not what is telling them apart.'
         );
     }
 
@@ -1482,7 +1773,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * branch can be broken - deleting it, and demoting it below the row-count guard - are each
      * INVISIBLE to one of them. The connector reports a transport failure as
      * ['error' => true, 'message' => ...], a TWO-ELEMENT array, so its element count collides
-     * with the address count of precisely the batch Plugin\Admin\OrderSave.php:29-36 sends:
+     * with the address count of precisely the batch Plugin\Admin\OrderSave::aroundExecute() sends:
      * billing plus shipping, TWO addresses.
      *  - TWO addresses pins that the branch EXISTS. count($response) === 2 === count($sentItems),
      *    so the row-count guard does NOT fire and cannot stand in for the branch. Delete the
@@ -1802,6 +2093,12 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * LOQ-17015, "the same address repeated within one batch is billed once per occurrence"; the
      * assertion below is what will have to change when it is done, so the current cost is visible
      * rather than rediscovered from an invoice.
+     *
+     * TWO COPIES IS THE CASE THIS TEST RUNS, AND ONLY TWO. Generalising from it is what produced
+     * a published - and false - bound of "one duplicate charge per distinct address per run".
+     * Three copies, and the free later chunk, are measured in
+     * Test\Unit\Helper\ValidatorImportRunDedupeTest::
+     * testEveryCopyInTheChunkAnAddressFirstAppearsInIsBilledAndEveryLaterChunkIsFree().
      */
     public function testADuplicatedAddressInOneBatchIsAnsweredUnderBothKeys(): void
     {
@@ -2080,7 +2377,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * An AQI that is PRESENT but not readable as a quality index FAILS CLOSED and is never
      * cached - the second route into the same guard.
      *
-     * The guard is a READABILITY test - is this a non-empty string (Helper/Validator.php:841-843)
+     * The guard is a READABILITY test - is this a non-empty string (checkQualityIndex())
      * - and deliberately not a null check, and that difference is the whole point of this test:
      * under PHP 8's <= rules '' <= 'A', false <= 'A' and 0 <= 'A' are ALL true, so every value
      * here used to be answered VALID, and a guard written as "$qualityIndex !== null" would still
@@ -2091,7 +2388,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      *
      * The rejection is the correct answer, not a compromise: an unreadable AQI is not a verdict,
      * so the batch path answers it the way verifyAddress() answers an unreadable AVC
-     * (Helper/Validator.php:377). Nothing being cached follows from the same rule - a false
+     * in verifyAddress(). Nothing being cached follows from the same rule - a false
      * verdict is never stored - so a fault answers this one row and dies with the request, and the
      * next identical batch asks the API again.
      *
@@ -2115,9 +2412,9 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             'An AQI that is present but unreadable must fail CLOSED. It used to answer "valid" - '
             . '"" <= "C", false <= "C" and 0 <= "C" are all true under PHP 8 - so ONE malformed response '
             . 'row made that address PASS: admin order create went through '
-            . '(Plugin\Admin\OrderSave.php:50-58 sees true and raises no error) and the import row was '
+            . '(Plugin\Admin\OrderSave::aroundExecute() sees true and raises no error) and the import row was '
             . 'accepted unverified, while verifyAddress() already failed CLOSED on the equivalent '
-            . 'unreadable AVC (Helper/Validator.php:377). The two paths must agree, and this is where the '
+            . 'unreadable AVC in verifyAddress(). The two paths must agree, and this is where the '
             . 'AQI side is held.'
         );
         $this->assertSame(
@@ -2173,7 +2470,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * CACHED.
      *
      * Fail-closed is only correct if it rejects EXACTLY the unreadable values. Without this test
-     * the guard at Helper/Validator.php:841-843 could be strengthened all the way to "reject
+     * the guard in checkQualityIndex() could be strengthened all the way to "reject
      * everything" - a whitelist of today's grade letters, empty(), a falsy test, is_numeric() -
      * with every other test in this class still green: the two fail-closed tests above would keep
      * passing, and so would every cache test, because a rejection is never cached anyway. What
@@ -2182,8 +2479,8 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      *
      * Three cases, deliberately not one:
      *  - 'A' against a threshold of 'A': the EQUALITY case, and the shipped default
-     *    (etc/config.xml:20 sets address_quality_index to 'A' and the field is not exposed in
-     *    etc/adminhtml/system.xml, so this is what most merchants actually run);
+     *    (etc/config.xml sets address_quality_index to 'A' - the strictest grade - so this is
+     *    what a merchant who has not touched the new admin field is running);
      *  - 'B' against a looser 'C' threshold, so this test does not accidentally prove only that
      *    equality survives - a guard narrowed to "$qualityIndex === $threshold" would pass the
      *    case above and fail this one;
@@ -2223,7 +2520,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             $first,
             sprintf(
                 'A READABLE AQI that meets the configured threshold MUST still pass; this case pins that '
-                . '%s. The fail-closed guard (Helper/Validator.php:841-843) rejects only values whose '
+                . '%s. The fail-closed guard in checkQualityIndex() rejects only values whose '
                 . 'SHAPE is unreadable - no string, or the empty string - and widening it to empty(), to '
                 . 'a falsy test, to a whitelist of the grade letters Loqate uses today or to is_numeric() '
                 . 'would over-reject genuine verdicts and block valid addresses at admin order create and '
@@ -2417,6 +2714,14 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * already failed closed incidentally, and are pinned so that stays true by rule rather
      * than by accident of comparison semantics.
      *
+     * 'an unset threshold' AND 'a blank threshold' ARE TWO CASES, and they only became two when
+     * createShopper()'s configuration reader was changed from '??' to offsetExists(). Until
+     * then the harness substituted '' for a configured null, so both data sets ran the identical
+     * fixture while each carried a justification about a comparison that never happened. They
+     * are genuinely different inputs - different PHP comparison rules, and different cache-key
+     * fingerprints, see testTheThresholdFingerprintTellsTheseFourApart() - so the harness has to
+     * be able to tell them apart, and now can.
+     *
      * @return array<string, array{0: mixed, 1: string}>
      */
     public static function unreadableThresholdProvider(): array
@@ -2438,13 +2743,15 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             ],
             'an unset threshold' => [
                 null,
-                "null already failed closed via 'E' <= null being false; pinned so the guard, not "
-                . 'PHP comparison semantics, is what guarantees it',
+                "a config path never written to reads as null, and 'E' <= null is false only because "
+                . 'PHP coerces null to 0 and compares numerically; pinned so the guard, and not that '
+                . 'coercion, is what refuses it',
             ],
             'a blank threshold' => [
                 '',
-                "the empty string already failed closed the same incidental way; pinned for the same "
-                . 'reason',
+                "an admin field saved empty reads as '', and 'E' <= '' is false only because two "
+                . 'strings are compared byte by byte - a DIFFERENT accident from null\'s, which is why '
+                . 'these are two cases and not one',
             ],
             'a numeric threshold' => [
                 3,
@@ -2466,7 +2773,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             "AQI 'A' at the shipped default threshold 'A'" => [
                 'A',
                 'A',
-                'the strongest grade, judged against the threshold etc/config.xml:20 ships - the equality '
+                'the strongest grade, judged against the threshold etc/config.xml ships - the equality '
                 . 'case, and the configuration most merchants run',
             ],
             "AQI 'B' under a looser 'C' threshold" => [
@@ -2640,14 +2947,14 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * Whole RESPONSE-ROW shapes that carry no readable AQI at all, keyed by the $apiVerdicts
      * token that produces them. Each value is one element of the list the CONNECTOR emits - that
      * is, one record's 'Matches' value after Verify::verifyAddress()'s
-     * array_column($response, 'Matches') (vendor/lqt/api-connector/src/Client/Verify.php:50-52).
+     * array_column($response, 'Matches').
      *
      * ALL THREE SURVIVE that array_column() with the row count PRESERVED, verified on PHP 8.3: it
      * drops only records that lack the 'Matches' KEY, so a record whose 'Matches' is [] - or even
-     * null - still contributes an element. The row-count guard (Helper/Validator.php:643-651)
+     * null - still contributes an element. The row-count guard in verifyMultipleAddresses()
      * therefore cannot see any of them; they reach the attribution loop
-     * (Helper/Validator.php:703-711), where $addressResponse[0]['AQI'] ?? null is null for every
-     * one, and only checkQualityIndex()'s shape guard (Helper/Validator.php:841-843) stands
+     * there, where $addressResponse[0]['AQI'] ?? null is null for every
+     * one, and only checkQualityIndex()'s shape guard stands
      * between them and a PASS. See
      * testARowWithNoReadableQualityIndexFailsClosedAndIsNeverCached().
      *
@@ -2848,57 +3155,6 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         );
 
         return $limit;
-    }
-
-    /**
-     * A SerializerInterface double that fails the way the PRODUCTION serializer fails.
-     *
-     * The configured serializer for this module is Magento\Framework\Serialize\Serializer\Json,
-     * whose unserialize() THROWS \InvalidArgumentException on anything it cannot decode -
-     * including the empty string and null - rather than answering null. A double written as
-     * `fn ($v) => json_decode($v, true)` makes the "a cached entry cannot be read back" path
-     * unreachable from this harness: getCachedBatchVerifyResult() wraps the call in
-     * `try { ... } catch (\InvalidArgumentException $e)`, and against a lenient double that
-     * catch can NEVER run - so deleting it would leave this file green while a truncated or
-     * half-migrated session payload became a fatal in the middle of an import or an admin
-     * order save. testAnUnreadableBatchCacheDegradesToOneExtraBilledAddress() and
-     * testRefreshingAnEntryWhileTheCacheIsFullEvictsNoUnrelatedVerdict() both plant exactly
-     * such a payload and both claim the read must "not throw"; this is what gives that claim
-     * something to be false about.
-     *
-     * Mirrors CapturedAddressStoreTest::createSerializerDouble(), which had to establish the
-     * same thing for the captured-address store, and for the same reason.
-     *
-     * @return SerializerInterface&MockObject
-     */
-    private function createSerializerDouble()
-    {
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
-        $serializer->method('unserialize')->willReturnCallback(
-            static function ($value) {
-                // Magento\Framework\Serialize\Serializer\Json::unserialize(), verbatim in
-                // behaviour: the values it rejects outright first, then a decode whose failure
-                // is reported by json_last_error() rather than by a null return - null being a
-                // legitimately decodable value.
-                if ($value === false || $value === null || $value === '') {
-                    throw new \InvalidArgumentException('Unable to unserialize value.');
-                }
-
-                // NOT cast to string first, because the production serializer does not cast
-                // either: a non-string reaching json_decode() is a TypeError there and must be
-                // one here, or a caller that hands it one would look safe while production
-                // fatals. The verdict readers guard that with is_string() before they call.
-                $decoded = json_decode($value, true);
-                if (json_last_error() !== JSON_ERROR_NONE) {
-                    throw new \InvalidArgumentException('Unable to unserialize value, string is corrupted.');
-                }
-
-                return $decoded;
-            }
-        );
-
-        return $serializer;
     }
 
     /** A Validator with no API key configured, so every method short-circuits. */

--- a/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
+++ b/Test/Unit/Helper/ValidatorBatchVerifyCacheTest.php
@@ -50,7 +50,24 @@ use ReflectionProperty;
  *    quality index (checkQualityIndex()) and the other cache's from the AVC thresholds - one
  *    must never answer the other's lookup, see
  *    testTheTwoVerdictCachesAreInvisibleToEachOtherInBothDirections();
- *  - only PASSING verdicts are stored, see testAFailingVerdictIsNeverCached().
+ *  - only PASSING verdicts are stored IN THE SESSION, see
+ *    testAFailingVerdictIsNeverWrittenToTheSessionVerdictStore(), whose paired opposite -
+ *    testAFailingVerdictIsRememberedForTheRestOfTheRunRatherThanRebilled() - pins that a
+ *    readable rejection IS remembered for the length of one run.
+ *
+ * TWO MEMORIES ANSWER THIS PATH SINCE LOQ-17148, and every test in this file that measures a
+ * SESSION-store property has to be read with that in mind. Validator keeps a RUN-scoped verdict
+ * map on the instance, holding BOTH polarities and bounded by nothing but the file being
+ * imported, because a customer import chunks at 100 rows and verifies every chunk inside ONE PHP
+ * request. It is consulted before the session store and answers first. So a second
+ * verifyMultipleAddresses() call on the SAME Validator can no longer see what the session store
+ * did: it measures the run map. Anything about the session store - eviction, the key-scheme
+ * stamp, the stored shape, a corrupted payload, what is and is not written - is therefore
+ * asserted either by READING THE STORE DIRECTLY, or across a SECOND REQUEST built with
+ * createShopper($this->sessionStore), which is a fresh Validator over the same session double
+ * and is exactly what an admin re-submitting an order or re-running an import gets. Do not
+ * "simplify" those second requests back onto $this->validator: it makes the test measure the
+ * other memory and every one of them would still be green.
  *
  * THE KEY ITSELF IS THE SAME RULE AS THE SINGLE-ADDRESS ONE: an address shares a verdict
  * with another submission only when the two ask Loqate about the same address, the
@@ -337,13 +354,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         // the wrong reason.
         $helper->method('getCurrentStore')->willReturn($storeId);
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('serialize')->willReturnCallback(
-            static fn ($value) => json_encode($value)
-        );
-        $serializer->method('unserialize')->willReturnCallback(
-            static fn ($value) => json_decode($value, true)
-        );
+        $serializer = $this->createSerializerDouble();
 
         $validator = new Validator(
             $logger,
@@ -619,9 +630,12 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      */
     public function testAnIdenticalBatchSubmittedTwiceBillsItsAddressesOnce(): void
     {
-        // Every address passes: a rejection is deliberately never cached (see
-        // testAFailingVerdictIsNeverCached()), so a batch containing one could not make the
-        // "no second request at all" claim this test is about.
+        // Every address passes, so this holds for BOTH memories and stays a statement about the
+        // merchant-facing guarantee rather than about which memory answered: a rejection is
+        // remembered for the run but never in the session (see
+        // testAFailingVerdictIsNeverWrittenToTheSessionVerdictStore() and its paired opposite),
+        // so a batch containing one could not make the "no second request at all" claim this
+        // test is about once the admin comes back on a later request.
         $batch = [];
         for ($i = 0; $i < 5; $i++) {
             $batch[] = $this->distinctAddress($i);
@@ -802,14 +816,34 @@ class ValidatorBatchVerifyCacheTest extends TestCase
     }
 
     /**
-     * A FAILING verdict is never cached, and that is load-bearing rather than tidiness.
+     * A FAILING verdict is never written to the SESSION verdict store, and that is
+     * load-bearing rather than tidiness.
      *
-     * Because no rejection is ever stored, an admin or an import can never be stranded on a
-     * replayed "invalid" they cannot clear - the checkout dead-end the single-address cache
-     * has to avoid by keying rejections on the exact address Loqate judged. The cost is
-     * stated and asserted here: a failing address is re-billed on every submission.
+     * Because no rejection is ever stored THERE, an admin or an import can never be stranded
+     * across requests on a replayed "invalid" they cannot clear - the checkout dead-end the
+     * single-address cache has to avoid by keying rejections on the exact address Loqate
+     * judged - and the bounded FIFO store keeps spending its slots on the sparse PASSES,
+     * which is what makes it worth having on a default install where most rows fail
+     * (Validator::BATCH_VERIFY_CACHE_LIMIT carries the measurements). The cost is stated and
+     * asserted here: a failing address is re-billed by every later request.
+     *
+     * THIS IS ONE HALF OF A PAIR, and the halves are two different guarantees since LOQ-17148
+     * gave the run its own memory. The other half -
+     * testAFailingVerdictIsRememberedForTheRestOfTheRunRatherThanRebilled() - pins that the
+     * SAME run does NOT re-bill it. Neither implies the other, so neither may be asserted
+     * through the other: an implementation that cached failures in the session would satisfy
+     * the run-scoped half and violate this one, and an implementation that forgot rejections
+     * the instant the response was read would satisfy this one and violate that.
+     *
+     * MEASURED ACROSS TWO REQUESTS ON PURPOSE. What the session store holds is only
+     * observable to a Validator that did not earn the verdicts: within one run the rejection
+     * is answered from the run-scoped memory, which is the other half's subject. So the
+     * second submission here is made by a FRESH Validator over the SAME session double, which
+     * is exactly the admin re-submitting the order or re-running the import in the same
+     * browser session - and what it puts on the wire is decided by the session store and by
+     * nothing else.
      */
-    public function testAFailingVerdictIsNeverCached(): void
+    public function testAFailingVerdictIsNeverWrittenToTheSessionVerdictStore(): void
     {
         $good = $this->distinctAddress(1);
         $bad = $this->distinctAddress(2);
@@ -822,24 +856,99 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             1,
             $this->batchStore($this->shopper),
             'Only the PASSING verdict may be cached: a stored rejection is what would make it possible for '
-            . 'an admin or an import to be stranded on an "invalid" they cannot clear.'
+            . 'an admin or an import to be stranded on an "invalid" they cannot clear, and it would spend a '
+            . 'slot of a bounded store that exists to hold the passes.'
+        );
+        $this->assertSame(
+            [['valid' => true, 'schema' => self::VERIFY_KEY_SCHEMA_VERSION]],
+            array_map(
+                static fn ($entry) => json_decode((string)$entry, true),
+                array_values($this->batchStore($this->shopper))
+            ),
+            'The one entry the store holds must be a PASS: counting entries alone would still pass if a '
+            . 'rejection were stored in place of the pass rather than alongside it.'
         );
 
-        $second = $this->validator->verifyMultipleAddresses([$good, $bad], false);
+        // A LATER REQUEST in the same browser session: same session store, brand new Validator.
+        $laterRequest = $this->createShopper($this->sessionStore);
+        $second = $laterRequest['validator']->verifyMultipleAddresses([$good, $bad], false);
 
-        $this->assertSame(2, $this->apiCallCount(), 'The failing address must be sent again.');
+        $this->assertSame(
+            1,
+            $this->shopperCallCount($laterRequest),
+            'The failing address must be sent again by a later request: nothing in the session store '
+            . 'answers for it, so there is a request to make.'
+        );
         $this->assertSame(
             [$bad['street'][0]],
-            array_column($this->apiRequests[1]['Addresses'], 'Address1'),
-            'ONLY the failing address may be re-sent: the passing one is cached, so re-billing it too '
-            . 'would defeat the fix.'
+            array_column($laterRequest['requests'][0]['Addresses'], 'Address1'),
+            'ONLY the failing address may be re-sent: the passing one IS in the session store, so '
+            . 're-billing it too would defeat the fix, and re-sending neither would mean the rejection had '
+            . 'been stored after all.'
         );
         $this->assertSame(
             3,
-            $this->addressesBilled(),
-            'Two addresses submitted twice, one of them cacheable: three billed addresses.'
+            $this->addressesBilled() + $this->addressesBilledBy($laterRequest),
+            'Two addresses submitted in two requests, one of them cacheable: three billed addresses.'
         );
         $this->assertSame([true, false], array_values($second), 'The verdicts must be unchanged.');
+    }
+
+    /**
+     * The other half of the pair, and the saving LOQ-17148 exists for: a READABLE REJECTION is
+     * remembered for the rest of the RUN, so a rejected address repeated later in the same run
+     * is not sent - or billed - a second time.
+     *
+     * A customer import chunks at 100 rows and verifies every chunk inside ONE PHP request,
+     * and etc/config.xml ships address_quality_index at 'A', the strictest grade, so on a
+     * default install most rows FAIL. A rejection that is forgotten the instant the response
+     * is read is therefore re-sent in every chunk the address appears in, and the Cleansing
+     * API is billed per ADDRESS, not per request.
+     *
+     * SEPARATELY FAILING FROM ITS SIBLING BY CONSTRUCTION: both submissions here are made by
+     * the SAME Validator, which is the lifetime a run has, and the session store is asserted
+     * NOT to have grown - so this test cannot be satisfied by starting to cache failures in
+     * the session, which is the change deliberately rejected on billing grounds.
+     */
+    public function testAFailingVerdictIsRememberedForTheRestOfTheRunRatherThanRebilled(): void
+    {
+        $good = $this->distinctAddress(1);
+        $bad = $this->distinctAddress(2);
+        $this->apiVerdicts[$bad['street'][0]] = 'fail';
+
+        $first = $this->validator->verifyMultipleAddresses([$good, $bad], false);
+
+        $this->assertSame([true, false], array_values($first), 'The second address must be rejected.');
+        $this->assertSame(2, $this->addressesBilled(), 'The first chunk bills both of its addresses.');
+
+        $second = $this->validator->verifyMultipleAddresses([$good, $bad], false);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount(),
+            'A chunk whose every address this run has already judged must issue NO request at all - not an '
+            . 'empty payload to a billable endpoint, and not a request carrying the rejected address again.'
+        );
+        $this->assertSame(
+            2,
+            $this->addressesBilled(),
+            'The rejected address must appear on the invoice ONCE for the run, not once per chunk it '
+            . 'appears in: this is the whole saving of LOQ-17148, and it is measured in ADDRESSES because '
+            . 'that is what Loqate bills.'
+        );
+        $this->assertSame(
+            [true, false],
+            array_values($second),
+            'The remembered rejection must come back as the REJECTION it was. Remembering the address but '
+            . 'answering it true would turn a billing fix into an unverified import.'
+        );
+        $this->assertCount(
+            1,
+            $this->batchStore($this->shopper),
+            'And the saving must come from the RUN memory, not from the session store, which must still '
+            . 'hold the single pass: caching failures there is a measured billing REGRESSION on this '
+            . 'workload, because failures crowd the sparse passes out of a bounded FIFO store.'
+        );
     }
 
     /**
@@ -1043,6 +1152,14 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * serialised on every request, and an import can present thousands of rows. Bounded but
      * newest-first would be worse than useless, because the entry most likely to be needed
      * again is the one just written.
+     *
+     * BOTH PROBES ARE MADE BY A LATER REQUEST, and that is the only lifetime in which
+     * eviction is observable at all. The run that filled the store remembers every one of
+     * those verdicts in its own map, which is deliberately UNBOUNDED - it dies with the
+     * request - so asking the filling Validator would measure that map and report a perfect
+     * hit rate whatever the session store had thrown away. The second request is a fresh
+     * Validator over the same session double, so what it puts on the wire is decided by the
+     * session store alone: nothing else survived.
      */
     public function testTheBatchCacheIsBoundedAndEvictsTheOldestVerdictFirst(): void
     {
@@ -1065,25 +1182,34 @@ class ValidatorBatchVerifyCacheTest extends TestCase
             . 'bounded) and no fewer (a cache that under-fills re-bills addresses it had room to keep).'
         );
 
-        $callsAfterFill = $this->apiCallCount();
-        $billedAfterFill = $this->addressesBilled();
+        $laterRequest = $this->createShopper($this->sessionStore);
 
         // The newest address must have survived...
-        $this->validator->verifyMultipleAddresses([$batch[$limit + 4]], false);
+        $laterRequest['validator']->verifyMultipleAddresses([$batch[$limit + 4]], false);
         $this->assertSame(
-            $billedAfterFill,
-            $this->addressesBilled(),
+            0,
+            $this->addressesBilledBy($laterRequest),
             'The most recently verified address must survive eviction: it is the likeliest to be asked '
             . 'about again.'
         );
-        $this->assertSame($callsAfterFill, $this->apiCallCount(), 'An all-hit batch must issue no request.');
+        $this->assertSame(
+            0,
+            $this->shopperCallCount($laterRequest),
+            'An all-hit batch must issue no request.'
+        );
 
         // ...while the oldest five have been evicted and must be verified again.
-        $this->validator->verifyMultipleAddresses([$batch[0]], false);
+        $laterRequest['validator']->verifyMultipleAddresses([$batch[0]], false);
         $this->assertSame(
-            $billedAfterFill + 1,
-            $this->addressesBilled(),
+            1,
+            $this->addressesBilledBy($laterRequest),
             'The oldest entries must be the ones evicted once the cache is full.'
+        );
+        $this->assertSame(
+            [$batch[0]['street'][0]],
+            array_column($laterRequest['requests'][0]['Addresses'], 'Address1'),
+            'And the address it re-bills must be the EVICTED one: a store that had evicted something else '
+            . 'entirely would run up the same invoice.'
         );
         $this->assertCount(
             $limit,
@@ -1522,6 +1648,14 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * module writing to the key, a half-migrated session payload) or an entry that cannot be
      * read as a verdict must degrade to "not cached" - one extra billed address - and never
      * throw in the middle of an import.
+     *
+     * Each corruption is presented to a SEPARATE REQUEST, because that is the only lifetime
+     * in which the session store is what answers: the Validator that wrote the entry
+     * remembers the verdict for its own run and would answer from that map without reading
+     * the corrupted store at all, so both corruptions would go unexercised and this test
+     * would be green whether the defensive reads existed or not. Corruption arriving on a
+     * later request is also the realistic case - a session payload is corrupted between
+     * requests, not during one.
      */
     public function testAnUnreadableBatchCacheDegradesToOneExtraBilledAddress(): void
     {
@@ -1529,9 +1663,14 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $this->assertCount(1, $this->batchStore($this->shopper), 'The verdict must be cached normally first.');
 
         $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = 'not-an-array';
-        $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
+        $unreadableStoreRequest = $this->createShopper($this->sessionStore);
+        $unreadableStoreRequest['validator']->verifyMultipleAddresses([self::ADDRESS], false);
 
-        $this->assertSame(2, $this->apiCallCount(), 'An unreadable store must fall back to verifying, not throw.');
+        $this->assertSame(
+            1,
+            $this->addressesBilledBy($unreadableStoreRequest),
+            'An unreadable store must fall back to verifying, not throw.'
+        );
         $this->assertCount(
             1,
             $this->batchStore($this->shopper),
@@ -1545,15 +1684,28 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $store[$key] = '{not json';
         $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
 
-        $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
+        $corruptedEntryRequest = $this->createShopper($this->sessionStore);
+        $corruptedEntryRequest['validator']->verifyMultipleAddresses([self::ADDRESS], false);
 
-        $this->assertSame(3, $this->apiCallCount(), 'A corrupted entry must be re-verified, not throw.');
+        $this->assertSame(
+            1,
+            $this->addressesBilledBy($corruptedEntryRequest),
+            'A corrupted entry must be re-verified, not throw, and not be read as a verdict.'
+        );
         $this->assertSame(
             ['valid' => true, 'schema' => self::VERIFY_KEY_SCHEMA_VERSION],
             json_decode((string)($this->batchStore($this->shopper)[$key] ?? ''), true),
             'The re-verified verdict must overwrite the corrupted entry with a usable one - carrying the '
             . 'key-scheme stamp, so recovering from corruption cannot quietly write an entry the next read '
             . 'would discard as stale.'
+        );
+        $this->assertSame(
+            3,
+            $this->addressesBilled()
+            + $this->addressesBilledBy($unreadableStoreRequest)
+            + $this->addressesBilledBy($corruptedEntryRequest),
+            'ONE address, three requests, two of them meeting a store they could not read: three billed '
+            . 'addresses and no more. Degrading to a miss costs exactly one re-verification each time.'
         );
     }
 
@@ -1564,6 +1716,11 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      *
      * This is the second, independent guard behind the separate session attribute, and it is
      * the one that still holds after somebody "simplifies" the two stores into one.
+     *
+     * The plant is presented to a SECOND REQUEST, because the shape guard lives on the
+     * session-store read: the Validator that earned the key remembers its own verdict for the
+     * run and would answer from there without ever looking at the planted entry, leaving the
+     * guard unexercised and this test green with the shape check deleted.
      */
     public function testASingleAddressVerdictPlantedInTheBatchStoreIsNotReadAsAVerdict(): void
     {
@@ -1581,14 +1738,21 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $store[$key] = json_encode(['error' => false, 'schema' => self::VERIFY_KEY_SCHEMA_VERSION]);
         $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
 
-        $this->validator->verifyMultipleAddresses([self::ADDRESS], false);
+        $laterRequest = $this->createShopper($this->sessionStore);
+        $verdicts = $laterRequest['validator']->verifyMultipleAddresses([self::ADDRESS], false);
 
         $this->assertSame(
-            2,
-            $this->apiCallCount(),
+            1,
+            $this->addressesBilledBy($laterRequest),
             'A verdict in the single-address cache\'s shape must not satisfy a batch lookup: these '
             . 'verdicts answer different questions - the AVC thresholds versus the address quality '
             . 'index - so reading one as the other would apply a threshold the merchant did not choose.'
+        );
+        $this->assertSame(
+            [0 => true],
+            $verdicts,
+            'And the LIVE verdict must be the one returned, so the plant can be seen not to have answered '
+            . 'the lookup rather than merely to have agreed with it.'
         );
     }
 
@@ -2104,6 +2268,12 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * the batch payload's distinct shape already guarded the two caches from each other. That
      * is a different guard: shape stops cross-CACHE conflation, the stamp stops cross-DEPLOY
      * staleness, and both key builders share one signature so a key-meaning change hits both.
+     *
+     * A DEPLOY IS BY DEFINITION A LATER REQUEST, and the fixture matches: the stale entry is
+     * presented to a fresh Validator over the same session. The Validator that earned the
+     * entry holds the same verdict in its own run memory and would answer from there, so
+     * asking it would exercise no stamp check at all - the check lives on the session-store
+     * read, which is the only place a verdict can be older than the running code.
      */
     public function testABatchVerdictWrittenUnderAnEarlierKeySchemeIsDiscardedRatherThanReplayed(): void
     {
@@ -2129,11 +2299,12 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $store[$key] = json_encode($payload);
         $this->shopper['session'][self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
 
-        $verdicts = $this->validator->verifyMultipleAddresses([$address], false);
+        $laterRequest = $this->createShopper($this->sessionStore);
+        $verdicts = $laterRequest['validator']->verifyMultipleAddresses([$address], false);
 
         $this->assertSame(
-            2,
-            $this->apiCallCount(),
+            1,
+            $this->addressesBilledBy($laterRequest),
             'A batch verdict stamped with another key scheme must be discarded and the address verified '
             . 'again: the key it is filed under no longer names the same address. Replaying it would be a '
             . 'false ACCEPT, since this store holds nothing but passes.'
@@ -2154,6 +2325,10 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * supplied for a missing key cannot equal the current version. Relaxing that default -
      * '?? null' to '?? self::VERIFY_KEY_SCHEMA_VERSION' - would silently admit every unstamped
      * entry, which is precisely the set written by the deploy before the stamp existed.
+     *
+     * Presented to a LATER REQUEST for the same reason as its sibling above: an entry written
+     * by an older deploy can only be met on a session-store read, and the Validator that
+     * earned this key would answer it out of its own run memory instead.
      */
     public function testABatchVerdictWithNoKeySchemeStampIsDiscardedRatherThanReplayed(): void
     {
@@ -2167,11 +2342,12 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $store[$key] = json_encode(['valid' => true]);
         $this->shopper['session'][self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
 
-        $verdicts = $this->validator->verifyMultipleAddresses([$address], false);
+        $laterRequest = $this->createShopper($this->sessionStore);
+        $verdicts = $laterRequest['validator']->verifyMultipleAddresses([$address], false);
 
         $this->assertSame(
-            2,
-            $this->apiCallCount(),
+            1,
+            $this->addressesBilledBy($laterRequest),
             'An UNSTAMPED batch verdict must be re-verified: it was written before the key scheme was '
             . 'recorded, so nothing establishes that its key still names this address. Admitting it would '
             . 'be a false ACCEPT, since this store holds nothing but passes.'
@@ -2325,6 +2501,15 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      * whenever the same address appears twice in one batch. This test uses the unreadable
      * payload, because that is the case that arrives with the cache already full after an
      * import.
+     *
+     * THREE REQUESTS, one per act, and the split is what makes the assertions mean anything.
+     * The store is filled by request one; request two meets the corrupted entry and performs
+     * the refresh; request three asks for the OLDEST address. Each is a fresh Validator over
+     * the same session double, so no run-scoped memory carries an answer between them - the
+     * Validator that filled the store remembers all of it, and the one that refreshed the
+     * newest entry remembers that. Asking either of them about $batch[0] would report a hit
+     * out of its own map no matter what array_shift() had done to the session store, which is
+     * precisely the eviction this test exists to detect.
      */
     public function testRefreshingAnEntryWhileTheCacheIsFullEvictsNoUnrelatedVerdict(): void
     {
@@ -2347,11 +2532,12 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $store[$keys[$limit - 1]] = '{not json';
         $this->sessionStore[self::BATCH_VERIFY_CACHE_SESSION_KEY] = $store;
 
-        $this->validator->verifyMultipleAddresses([$batch[$limit - 1]], false);
+        $refreshRequest = $this->createShopper($this->sessionStore);
+        $refreshRequest['validator']->verifyMultipleAddresses([$batch[$limit - 1]], false);
 
         $this->assertSame(
-            $limit + 1,
-            $this->addressesBilled(),
+            1,
+            $this->addressesBilledBy($refreshRequest),
             'Fixture guard: the corrupted entry must genuinely have missed, or the refresh under test '
             . 'never happened.'
         );
@@ -2363,18 +2549,26 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         );
 
         // THE assertion: the entry at the far end of the FIFO queue - the one with nothing to do
-        // with the refresh - must still be replayable.
-        $replayed = $this->validator->verifyMultipleAddresses([$batch[0]], false);
+        // with the refresh - must still be replayable, by a request that has never seen it.
+        $replayRequest = $this->createShopper($this->sessionStore);
+        $replayed = $replayRequest['validator']->verifyMultipleAddresses([$batch[0]], false);
 
         $this->assertSame(
-            $limit + 1,
-            $this->addressesBilled(),
+            0,
+            $this->addressesBilledBy($replayRequest),
             'The OLDEST verdict must survive a refresh of the newest one. Without the unset-then-append, '
             . 'the eviction loop counts the key it is about to overwrite as if it needed room and shifts '
             . 'this entry out - so a corrupted or repeated address quietly costs an unrelated, perfectly '
             . 'good verdict, and every such write shrinks the cache by one.'
         );
         $this->assertSame([0 => true], $replayed, 'And it must replay as the verdict it was, not as a miss.');
+        $this->assertSame(
+            $limit + 1,
+            $this->addressesBilled() + $this->addressesBilledBy($refreshRequest)
+            + $this->addressesBilledBy($replayRequest),
+            'Across all three requests the invoice must show the ' . $limit . ' distinct addresses plus the '
+            . 'ONE re-verification the corrupted payload forced, and nothing else.'
+        );
     }
 
     /**
@@ -2595,8 +2789,24 @@ class ValidatorBatchVerifyCacheTest extends TestCase
      */
     private function addressesBilled(): int
     {
+        return $this->addressesBilledBy($this->shopper);
+    }
+
+    /**
+     * addressesBilled() for a specific shopper built by createShopper().
+     *
+     * Needed by every test that measures a SESSION-store property, because those properties
+     * are only observable across REQUESTS: a second request builds its own Validator (and so
+     * its own connector), and the invoice it runs up is the one that says what the session
+     * store did or did not answer. Summing the two shoppers would hide exactly that.
+     *
+     * @param array $shopper Shopper harness from createShopper().
+     * @return int
+     */
+    private function addressesBilledBy(array $shopper): int
+    {
         $billed = 0;
-        foreach ($this->apiRequests as $payload) {
+        foreach ($shopper['requests'] as $payload) {
             $billed += count((array)($payload['Addresses'] ?? []));
         }
 
@@ -2640,6 +2850,57 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         return $limit;
     }
 
+    /**
+     * A SerializerInterface double that fails the way the PRODUCTION serializer fails.
+     *
+     * The configured serializer for this module is Magento\Framework\Serialize\Serializer\Json,
+     * whose unserialize() THROWS \InvalidArgumentException on anything it cannot decode -
+     * including the empty string and null - rather than answering null. A double written as
+     * `fn ($v) => json_decode($v, true)` makes the "a cached entry cannot be read back" path
+     * unreachable from this harness: getCachedBatchVerifyResult() wraps the call in
+     * `try { ... } catch (\InvalidArgumentException $e)`, and against a lenient double that
+     * catch can NEVER run - so deleting it would leave this file green while a truncated or
+     * half-migrated session payload became a fatal in the middle of an import or an admin
+     * order save. testAnUnreadableBatchCacheDegradesToOneExtraBilledAddress() and
+     * testRefreshingAnEntryWhileTheCacheIsFullEvictsNoUnrelatedVerdict() both plant exactly
+     * such a payload and both claim the read must "not throw"; this is what gives that claim
+     * something to be false about.
+     *
+     * Mirrors CapturedAddressStoreTest::createSerializerDouble(), which had to establish the
+     * same thing for the captured-address store, and for the same reason.
+     *
+     * @return SerializerInterface&MockObject
+     */
+    private function createSerializerDouble()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
+        $serializer->method('unserialize')->willReturnCallback(
+            static function ($value) {
+                // Magento\Framework\Serialize\Serializer\Json::unserialize(), verbatim in
+                // behaviour: the values it rejects outright first, then a decode whose failure
+                // is reported by json_last_error() rather than by a null return - null being a
+                // legitimately decodable value.
+                if ($value === false || $value === null || $value === '') {
+                    throw new \InvalidArgumentException('Unable to unserialize value.');
+                }
+
+                // NOT cast to string first, because the production serializer does not cast
+                // either: a non-string reaching json_decode() is a TypeError there and must be
+                // one here, or a caller that hands it one would look safe while production
+                // fatals. The verdict readers guard that with is_string() before they call.
+                $decoded = json_decode($value, true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    throw new \InvalidArgumentException('Unable to unserialize value, string is corrupted.');
+                }
+
+                return $decoded;
+            }
+        );
+
+        return $serializer;
+    }
+
     /** A Validator with no API key configured, so every method short-circuits. */
     private function createKeylessValidator(): Validator
     {
@@ -2647,9 +2908,7 @@ class ValidatorBatchVerifyCacheTest extends TestCase
         $helper->method('getConfigValue')->willReturn('');
         $helper->method('getCurrentStore')->willReturn(0);
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
-        $serializer->method('unserialize')->willReturnCallback(static fn ($value) => json_decode($value, true));
+        $serializer = $this->createSerializerDouble();
 
         return new Validator(
             $this->createMock(Logger::class),

--- a/Test/Unit/Helper/ValidatorImportRunDedupeTest.php
+++ b/Test/Unit/Helper/ValidatorImportRunDedupeTest.php
@@ -1,0 +1,1136 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Helper;
+
+use Loqate\ApiConnector\Client\Verify;
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Logger\Logger;
+use Loqate\ApiIntegration\Model\Config\Source\AddressQualityIndex;
+use Magento\Customer\Model\Session;
+use Magento\Directory\Model\RegionFactory;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use ArrayObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * Unit tests for the BILLING guarantee LOQ-17148 buys on the CUSTOMER IMPORT path:
+ * Validator::verifyMultipleAddresses() called repeatedly, within ONE PHP request, over the
+ * chunks of one import file.
+ *
+ * WHY A SECOND FILE BESIDE ValidatorBatchVerifyCacheTest. That class pins what the SESSION
+ * batch cache does - it is keyed on "a later request in the same session", and its whole
+ * subject is what survives between requests. Everything here is keyed on the opposite
+ * lifetime: what one import RUN must remember about itself and must NOT leave behind. The two
+ * lifetimes are different guarantees with opposite failure modes (replaying too little costs
+ * money, replaying too much brands a merchant's rows invalid), so they are asserted apart
+ * rather than interleaved into a class that is already the largest in the suite.
+ *
+ * WHAT WAS UNFIXED, and what "one run" means here. LOQ-16976 gave this method a session-scoped
+ * verdict cache, but Plugin\Admin\ValidateImportAddress::afterValidateData() chunks one import
+ * file at 100 rows and verifies every chunk INSIDE ONE REQUEST, and the session store caches
+ * PASSES ONLY. So a REJECTED address repeated across chunks was re-sent - and therefore
+ * re-billed, the Cleansing API being billed per ADDRESS and not per request - in every chunk it
+ * appeared in, however many times that was. On a default install that is close to every row:
+ * etc/config.xml ships address_quality_index at 'A', the strictest grade, so most rows fail and
+ * were never cacheable in the first place. "One run" is therefore modelled as ONE Validator
+ * INSTANCE answering several batches, because that is exactly the lifetime an import chunk loop
+ * has; "a later run" is a second Validator over the same session double, which is what
+ * createRequest() takes a session for.
+ *
+ * WHAT MUST NOT BE FIXED WITH IT, measured and deliberate (LOQ-17148 design note D2). The
+ * SESSION store stays passes-only. Caching failures THERE is a regression on the target
+ * workload, not an improvement: eviction is FIFO and bounded by
+ * Validator::BATCH_VERIFY_CACHE_LIMIT, so on a 1000-row file at a 5% pass rate the failures
+ * crowd out the sparse passes the store currently manages to keep, and run 2 goes from 950
+ * billed addresses to 1000. It is also what keeps a merchant from being stranded: a rejection
+ * that outlived the request would still be replayed after they corrected the file or loosened
+ * the threshold. testARejectionIsNeverReplayedToALaterRequest() is that half.
+ *
+ * THE ONE RULE THAT GOVERNS ALL OF IT: NEVER REMEMBER A VERDICT WE COULD NOT READ. An AQI that
+ * could not be read, or a threshold that could not be read, produces a rejection that is a
+ * FAULT REPORT rather than a verdict - so it is remembered nowhere, not even for the identical
+ * address in the same run, and the row is billed again. One connector fault or one bad
+ * credential must not brand every matching row in the file invalid for the rest of the run.
+ * That is what testAnUnreadableQualityIndexIsRememberedNowhereSoTheRowIsBilledAgain() and
+ * testAnUnreadableThresholdRejectsEveryRowAndIsRememberedNowhere() hold, and it is the
+ * assertion to look at first if a dedupe change ever makes the headline test cheaper.
+ *
+ * Every count asserted here is ADDRESSES BILLED - count($payload['Addresses']) summed over
+ * every connector invocation - and not requests, because that is what the invoice is.
+ */
+class ValidatorImportRunDedupeTest extends TestCase
+{
+    /** Any non-empty key makes the batch path reach the billable call. */
+    private const API_KEY = 'TEST-API-KEY-0000';
+
+    /**
+     * Configured address quality index threshold. checkQualityIndex() compares the response's
+     * AQI against it with <=, as plain strings, so 'A' and 'B' pass a 'C' threshold and 'E'
+     * does not. Deliberately NOT the shipped 'A', so a passing grade and a failing grade are
+     * both expressible without either being the boundary value.
+     */
+    private const AQI_THRESHOLD = 'C';
+
+    /** AQI better than self::AQI_THRESHOLD => the row passes. */
+    private const PASSING_AQI = 'A';
+
+    /** AQI poorer than self::AQI_THRESHOLD => the row is REJECTED, which is the broken case. */
+    private const FAILING_AQI = 'E';
+
+    /**
+     * An AVC the response rows carry for realism only. The batch path judges the AQI and
+     * ignores the AVC entirely; a row without one would still be a faithful fixture, but the
+     * Cleansing API does not send one, so neither does this.
+     */
+    private const CARRIED_AVC = 'V55-I22-P9-99';
+
+    /** Session data key the BATCH verdict cache must live under. */
+    private const BATCH_VERIFY_CACHE_SESSION_KEY = 'loqate_verified_batch_addresses';
+
+    /** Session data key the SINGLE-address verdict cache lives under. */
+    private const VERIFY_CACHE_SESSION_KEY = 'loqate_verified_addresses';
+
+    /** Config path of the threshold batch verdicts are judged against. */
+    private const AQI_CONFIG_PATH = 'loqate_settings/address_settings/address_quality_index';
+
+    /**
+     * Rows per verification batch, as Plugin\Admin\ValidateImportAddress::afterValidateData()
+     * chunks an import file. Mirrored rather than read from the plugin because it is a literal
+     * there; if the plugin ever chunks differently, this test's file layout is what has to be
+     * re-thought, so it should fail loudly rather than follow along.
+     */
+    private const IMPORT_CHUNK_SIZE = 100;
+
+    /**
+     * Response-row shapes carrying no readable AQI at all, keyed by the $apiVerdicts token
+     * that produces them. Each value is one element of the list the CONNECTOR emits - one
+     * record's 'Matches' value after Verify::verifyAddress()'s array_column($response,
+     * 'Matches').
+     *
+     * ALL THREE survive that array_column() with the row count PRESERVED (it drops only
+     * records lacking the 'Matches' KEY), so verifyMultipleAddresses()' row-count guard cannot
+     * see them and they reach the attribution loop as an AQI of null. The same taxonomy is
+     * used by ValidatorBatchVerifyCacheTest; it is repeated rather than shared because these
+     * are fixture shapes and a shared parent class would couple two test classes with
+     * different subjects.
+     *
+     * @var array<string, mixed>
+     */
+    private const UNREADABLE_ROW_SHAPES = [
+        // "Matches":[{}] - a match object with no AQI field in it.
+        'match carrying no AQI' => [[]],
+        // "Matches":[] - Loqate saying "no match for this address".
+        'Matches list that is empty' => [],
+        // "Matches":null - a survivor of array_column() just as [] is.
+        'Matches value that is null' => null,
+    ];
+
+    /**
+     * AQI values that are PRESENT in the response but carry no readable grade, keyed by the
+     * $apiVerdicts token that produces them. Every one compares as BETTER than any letter
+     * threshold under PHP 8's <= rules, which is what made them dangerous rather than merely
+     * odd. The INT 0 belongs here; the STRING '0' does not, being a readable non-empty string.
+     *
+     * @var array<string, mixed>
+     */
+    private const UNREADABLE_AQI_VALUES = [
+        'empty-aqi' => '',
+        'false-aqi' => false,
+        'zero-aqi' => 0,
+    ];
+
+    /** @var array The primary request harness, as returned by createRequest(). */
+    private $request;
+
+    /**
+     * What the API answers per address, keyed by the address's first street line: 'pass',
+     * 'fail', or one of the self::UNREADABLE_ROW_SHAPES / self::UNREADABLE_AQI_VALUES tokens.
+     * Anything absent answers 'pass'.
+     *
+     * Mutable mid-test on purpose: an address whose answer CHANGES between two batches of one
+     * run is how a remembered verdict is told apart from a live one.
+     *
+     * @var array<string, string>
+     */
+    private $apiVerdicts = [];
+
+    protected function setUp(): void
+    {
+        $this->apiVerdicts = [];
+        $this->request = $this->createRequest();
+    }
+
+    /**
+     * THE ACCEPTANCE MEASUREMENT of LOQ-17148, on the file shape that showed the defect: an
+     * import file LARGER than the session cache's bound, whose repeated addresses are the ones
+     * Loqate REJECTS.
+     *
+     * Within one run, the number of addresses billed must equal the number of DISTINCT
+     * addresses in the file. Not "fewer than before" - exactly the distinct count, because any
+     * excess is a duplicate somebody paid for twice.
+     *
+     * WHY THE REPEATS ARE ALL REJECTIONS. Passing repeats were already deduped by the session
+     * store (LOQ-16976), so a file whose repeats pass would go green against the unfixed code
+     * and measure nothing. Rejections are the case that was re-billed in every chunk they
+     * appeared in, and on a default install they are most of the file: etc/config.xml ships
+     * address_quality_index at 'A'.
+     *
+     * WHY THE FILE IS BIGGER THAN THE LIMIT, and why the limit is read by reflection rather
+     * than mirrored: this is precisely the size at which the session store stops helping, since
+     * FIFO eviction over a working set larger than the cache yields close to zero hits however
+     * the constant is chosen. A file that FITS in the limit cannot distinguish the fix from the
+     * cache that was already there.
+     *
+     * WHAT THE FIXTURE DELIBERATELY DOES NOT CONTAIN, asserted rather than promised: no address
+     * appears twice inside ONE chunk. Two copies of an address in a single batch are both sent,
+     * because nothing is written until the response comes back - that is LOQ-17015, a separate
+     * ticket with its own arithmetic (the row-count guard in verifyMultipleAddresses() depends
+     * on one response row per sent item), and pulling it into this measurement would make the
+     * headline number unmeetable for a reason this ticket is not about.
+     */
+    public function testAnImportRunLargerThanTheCacheLimitBillsEachDistinctAddressOnce(): void
+    {
+        $limit = $this->batchCacheLimit();
+        $fileIds = $this->crossChunkRepeatFileIds();
+        $rejectedIds = $this->rejectedFileIds();
+        foreach ($rejectedIds as $id) {
+            $this->apiVerdicts[$this->distinctAddress($id)['street'][0]] = 'fail';
+        }
+        $this->assertFileRepeatsOnlyAcrossChunks($fileIds, $rejectedIds, $limit);
+
+        $verdicts = $this->verifyFileInChunks($this->request, $fileIds);
+
+        $distinctCount = count(array_unique($fileIds));
+        $this->assertSame(
+            $distinctCount,
+            $this->addressesBilled($this->request),
+            sprintf(
+                'A %d-row import file holding %d distinct addresses must cost %d billed addresses in one '
+                . 'run, not one per row. The Cleansing API is billed per ADDRESS, and before LOQ-17148 a '
+                . 'REJECTED address was re-sent in every chunk it appeared in, because the session store '
+                . 'caches passes only - which on a default install (address_quality_index ships as \'A\') is '
+                . 'most of the file. Any number above %d is a duplicate the merchant paid for twice.',
+                count($fileIds),
+                $distinctCount,
+                $distinctCount,
+                $distinctCount
+            )
+        );
+        $this->assertSame(
+            [],
+            array_keys(array_filter(
+                array_count_values($this->streetsBilled($this->request)),
+                static fn (int $times): bool => $times > 1
+            )),
+            'No address may reach the billable endpoint twice in one run. Asserted per address rather than '
+            . 'only in total, so a total that happens to add up while one address is billed twice and '
+            . 'another is skipped cannot pass.'
+        );
+
+        $expected = [];
+        foreach (array_values($fileIds) as $row => $id) {
+            $expected[$row] = !in_array($id, $rejectedIds, true);
+        }
+        $this->assertSame(
+            $expected,
+            $verdicts,
+            'Every row must still carry the verdict of the address on THAT row, in file order: the merged '
+            . 'chunk results are what Plugin\Admin\ValidateImportAddress turns into row numbers, so a '
+            . 'de-duplicated row that loses its slot renumbers every row after it.'
+        );
+    }
+
+    /**
+     * The single row of the measurement above, in isolation: a REJECTED address that comes back
+     * in a later chunk of the same run is billed exactly once.
+     *
+     * Kept separate from the headline test because a 260-row file that is off by one tells you
+     * only that something is wrong, while this one names it. It is also the smallest fixture
+     * that fails against the unfixed code, so it is the first thing to run while implementing.
+     */
+    public function testARejectedAddressRepeatedInALaterChunkIsBilledOnce(): void
+    {
+        $accepted = $this->distinctAddress(1);
+        $rejected = $this->distinctAddress(2);
+        $this->apiVerdicts[$rejected['street'][0]] = 'fail';
+
+        $firstChunk = $this->request['validator']->verifyMultipleAddresses([$accepted, $rejected], false);
+        $laterChunk = $this->request['validator']->verifyMultipleAddresses([$rejected, $accepted], false);
+
+        $this->assertSame(
+            2,
+            $this->addressesBilled($this->request),
+            'Two distinct addresses, each appearing in two chunks of one import run: two billed addresses. '
+            . 'The rejected one used to be billed again in every chunk it appeared in, because only passes '
+            . 'were remembered - and a rejection is exactly as definitive a verdict as a pass, as long as '
+            . 'the AQI it was read from was readable.'
+        );
+        $this->assertSame(
+            [true, false],
+            array_values($firstChunk),
+            'Fixture precondition, read off the verdicts rather than assumed: the second address really is '
+            . 'the one Loqate rejects, or this test would be measuring a repeated PASS - which the session '
+            . 'store already deduped before LOQ-17148.'
+        );
+        $this->assertSame(
+            [false, true],
+            array_values($laterChunk),
+            'And the later chunk must report the SAME verdicts under ITS OWN keys: dedupe may not cost a '
+            . 'row its verdict, or the import reports an invalid row against a valid row\'s number.'
+        );
+    }
+
+    /**
+     * A rejection is NEVER replayed to a LATER REQUEST - the deliberate limit of the fix
+     * (LOQ-17148 design note D2), and the reason the session store stays passes-only.
+     *
+     * Two things rest on it. A merchant who corrects the file, or loosens
+     * address_quality_index, must be re-verified rather than stranded on a "no" earned under
+     * the old data or the old threshold - so the second request here is answered by a Loqate
+     * that has changed its mind, and must report the NEW verdict. And the session payload must
+     * not fill with rejections: eviction is FIFO and bounded, so on a file whose rows mostly
+     * fail, cached failures would crowd out the sparse passes the store does manage to keep and
+     * the NEXT run would be billed MORE than it is today, not less.
+     *
+     * A fresh Validator over the SAME session double is what "a later request" is: the run
+     * scoped memory dies with the object, and only what was written to the session survives.
+     */
+    public function testARejectionIsNeverReplayedToALaterRequest(): void
+    {
+        $address = $this->distinctAddress(1);
+        $this->apiVerdicts[$address['street'][0]] = 'fail';
+
+        $firstRun = $this->createRequest();
+        $rejection = $firstRun['validator']->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame([0 => false], $rejection, 'The address is rejected on the first run.');
+        $this->assertSame(
+            [],
+            $this->batchStore($firstRun),
+            'A rejection may not be written to the SESSION store. Stored there it would outlive the '
+            . 'request, so a merchant who corrected the address or loosened the threshold would keep being '
+            . 'told "invalid" with no request made and no way to clear it - and, on a file whose rows '
+            . 'mostly fail, the FIFO bound would spend the whole store on rejections and re-bill the passes '
+            . 'it used to keep.'
+        );
+        $this->assertSame(
+            [],
+            $this->singleStore($firstRun),
+            'Nor to the single-address store, whose verdicts are judged against the AVC thresholds and not '
+            . 'the AQI: a rejection hidden there would be replayed by verifyAddress() at checkout.'
+        );
+
+        // The merchant loosens the threshold, or fixes the data: Loqate now accepts the address.
+        $this->apiVerdicts[$address['street'][0]] = 'pass';
+        $laterRun = $this->createRequest($firstRun['session']);
+        $reVerified = $laterRun['validator']->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame(
+            1,
+            $this->addressesBilled($laterRun),
+            'The later request must ASK Loqate again. Being billed one address per run for a row that keeps '
+            . 'failing is the accepted cost of never stranding a merchant on a stale rejection; it is also '
+            . 'what stops a rejection outliving the configuration it was judged under.'
+        );
+        $this->assertSame(
+            [0 => true],
+            $reVerified,
+            'And it must report the LIVE verdict, so the stale rejection can be seen not to have answered '
+            . 'the lookup rather than merely to have agreed with it.'
+        );
+    }
+
+    /**
+     * THE TRAP. A rejection reached because the AQI could not be READ is remembered NOWHERE -
+     * not in the session, and not for the rest of the run either - so the identical address is
+     * billed again, and a later readable answer for it is reported as it comes.
+     *
+     * This is the invariant a run-scoped memory of failures is most likely to break, and the
+     * damage is the opposite of a billing one: an unreadable response is a FAULT REPORT, not a
+     * verdict, and remembering it would let ONE connector fault, one credential problem or one
+     * "no match for this address" brand every matching row in the file invalid for the rest of
+     * the run - reported to the merchant as a row to go and fix, with nothing on the server
+     * saying otherwise.
+     *
+     * Both routes to an unreadable AQI are covered, because they arrive differently and a guard
+     * written for one misses the other: a row with no AQI in it at all (the '??' supplies null)
+     * and an AQI that is PRESENT but unreadable ('', false, int 0 - each of which compares as
+     * better than any letter grade under PHP 8's <= rules).
+     *
+     * The third batch is the load-bearing one: it proves no FALSE verdict was remembered, which
+     * an assertion about the billed count alone cannot distinguish from a rejection that was
+     * remembered and happened to be re-billed anyway.
+     *
+     * @param string $token $apiVerdicts token naming the unreadable answer to give.
+     */
+    #[DataProvider('unreadableAnswerProvider')]
+    public function testAnUnreadableQualityIndexIsRememberedNowhereSoTheRowIsBilledAgain(string $token): void
+    {
+        $address = $this->distinctAddress(1);
+        $this->apiVerdicts[$address['street'][0]] = $token;
+
+        $firstChunk = $this->request['validator']->verifyMultipleAddresses([$address], false);
+        $laterChunk = $this->request['validator']->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame([0 => false], $firstChunk, 'An AQI we could not read must still REJECT the row.');
+        $this->assertSame(
+            [0 => false],
+            $laterChunk,
+            'And it must reject it again on its own merits, not on a remembered one.'
+        );
+        $this->assertSame(
+            2,
+            $this->addressesBilled($this->request),
+            'The repeated row must be BILLED AGAIN. Remembering a rejection nobody could read - even only '
+            . 'for the rest of this run - is what would let ONE connector fault or one bad credential mark '
+            . 'every matching row in the file invalid, and the merchant would be sent to edit rows Loqate '
+            . 'never rejected. Paying for the retry is the cheaper mistake by a wide margin.'
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($this->request),
+            'Nothing may reach the session store either: NEVER REMEMBER A VERDICT WE COULD NOT READ has to '
+            . 'hold in ONE place, for both lifetimes, or the two rules drift apart and one of them is the '
+            . 'one that gets relaxed.'
+        );
+
+        // Loqate answers the third chunk readably, and PASSES the address.
+        $this->apiVerdicts[$address['street'][0]] = 'pass';
+        $afterTheFaultCleared = $this->request['validator']->verifyMultipleAddresses([$address], false);
+
+        $this->assertSame(
+            [0 => true],
+            $afterTheFaultCleared,
+            'Once Loqate answers readably the row must be reported VALID, in the SAME run. This is the '
+            . 'assertion a billed-count check cannot make: it fails if the unreadable rejection was '
+            . 'remembered at all, whatever it cost.'
+        );
+    }
+
+    /**
+     * The two families of unreadable answer, one data set each: a row with no readable AQI in
+     * it at all, and an AQI that is present but is not a grade.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function unreadableAnswerProvider(): array
+    {
+        $cases = [];
+        foreach (array_keys(self::UNREADABLE_ROW_SHAPES) as $token) {
+            $cases['response row is a ' . $token] = [$token];
+        }
+        foreach (array_keys(self::UNREADABLE_AQI_VALUES) as $token) {
+            $cases['AQI is ' . $token] = [$token];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * An UNREADABLE THRESHOLD rejects every row, and is remembered nowhere - so a repeated row
+     * is billed again.
+     *
+     * The threshold side of the same rule, and the one that is easier to get wrong, because the
+     * rejection LOOKS like a verdict: the response was perfectly readable, and the only
+     * unreadable thing is the merchant's own configuration. It is still not a verdict. A value
+     * nobody can read cannot be said to admit or refuse any address, so remembering the
+     * refusal would keep refusing rows after the configuration was corrected - within the run
+     * for the run-scoped memory, and for the whole session had it been stored there.
+     *
+     * 'E' is the AQI under test on purpose: the worst grade Loqate returns is the value that
+     * must never pass a threshold nobody can read, and a test using 'A' would still pass if the
+     * guard regressed to comparing against the shipped default.
+     *
+     * @param mixed $threshold Configured address_quality_index that cannot be read as a grade.
+     * @param string $why What this case protects, quoted into the failure message.
+     */
+    #[DataProvider('unreadableThresholdProvider')]
+    public function testAnUnreadableThresholdRejectsEveryRowAndIsRememberedNowhere(
+        $threshold,
+        string $why
+    ): void {
+        $request = $this->createRequest(
+            null,
+            new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => $threshold])),
+            static fn ($payload): array => array_map(
+                static fn (): array => [['AQI' => 'E', 'AVC' => self::CARRIED_AVC]],
+                (array)$payload['Addresses']
+            )
+        );
+        $rows = [$this->distinctAddress(1), $this->distinctAddress(2)];
+
+        $firstChunk = $request['validator']->verifyMultipleAddresses($rows, false);
+        $laterChunk = $request['validator']->verifyMultipleAddresses($rows, false);
+
+        $this->assertSame(
+            [false, false],
+            array_values($firstChunk),
+            sprintf(
+                'The worst AQI Loqate returns must not pass a threshold nobody can read; this case pins '
+                . 'that %s.',
+                $why
+            )
+        );
+        $this->assertSame(
+            [false, false],
+            array_values($laterChunk),
+            'The repeated rows must be rejected on their own answer, not on a remembered one.'
+        );
+        $this->assertSame(
+            4,
+            $this->addressesBilled($request),
+            'Both rows must be BILLED AGAIN in the later chunk. A rejection produced by a threshold we '
+            . 'could not read is a configuration fault report, not a verdict: remembered, it would keep '
+            . 'rejecting rows after the merchant corrected the setting, and it would do so for a whole '
+            . 'import run with no request made and nothing in the log for the rows after the first.'
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($request),
+            'And nothing may be written to the session store, where it would outlive the request entirely.'
+        );
+    }
+
+    /**
+     * Threshold values that cannot be read as a grade, and why each matters. Mirrors
+     * ValidatorBatchVerifyCacheTest's own provider: the three fail-OPEN cases are the point,
+     * each sorting above 'E' under the string comparison, and the rest are pinned so that
+     * staying closed is a rule rather than an accident of comparison semantics.
+     *
+     * @return array<string, array{0: mixed, 1: string}>
+     */
+    public static function unreadableThresholdProvider(): array
+    {
+        return [
+            "the fail-open case 'zzz'" => [
+                'zzz',
+                "'zzz' sorts above every grade, so 'E' <= 'zzz' is true and every address would pass",
+            ],
+            "a lowercase grade 'c'" => [
+                'c',
+                'lowercase sorts above uppercase in ASCII, so a plausible typo in a data patch loosens the '
+                . 'bar instead of tightening it',
+            ],
+            'an unset threshold' => [
+                null,
+                'a path never written to reads as null, which is the state a fresh install would be in if '
+                . 'etc/config.xml ever stopped supplying a default',
+            ],
+            'a numeric threshold' => [
+                3,
+                'an int is not a grade at all, and comparing a grade letter against an int is not a '
+                . 'comparison anyone reasoned about',
+            ],
+        ];
+    }
+
+    /**
+     * A batch whose every address is answered from a remembered verdict issues NO REQUEST AT
+     * ALL - not an empty one against a billable endpoint, and not one carrying the rows that
+     * were already decided.
+     *
+     * True today for passes; it must become true for the run-scoped rejections too, and it is
+     * the property that makes the saving real rather than notional. A chunk of an import file
+     * that repeats rows already decided earlier in the run is the common case on a file with
+     * duplicated addresses, and the cheapest possible handling of it is silence.
+     */
+    public function testAChunkAnsweredEntirelyFromRememberedVerdictsIssuesNoRequest(): void
+    {
+        $accepted = $this->distinctAddress(1);
+        $rejected = $this->distinctAddress(2);
+        $this->apiVerdicts[$rejected['street'][0]] = 'fail';
+
+        $this->request['validator']->verifyMultipleAddresses([$accepted, $rejected], false);
+        $this->assertSame(1, $this->apiCallCount($this->request), 'The first chunk is verified normally.');
+
+        $repeatChunk = $this->request['validator']->verifyMultipleAddresses([$rejected, $accepted], false);
+
+        $this->assertSame(
+            1,
+            $this->apiCallCount($this->request),
+            'A chunk in which every row is already decided must issue NO further request. Sending the '
+            . 'decided rows again bills them again; sending an empty \'Addresses\' payload to a billable '
+            . 'endpoint and discarding the answer is worse still.'
+        );
+        $this->assertSame(
+            [0 => false, 1 => true],
+            $repeatChunk,
+            'And it must answer every row, under its own key and in input order, without asking anyone: a '
+            . 'chunk that returns fewer rows than it was given renumbers every row after it in '
+            . 'Plugin\Admin\ValidateImportAddress\'s merged result.'
+        );
+    }
+
+    /**
+     * A PASSING address evicted from the bounded session store is still not re-billed later in
+     * the SAME run.
+     *
+     * This is the other half of "a file larger than the limit", and the one the session store
+     * structurally cannot deliver: eviction is FIFO and the store is bounded, so on a file
+     * bigger than the bound the rows verified early are gone before the file ends. Raising the
+     * constant does not fix that - it is inherent to FIFO over a working set larger than the
+     * cache - and this is why the run-scoped memory has to hold BOTH polarities rather than
+     * only the rejections the session store never held.
+     *
+     * The eviction is asserted, not assumed: if the fill stopped evicting, the replay below
+     * would be a session hit and this test would silently be measuring the old cache.
+     */
+    public function testAPassEvictedFromTheSessionStoreIsNotRebilledLaterInTheSameRun(): void
+    {
+        $limit = $this->batchCacheLimit();
+        $earlyRow = $this->addressOnStreet('Evicted Pass Lane');
+
+        $this->request['validator']->verifyMultipleAddresses([$earlyRow], false);
+        $this->assertSame(1, $this->addressesBilled($this->request), 'The early row is verified and billed.');
+
+        $filler = [];
+        for ($i = 1; $i <= $limit; $i++) {
+            $filler[] = $this->distinctAddress($i);
+        }
+        $this->request['validator']->verifyMultipleAddresses($filler, false);
+
+        $streetsStillCached = implode(' ', array_keys($this->batchStore($this->request)));
+        $this->assertStringNotContainsString(
+            'EVICTED PASS LANE',
+            $streetsStillCached,
+            'Fixture precondition: the early row\'s verdict must have been EVICTED from the session store '
+            . 'by the rows that followed it, or the replay below would be answered by that store and this '
+            . 'test would prove nothing about a file larger than the bound.'
+        );
+
+        $replay = $this->request['validator']->verifyMultipleAddresses([$earlyRow], false);
+
+        $this->assertSame(
+            1 + $limit,
+            $this->addressesBilled($this->request),
+            'The evicted row must NOT be billed again inside the same run. FIFO eviction over a file larger '
+            . 'than the bound is exactly where the session store stops paying for itself, and it is why the '
+            . 'run-scoped memory has to remember passes as well as rejections.'
+        );
+        $this->assertSame([0 => true], $replay, 'And it must still be reported with the verdict it earned.');
+    }
+
+    /**
+     * Every address quality index a merchant can SELECT in the admin form must be a threshold
+     * the verifier actually accepts addresses against - so no selectable value can silently
+     * reject every address in the file.
+     *
+     * The list is read from the admin field's own source model rather than written out here,
+     * because that is the artefact that decides what the merchant is offered (LOQ-17148 design
+     * note D4 exposes the field with this source model). The set-level correspondence with the
+     * verifier's accepted values is asserted in
+     * Test\Unit\Model\Config\Source\AddressQualityIndexTest; this is the BEHAVIOURAL half - the
+     * option is put in the configuration, an address at exactly that grade is verified, and the
+     * verdict is read off the wire.
+     *
+     * Equality is the grade under test on purpose: it is the boundary of the <= comparison and
+     * the case the shipped default 'A' actually runs, since 'A' is the strongest grade there is
+     * and nothing beats it.
+     *
+     * @param string $threshold One value of the admin field's option list.
+     */
+    #[DataProvider('selectableQualityIndexProvider')]
+    public function testEverySelectableQualityIndexThresholdAcceptsAnAddressAtThatGrade(string $threshold): void
+    {
+        $request = $this->createRequest(
+            null,
+            new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => $threshold])),
+            static fn ($payload): array => array_map(
+                static fn (): array => [['AQI' => $threshold, 'AVC' => self::CARRIED_AVC]],
+                (array)$payload['Addresses']
+            )
+        );
+
+        $verdicts = $request['validator']->verifyMultipleAddresses([$this->distinctAddress(1)], false);
+
+        $this->assertSame(
+            [0 => true],
+            $verdicts,
+            sprintf(
+                'A merchant who selects "%s" in the admin form must get a threshold that ACCEPTS an address '
+                . 'graded "%s". A selectable value the verifier rejects everything under is worse than an '
+                . 'unexposed setting: the merchant configures a quality bar, every import row comes back '
+                . 'invalid, and nothing anywhere says the value itself is the problem.',
+                $threshold,
+                $threshold
+            )
+        );
+        $this->assertCount(
+            1,
+            $this->batchStore($request),
+            'And the pass must be cacheable under that threshold: a value that verifies but never caches '
+            . 'would re-bill every row of every run on that store view.'
+        );
+    }
+
+    /**
+     * The address quality indexes the admin field offers, one data set each, read from the
+     * source model the field is wired to.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function selectableQualityIndexProvider(): array
+    {
+        $cases = [];
+        foreach ((new AddressQualityIndex())->toOptionArray() as $option) {
+            $value = (string)($option['value'] ?? '');
+            $cases['the selectable threshold ' . var_export($value, true)] = [$value];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * Verify a whole import file the way Plugin\Admin\ValidateImportAddress::afterValidateData()
+     * does: chunked at self::IMPORT_CHUNK_SIZE and array_merge()d, on ONE Validator - which is
+     * what makes it one run.
+     *
+     * The merge is the plugin's own, deliberately: it renumbers integer keys BY INSERTION
+     * ORDER, so a chunk that comes back short or out of order shows up here as a shifted row
+     * exactly as it would in the merchant's import report.
+     *
+     * @param array $request Request harness from createRequest().
+     * @param int[] $fileIds distinctAddress() indexes, one per file row, in file order.
+     * @return array<int, bool> Merged verdicts, keyed by 0-based file row.
+     */
+    private function verifyFileInChunks(array $request, array $fileIds): array
+    {
+        $merged = [];
+        foreach (array_chunk($fileIds, self::IMPORT_CHUNK_SIZE) as $position => $chunk) {
+            $verdicts = $request['validator']->verifyMultipleAddresses(
+                array_map(fn (int $id): array => $this->distinctAddress($id), $chunk),
+                false
+            );
+
+            $this->assertIsArray(
+                $verdicts,
+                sprintf(
+                    'Chunk #%d must come back as a verdict array. false means the request failed or its row '
+                    . 'count could not be attributed, and neither is what this fixture asked for.',
+                    $position + 1
+                )
+            );
+            $this->assertSame(
+                range(0, count($chunk) - 1),
+                array_keys($verdicts),
+                sprintf(
+                    'Chunk #%d must answer every row it was given, keyed 0..N-1 in input order. That is the '
+                    . 'guarantee the merge below rests on: array_merge() renumbers by insertion order, so a '
+                    . 'missing or out-of-order slot mis-attributes every later row number.',
+                    $position + 1
+                )
+            );
+
+            $merged = array_merge($merged, $verdicts);
+        }
+
+        return $merged;
+    }
+
+    /**
+     * The import file of the headline measurement, as distinctAddress() indexes in file order:
+     * three chunks, repeats ACROSS chunk boundaries only.
+     *
+     * Chunk 1 introduces 100 addresses. Chunk 2 repeats 40 of them and introduces 60 more.
+     * Chunk 3 repeats 10 of chunk 1's a THIRD time and introduces 50 more. 260 rows, 210
+     * distinct - more than the session store's bound, which is the size at which that store
+     * stops helping.
+     *
+     * @return int[]
+     */
+    private function crossChunkRepeatFileIds(): array
+    {
+        return array_merge(
+            range(1, 100),
+            array_merge(range(1, 40), range(101, 160)),
+            array_merge(range(1, 10), range(161, 210))
+        );
+    }
+
+    /**
+     * The addresses of that file Loqate REJECTS: exactly the ones that repeat across chunks.
+     *
+     * Repeats have to be the rejections for this fixture to measure anything - a repeated PASS
+     * was already deduped by the session store before LOQ-17148 - and it is also the realistic
+     * shape, since etc/config.xml ships the strictest grade as the threshold.
+     *
+     * @return int[]
+     */
+    private function rejectedFileIds(): array
+    {
+        return range(1, 40);
+    }
+
+    /**
+     * Assert the headline fixture is the shape its measurement needs, so a green run cannot
+     * come from a file that quietly stopped exercising the case.
+     *
+     * @param int[] $fileIds distinctAddress() indexes in file order.
+     * @param int[] $rejectedIds Indexes Loqate rejects.
+     * @param int $limit Validator::BATCH_VERIFY_CACHE_LIMIT.
+     * @return void
+     */
+    private function assertFileRepeatsOnlyAcrossChunks(array $fileIds, array $rejectedIds, int $limit): void
+    {
+        $this->assertGreaterThan(
+            $limit,
+            count(array_unique($fileIds)),
+            'The file must hold MORE distinct addresses than the session store can, or the measurement '
+            . 'below could be met by the bounded cache that was already there and would say nothing about '
+            . 'a file the size of a real import.'
+        );
+
+        $repeatedAcrossChunks = [];
+        foreach (array_chunk($fileIds, self::IMPORT_CHUNK_SIZE) as $position => $chunk) {
+            $this->assertSame(
+                count($chunk),
+                count(array_unique($chunk)),
+                sprintf(
+                    'Chunk #%d must not repeat an address WITHIN itself. Two copies in one batch are both '
+                    . 'sent - nothing is written until the response comes back - which is LOQ-17015 and its '
+                    . 'own arithmetic, so including one here would make this measurement unmeetable for a '
+                    . 'reason LOQ-17148 is not about.',
+                    $position + 1
+                )
+            );
+
+            if ($position > 0) {
+                $repeatedAcrossChunks = array_merge(
+                    $repeatedAcrossChunks,
+                    array_intersect($chunk, array_slice($fileIds, 0, $position * self::IMPORT_CHUNK_SIZE))
+                );
+            }
+        }
+
+        $this->assertNotSame(
+            [],
+            $repeatedAcrossChunks,
+            'The file must actually repeat addresses across chunk boundaries, or there is nothing to '
+            . 'de-duplicate and the measurement is trivially satisfied.'
+        );
+        $this->assertSame(
+            [],
+            array_values(array_diff(array_unique($repeatedAcrossChunks), $rejectedIds)),
+            'Every cross-chunk repeat must be an address Loqate REJECTS. A repeated pass was already '
+            . 'deduped by the session store before LOQ-17148, so a fixture whose repeats pass would go '
+            . 'green against the unfixed code.'
+        );
+    }
+
+    /**
+     * Build one independent "request": a Validator wired to its own billable connector mock,
+     * its own live store configuration and a session double that actually retains data.
+     *
+     * ONE Validator IS ONE REQUEST, and that is the whole point of this harness: the import
+     * chunk loop in Plugin\Admin\ValidateImportAddress::afterValidateData() calls
+     * verifyMultipleAddresses() several times on one instance, so several calls on one harness
+     * model one run, and a second harness over the SAME session models a later request.
+     *
+     * Modelled on ValidatorBatchVerifyCacheTest::createShopper() and kept deliberately similar,
+     * since the two classes' results are read against each other.
+     *
+     * @param ArrayObject|null $session Session backing store to reuse, or null for a new session.
+     * @param ArrayObject|null $config Live store configuration, config path => value.
+     * @param callable|null $respond Replacement connector response builder, given the payload.
+     * @return array{validator: Validator, connector: Verify&MockObject, requests: ArrayObject,
+     *     session: ArrayObject, config: ArrayObject}
+     */
+    private function createRequest(
+        ?ArrayObject $session = null,
+        ?ArrayObject $config = null,
+        ?callable $respond = null
+    ): array {
+        $sessionStore = $session ?? new ArrayObject();
+        $requests = new ArrayObject();
+        $configStore = $config ?? new ArrayObject(self::configWith([]));
+
+        $logger = $this->createMock(Logger::class);
+
+        // The shared Test/stubs Session is a no-op (getData() returns null, setData() stores
+        // nothing), so nothing could ever survive between calls and every "is this remembered"
+        // assertion would pass for the wrong reason. This double retains data in $sessionStore,
+        // which also lets the tests read the cache attributes directly. getData()/setData() have
+        // to be *added* when the real Magento\Customer\Model\Session is present, because it does
+        // not declare them (SessionManager __call-forwards them to Session\Storage); the
+        // Test/stubs Session does declare them, and PHPUnit refuses to "add" an existing method
+        // - hence the method_exists() filter, which keeps this double working on both sides.
+        $sessionBuilder = $this->getMockBuilder(Session::class)->disableOriginalConstructor();
+        $undeclared = array_values(array_filter(
+            ['getData', 'setData'],
+            static fn (string $method): bool => !method_exists(Session::class, $method)
+        ));
+        if ($undeclared) {
+            $sessionBuilder->addMethods($undeclared);
+        }
+        $sessionMock = $sessionBuilder->getMock();
+        $sessionMock->method('getData')->willReturnCallback(
+            static function ($key = '', $clear = false) use ($sessionStore) {
+                return $sessionStore[$key] ?? null;
+            }
+        );
+        $sessionMock->method('setData')->willReturnCallback(
+            static function ($key, $value = null) use ($sessionStore, $sessionMock) {
+                $sessionStore[$key] = $value;
+
+                return $sessionMock;
+            }
+        );
+
+        // No fixture here uses region_id, but parseAddress() resolves one through RegionFactory,
+        // so the factory must not return null if one ever grows one.
+        $regionFactory = $this->createMock(RegionFactory::class);
+        $regionFactory->method('create')->willReturnCallback(
+            static function () {
+                return new class {
+                    public function load($regionId)
+                    {
+                        return $this;
+                    }
+
+                    public function getName()
+                    {
+                        return '';
+                    }
+                };
+            }
+        );
+
+        $moduleList = $this->createMock(ModuleListInterface::class);
+        $moduleList->method('getOne')->willReturn(['setup_version' => '9.9.9']);
+
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturnCallback(
+            static function ($configPath) use ($configStore) {
+                // A non-empty API key is required twice: the constructor only builds the
+                // connector when it is set, and verifyMultipleAddresses() short-circuits with
+                // noKeyFound when it is not.
+                if ($configPath === 'loqate_settings/settings/api_key') {
+                    return self::API_KEY;
+                }
+
+                return $configStore->offsetExists($configPath) ? $configStore[$configPath] : '';
+            }
+        );
+        // Verdicts are namespaced per store view, because the AQI threshold behind them is read
+        // at SCOPE_STORE. Stubbed explicitly: getCurrentStore() is declared int, so an unstubbed
+        // mock returns 0 anyway, but relying on that hides which scope a key was built for.
+        $helper->method('getCurrentStore')->willReturn(0);
+
+        // Fails the way the PRODUCTION serializer fails.
+        // Magento\Framework\Serialize\Serializer\Json::unserialize() THROWS
+        // \InvalidArgumentException on anything it cannot decode - the empty string and null
+        // included - rather than answering null. A lenient `fn ($v) => json_decode($v, true)`
+        // double makes getCachedBatchVerifyResult()'s catch block unreachable from the harness,
+        // so an import meeting a truncated session payload would fatal in production while this
+        // file stayed green. Mirrors CapturedAddressStoreTest::createSerializerDouble() and
+        // ValidatorBatchVerifyCacheTest::createSerializerDouble().
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
+        $serializer->method('unserialize')->willReturnCallback(
+            static function ($value) {
+                if ($value === false || $value === null || $value === '') {
+                    throw new \InvalidArgumentException('Unable to unserialize value.');
+                }
+
+                $decoded = json_decode($value, true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    throw new \InvalidArgumentException('Unable to unserialize value, string is corrupted.');
+                }
+
+                return $decoded;
+            }
+        );
+
+        $validator = new Validator($logger, $sessionMock, $regionFactory, $moduleList, $helper, $serializer);
+
+        // The connector is built inside the constructor (new Verify($apiKey)), so the only way
+        // to intercept the billable call is to swap the private property afterwards.
+        $connector = $this->createMock(Verify::class);
+        $connector->method('verifyAddress')->willReturnCallback(
+            function ($payload) use ($requests, $respond) {
+                $requests[] = $payload;
+
+                if ($respond !== null) {
+                    return $respond($payload);
+                }
+
+                // One row per address SENT, in the order they were sent: that positional
+                // correspondence is what the production code attributes verdicts by, and it is
+                // how the Cleansing API answers a batch.
+                $rows = [];
+                foreach ((array)($payload['Addresses'] ?? []) as $address) {
+                    $rows[] = $this->responseRowFor((array)$address);
+                }
+
+                return $rows;
+            }
+        );
+        $reflection = new ReflectionProperty(Validator::class, 'apiConnector');
+        $reflection->setAccessible(true);
+        $reflection->setValue($validator, $connector);
+
+        return [
+            'validator' => $validator,
+            'connector' => $connector,
+            'requests' => $requests,
+            'session' => $sessionStore,
+            'config' => $configStore,
+        ];
+    }
+
+    /**
+     * What the API answers for one parsed address, in the shape verifyMultipleAddresses() reads:
+     * $response[$n][0]['AQI'].
+     *
+     * The return type is deliberately left off rather than declared array: the connector's
+     * array_column($response, 'Matches') emits whatever each record's 'Matches' held, so a row
+     * can legitimately arrive as null or as [].
+     *
+     * @param array $address One entry of the payload's 'Addresses' list.
+     * @return mixed One response row.
+     */
+    private function responseRowFor(array $address)
+    {
+        $verdict = $this->apiVerdicts[(string)($address['Address1'] ?? '')] ?? 'pass';
+
+        if (array_key_exists($verdict, self::UNREADABLE_ROW_SHAPES)) {
+            return self::UNREADABLE_ROW_SHAPES[$verdict];
+        }
+
+        if (array_key_exists($verdict, self::UNREADABLE_AQI_VALUES)) {
+            return [[
+                'AQI' => self::UNREADABLE_AQI_VALUES[$verdict],
+                'AVC' => self::CARRIED_AVC,
+            ]];
+        }
+
+        return [[
+            'AQI' => $verdict === 'fail' ? self::FAILING_AQI : self::PASSING_AQI,
+            'AVC' => self::CARRIED_AVC,
+        ]];
+    }
+
+    /** A unique, fully-formed import row per index. */
+    private function distinctAddress(int $index): array
+    {
+        return [
+            'street' => [$index . ' Test Street'],
+            'city' => 'London',
+            'region' => 'Greater London',
+            'postcode' => 'SW1A ' . $index . 'AA',
+            'country_id' => 'GB',
+        ];
+    }
+
+    /**
+     * An import row on a named street, for the one test that has to recognise its address
+     * inside a cache key: distinctAddress()' streets are numeric prefixes of one another
+     * ('1 Test Street' is a substring of '11 Test Street'), so they cannot be searched for.
+     *
+     * @param string $street Street line, unique among the fixtures it is used with.
+     * @return array Magento-shaped address.
+     */
+    private function addressOnStreet(string $street): array
+    {
+        return [
+            'street' => [$street],
+            'city' => 'London',
+            'region' => 'Greater London',
+            'postcode' => 'SW1A 9ZZ',
+            'country_id' => 'GB',
+        ];
+    }
+
+    /**
+     * Store configuration for these tests: the AQI threshold every batch verdict is judged
+     * against, plus whatever else a test cares about.
+     *
+     * @param array<string, mixed> $overrides Config path => value.
+     * @return array<string, mixed>
+     */
+    private static function configWith(array $overrides): array
+    {
+        return array_merge([self::AQI_CONFIG_PATH => self::AQI_THRESHOLD], $overrides);
+    }
+
+    /**
+     * Number of ADDRESSES a request put on the invoice: the Cleansing API is billed per
+     * address, not per request, so this - and not the request count - is what LOQ-17148 has to
+     * reduce.
+     *
+     * @param array $request Request harness from createRequest().
+     * @return int
+     */
+    private function addressesBilled(array $request): int
+    {
+        return count($this->streetsBilled($request));
+    }
+
+    /**
+     * The first street line of every address a request sent to the billable endpoint, in order:
+     * one entry per billed address, so a repeat is visible as a repeat rather than only as a
+     * total.
+     *
+     * @param array $request Request harness from createRequest().
+     * @return string[]
+     */
+    private function streetsBilled(array $request): array
+    {
+        $streets = [];
+        foreach ($request['requests'] as $payload) {
+            foreach ((array)($payload['Addresses'] ?? []) as $address) {
+                $streets[] = (string)(((array)$address)['Address1'] ?? '');
+            }
+        }
+
+        return $streets;
+    }
+
+    /** Number of billable Loqate Cleansing requests a request harness issued. */
+    private function apiCallCount(array $request): int
+    {
+        return count($request['requests']);
+    }
+
+    /** The BATCH verdict cache as currently held in a request's session. */
+    private function batchStore(array $request): array
+    {
+        $store = $request['session'][self::BATCH_VERIFY_CACHE_SESSION_KEY] ?? [];
+
+        return is_array($store) ? $store : [];
+    }
+
+    /** The SINGLE-address verdict cache as currently held in a request's session. */
+    private function singleStore(array $request): array
+    {
+        $store = $request['session'][self::VERIFY_CACHE_SESSION_KEY] ?? [];
+
+        return is_array($store) ? $store : [];
+    }
+
+    /**
+     * Validator::BATCH_VERIFY_CACHE_LIMIT, read from the production class rather than mirrored,
+     * because these tests are about what happens on a file LARGER than it: a mirrored literal
+     * that drifted would leave them measuring the easy case instead.
+     *
+     * @return int
+     */
+    private function batchCacheLimit(): int
+    {
+        $reflection = new ReflectionClass(Validator::class);
+        if (!$reflection->hasConstant('BATCH_VERIFY_CACHE_LIMIT')) {
+            $this->fail(
+                'Validator::BATCH_VERIFY_CACHE_LIMIT is not defined: the session verdict store must be '
+                . 'bounded, or an import can inflate the customer session without limit.'
+            );
+        }
+
+        return (int)$reflection->getConstant('BATCH_VERIFY_CACHE_LIMIT');
+    }
+}

--- a/Test/Unit/Helper/ValidatorImportRunDedupeTest.php
+++ b/Test/Unit/Helper/ValidatorImportRunDedupeTest.php
@@ -7,6 +7,7 @@ use Loqate\ApiIntegration\Helper\Data;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
 use Loqate\ApiIntegration\Model\Config\Source\AddressQualityIndex;
+use Loqate\ApiIntegration\Plugin\Admin\ValidateImportAddress;
 use Loqate\ApiIntegration\Test\Support\ProductionSerializerDouble;
 use Magento\Customer\Model\Session;
 use Magento\Directory\Model\RegionFactory;
@@ -123,9 +124,14 @@ class ValidatorImportRunDedupeTest extends TestCase
 
     /**
      * Rows per verification batch, as Plugin\Admin\ValidateImportAddress::afterValidateData()
-     * chunks an import file. Mirrored rather than read from the plugin because it is a literal
-     * there; if the plugin ever chunks differently, this test's file layout is what has to be
-     * re-thought, so it should fail loudly rather than follow along.
+     * chunks an import file, and the size every fixture in this file is laid out around: the
+     * headline file's three chunks and its "repeats across chunk boundaries only" precondition are
+     * both arithmetic on this number.
+     *
+     * It is NOT the authority for that number - importChunkSize() reads the plugin's own literal,
+     * and fails the test if the two ever disagree. Written here as well because the layouts above
+     * cannot follow a change silently: if the plugin chunks differently, the fixtures have to be
+     * re-thought by a person, so the divergence must stop the suite rather than quietly re-scale it.
      */
     private const IMPORT_CHUNK_SIZE = 100;
 
@@ -599,12 +605,19 @@ class ValidatorImportRunDedupeTest extends TestCase
      *
      * EXACTLY ONE LINE PER BATCH, which is a frequency and not just a presence. Zero would leave
      * the merchant with a whole file of "Invalid address at row #N" and nothing anywhere saying
-     * their own setting refused it - the failure this line exists to prevent. One per ROW would
-     * bury it: a 100-row chunk would write 100 identical lines and a 10,000-row file 10,000, so
-     * the signal is lost in its own volume and the log costs real money to ship. The line is
-     * asserted BYTE FOR BYTE, because it is a merchant-facing artefact that support reads out of
-     * a log file: rewording it is a decision to make deliberately, which means updating this
-     * expectation, not one to have absorbed by a test matching a fragment.
+     * their own setting is a bar no address can clear - the failure this line exists to prevent.
+     * One per ROW would bury it: a 100-row chunk would write 100 identical lines and a 10,000-row
+     * file 10,000, so the signal is lost in its own volume and the log costs real money to ship.
+     * The line is asserted BYTE FOR BYTE, because it is a merchant-facing artefact that support
+     * reads out of a log file: rewording it is a decision to make deliberately, which means
+     * updating this expectation, not one to have absorbed by a test matching a fragment.
+     *
+     * WHAT THE LINE MAY NOT SAY, and why the wording moved. It used to end "rejecting the
+     * address", which the response-side caller could say truthfully and this pre-flight cannot:
+     * the threshold is read ONCE PER BATCH before any row is decided, so on a batch that refuses
+     * nothing the line named an outcome that never happened and sent support looking for refused
+     * rows that do not exist. It now reports only the configuration. That batch is pinned by
+     * testAnAllCapturedBatchUnderAnUnreadableThresholdStillReportsTheConfigurationOnce().
      *
      * @param mixed $threshold Configured address_quality_index that cannot be read as a grade.
      * @param string $why What this case protects, quoted into the failure message.
@@ -645,9 +658,10 @@ class ValidatorImportRunDedupeTest extends TestCase
             [$this->expectedBrokenThresholdLine($threshold)],
             $this->thresholdLogLines($request),
             'ONE line, and this exact line. It is the only signal a merchant has that their own quality '
-            . 'bar - not their data - is what refused the file, so it must name the offending value and '
-            . 'its type and say what the accepted values are. Zero lines is the defect this replaces; one '
-            . 'per ROW would bury the signal under a line per import row.'
+            . 'bar - not their data - is a bar nothing can clear, so it must name the offending value and '
+            . 'its type and say what the accepted values are, and it must claim no more than that. Zero '
+            . 'lines is the defect this replaces; one per ROW would bury the signal under a line per '
+            . 'import row.'
         );
 
         $request['validator']->verifyMultipleAddresses($rows, false);
@@ -737,6 +751,12 @@ class ValidatorImportRunDedupeTest extends TestCase
      * The mixed batch is what makes it a deviation rather than a special case: the captured row
      * passes and the typed row beside it is refused, in ONE call, so the guard demonstrably runs
      * per row and after the short-circuit rather than as a whole-batch bail-out.
+     *
+     * BEING MIXED IS ALSO ITS LIMIT, which is why it has a sibling. One row IS refused here, so
+     * this fixture cannot see anything the broken-threshold log line claims about refusals - the
+     * retired "rejecting the address" wording was accidentally true on exactly this batch. The
+     * all-captured batch, where the line fires with nothing refused at all, is pinned by
+     * testAnAllCapturedBatchUnderAnUnreadableThresholdStillReportsTheConfigurationOnce().
      */
     public function testACapturedAddressStillPassesUnderAnUnreadableThresholdAndStillCostsNoRequest(): void
     {
@@ -779,6 +799,95 @@ class ValidatorImportRunDedupeTest extends TestCase
             $this->batchStore($request),
             'Nor is the captured pass written to the verdict store: it is not a verdict, it is a bypass, '
             . 'and it is keyed under a threshold nobody can read.'
+        );
+    }
+
+    /**
+     * A batch whose EVERY row is a captured address, under an unreadable threshold: every row
+     * passes, nothing is bought - and the broken-quality-bar line is written anyway, saying only
+     * what the configuration is.
+     *
+     * THE CASE THAT PRODUCED THE REWORD, and the reason it is pinned in its own fixture rather
+     * than left to
+     * testACapturedAddressStillPassesUnderAnUnreadableThresholdAndStillCostsNoRequest(): that
+     * batch is MIXED, so one row IS refused there and the retired sentence "rejecting the address"
+     * was accidentally true. Here nothing is refused at all, and the old wording named an outcome
+     * that never happened - support would go looking for refused rows that do not exist.
+     *
+     * THE LINE IS A CONFIGURATION REPORT, WHICH IS WHY ITS PRESENCE IS ASSERTED INDEPENDENTLY OF
+     * THE REFUSAL COUNT. Read quickly, "zero rejections, one warning" looks like the bug rather
+     * than the fix. It is the fix: the threshold pre-flight reads the setting ONCE PER BATCH,
+     * before any row is decided, and a merchant whose quality bar cannot be read needs to be told
+     * so on every batch that ran under it - not only on the batches that happened to contain a row
+     * the fault could bite. Both halves are therefore asserted together and neither is derived
+     * from the other: [true, true] AND exactly one line.
+     *
+     * IT IS ALSO THE FIXTURE THAT FAILS IF THE LINE IS EVER MADE CONDITIONAL on at least one row
+     * having been refused - the alternative fix the coder rejected. That would make a
+     * CONFIGURATION diagnostic depend on the composition of whatever batch happened to run, and on
+     * this path specifically on the shopper's captured-address session: an admin creating an order
+     * entirely from Loqate-picked addresses would silence the only signal their setting is broken,
+     * and it would stay silent until an uncaptured row happened along. Same hole as the
+     * all-empty-'Matches' file this branch closed, through a different door.
+     *
+     * The negative assertion on 'rejecting the address' is deliberately cheap and deliberately
+     * redundant with the byte-for-byte expectation: a future edit that loosens the exact-match
+     * helper - for a grade list change, say - must not also quietly re-admit a sentence that
+     * claims a refusal nobody made.
+     */
+    public function testAnAllCapturedBatchUnderAnUnreadableThresholdStillReportsTheConfigurationOnce(): void
+    {
+        $firstCaptured = $this->distinctAddress(1);
+        $secondCaptured = $this->distinctAddress(2);
+
+        $request = $this->createRequest(
+            null,
+            new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => 'zzz'])),
+            static fn ($payload): array => array_map(
+                static fn (): array => [['AQI' => 'E', 'AVC' => self::CARRIED_AVC]],
+                (array)$payload['Addresses']
+            )
+        );
+        $request['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = [
+            self::capturedEntry($firstCaptured),
+            self::capturedEntry($secondCaptured),
+        ];
+
+        $verdicts = $request['validator']->verifyMultipleAddresses(
+            [$firstCaptured, $secondCaptured],
+            true
+        );
+
+        $this->assertSame(
+            [true, true],
+            array_values($verdicts),
+            'Fixture precondition AND guarantee in one: EVERY row of this batch is a captured address, so '
+            . 'the captured short-circuit answers all of them and the threshold guard refuses NOTHING. If '
+            . 'this ever reads [false, false] the pre-flight has moved ahead of the captured guard, and a '
+            . 'mis-set dropdown has become a total block of every address picked from the Loqate lookup.'
+        );
+        $this->assertSame(
+            0,
+            $this->apiCallCount($request),
+            'And nothing is bought: captured rows need no verification, so there is no payload to assemble '
+            . 'and no round trip to pay for.'
+        );
+        $this->assertSame(
+            [$this->expectedBrokenThresholdLine('zzz')],
+            $this->thresholdLogLines($request),
+            'The broken quality bar is STILL reported, exactly once, on a batch where not one row was '
+            . 'refused. This is not "a warning with nothing behind it": the line reports the CONFIGURATION, '
+            . 'which is broken whatever this batch contained, and making it conditional on a refusal would '
+            . 'silence it for an admin who creates orders entirely from Loqate-picked addresses - until '
+            . 'some later row that is not captured finally surfaces a fault that was there all along.'
+        );
+        $this->assertStringNotContainsString(
+            'rejecting the address',
+            implode("\n", $this->thresholdLogLines($request)),
+            'And it may not claim a refusal that did not happen. This clause is what the line used to end '
+            . 'with, and on THIS batch it was simply false - zero rows were rejected. Asserted separately '
+            . 'from the exact-match expectation above on purpose: reverting the wording has to fail loudly '
+            . 'here too, rather than only through a byte-for-byte helper a later edit might loosen.'
         );
     }
 
@@ -829,8 +938,10 @@ class ValidatorImportRunDedupeTest extends TestCase
             'Read off the WIRE: all THREE copies of each address really were sent, in row order. Nothing '
             . 'is written to either memory until the response comes back, and the pre-flight loop runs to '
             . 'completion over the whole chunk before the request is issued, so every copy misses. That is '
-            . 'LOQ-17015, and its bound is the CHUNK SIZE - 100 identical rows in one chunk bill 100 - not '
-            . 'one charge per distinct address, which is what an earlier revision of this claim said.'
+            . 'LOQ-17015, and its bound is the CHUNK SIZE - not one charge per distinct address, which is '
+            . 'what an earlier revision of this claim said. The bound AT the chunk size is executed, not '
+            . 'argued, by '
+            . 'testAFullChunkOfOneAddressIsBilledOncePerRowAndTheChunkAfterItIsFree().'
         );
         $this->assertSame(
             [true, true, true, false, false, false],
@@ -860,6 +971,118 @@ class ValidatorImportRunDedupeTest extends TestCase
             array_values($laterChunk),
             'The replayed chunk must report the same verdicts under its own keys, including the rejections: '
             . 'a de-duplicated row that loses its slot renumbers every import row after it.'
+        );
+    }
+
+    /**
+     * THE LOQ-17015 RESIDUE BOUND AT ITS WORST CASE: a chunk that is nothing but copies of ONE
+     * address, as many as the import plugin will ever put in one batch, bills one address PER ROW
+     * - and the identical chunk after it bills nothing.
+     *
+     * WHY THIS EXISTS BESIDE THE THREE-COPY TEST ABOVE. That one proves the SHAPE of the bound
+     * ("k copies cost k" rather than "the first copy plus one") on a cheap fixture. It does not
+     * prove the SIZE, and the size is the part of the claim that costs money: the published bound
+     * says "a chunk of 100 identical rows bills 100", and a suite that only ever runs k=3 leaves
+     * the strongest sentence in the documentation argued rather than executed. That is precisely
+     * how this series shipped a bound that was wrong by 99x - the two-copy case was probed,
+     * generalised to all n in prose, and disproved by execution twice. So the worst case now runs.
+     *
+     * THE k IS THE CHUNK SIZE ITSELF, READ FROM THE PLUGIN, not a literal repeated here. See
+     * importChunkSize(): it takes the number out of
+     * Plugin\Admin\ValidateImportAddress::afterValidateData()'s own array_chunk() call, so this
+     * test measures the batch production actually assembles. A mirrored literal drifting away from
+     * the plugin would leave the worst case unmeasured while looking measured, which is the same
+     * failure mode as describing it in prose.
+     *
+     * BOTH POLARITIES, ONE FULL-SIZE CHUNK EACH, rather than a half-and-half chunk: an accepted
+     * address is remembered in both memories and a rejected one only in the run map, so a dedupe
+     * that collapsed copies for one polarity and not the other must fail here too - but splitting
+     * a single chunk between them would pin k at half the chunk size and stop measuring the worst
+     * case, which is the whole point of this fixture.
+     *
+     * THE WIRE CONTENTS ARE ASSERTED, not just the count. A count says the right number of
+     * addresses was billed; the street list in row order says the right ADDRESSES were, in the
+     * order the response has to be attributed back to. That is what makes this stronger than a
+     * counter, and it is what would catch a dedupe that sent k copies of the wrong row.
+     */
+    public function testAFullChunkOfOneAddressIsBilledOncePerRowAndTheChunkAfterItIsFree(): void
+    {
+        $chunkSize = $this->importChunkSize();
+        $accepted = $this->distinctAddress(1);
+        $rejected = $this->distinctAddress(2);
+        $this->apiVerdicts[$rejected['street'][0]] = 'fail';
+
+        $acceptedChunk = array_fill(0, $chunkSize, $accepted);
+        $rejectedChunk = array_fill(0, $chunkSize, $rejected);
+
+        $firstAcceptedChunk = $this->request['validator']->verifyMultipleAddresses($acceptedChunk, false);
+        $firstRejectedChunk = $this->request['validator']->verifyMultipleAddresses($rejectedChunk, false);
+
+        $this->assertSame(
+            array_merge(
+                array_fill(0, $chunkSize, $accepted['street'][0]),
+                array_fill(0, $chunkSize, $rejected['street'][0])
+            ),
+            $this->streetsBilled($this->request),
+            sprintf(
+                'Read off the WIRE at FULL CHUNK SIZE: a chunk of %1$d identical rows bills %1$d addresses, '
+                . 'in row order, for each polarity. Nothing is written to either memory until the response '
+                . 'comes back and the pre-flight loop runs to completion before the request is issued, so '
+                . 'every copy misses. This is the sentence the LOQ-17015 residue bound is published as, and '
+                . 'until now nothing executed it at this size - the earlier claim of one duplicate charge '
+                . 'per distinct address was wrong here by a factor of %1$d, and was believed because it was '
+                . 'only ever argued.',
+                $chunkSize
+            )
+        );
+        $this->assertSame(
+            array_fill(0, $chunkSize, true),
+            array_values($firstAcceptedChunk),
+            'Every copy is answered under its own row: the row-count guard and the positional attribution '
+            . 'both depend on ONE RESPONSE ROW PER SENT ITEM, which is exactly what makes the copies cost '
+            . 'what they cost. A chunk that answered fewer rows than it was given would renumber every '
+            . 'import row after it.'
+        );
+        $this->assertSame(
+            array_fill(0, $chunkSize, false),
+            array_values($firstRejectedChunk),
+            'And the rejected polarity is answered the same way, row for row - the polarity the session '
+            . 'store never held, so its copies are the ones only the run map can make free later.'
+        );
+
+        $laterAcceptedChunk = $this->request['validator']->verifyMultipleAddresses($acceptedChunk, false);
+        $laterRejectedChunk = $this->request['validator']->verifyMultipleAddresses($rejectedChunk, false);
+
+        $this->assertSame(
+            2 * $chunkSize,
+            $this->addressesBilled($this->request),
+            sprintf(
+                'THE OTHER HALF, ALSO AT FULL SIZE: repeating both %1$d-row chunks bills NOTHING further. '
+                . 'By then the pass is in the session store and the run map and the rejection is in the run '
+                . 'map, so all %2$d replayed rows are answered from memory. %2$d billed addresses in total, '
+                . 'not %3$d: the residue is bounded by the chunk an address FIRST appears in, whatever the '
+                . 'file does afterwards.',
+                $chunkSize,
+                2 * $chunkSize,
+                4 * $chunkSize
+            )
+        );
+        $this->assertSame(
+            2,
+            $this->apiCallCount($this->request),
+            'And the replays issue no request at all - not even an empty \'Addresses\' payload, which would '
+            . 'be a round trip to a billable endpoint paid for and discarded.'
+        );
+        $this->assertSame(
+            array_fill(0, $chunkSize, true),
+            array_values($laterAcceptedChunk),
+            'The replayed accepted chunk still reports every row, under its own key.'
+        );
+        $this->assertSame(
+            array_fill(0, $chunkSize, false),
+            array_values($laterRejectedChunk),
+            'And so does the replayed rejected chunk: free must not become silent, or a whole chunk of '
+            . 'invalid rows vanishes from the merchant\'s report.'
         );
     }
 
@@ -1425,8 +1648,9 @@ class ValidatorImportRunDedupeTest extends TestCase
      *
      * Filtered rather than taken whole, because the same logger carries unrelated INFO records
      * (a missing API key, a response whose row count could not be attributed) and this file's
-     * subject is only the one line a merchant needs to see when their own setting is what
-     * refused the file.
+     * subject is only the one line a merchant needs to see when their own setting is a quality
+     * bar no address can clear. It reports the CONFIGURATION, not what became of any row: the
+     * pre-flight that emits it runs once per batch, before a single verdict exists.
      *
      * @param array $request Request harness from createRequest().
      * @return string[]
@@ -1446,6 +1670,14 @@ class ValidatorImportRunDedupeTest extends TestCase
      * out, so a grade added to the module is offered to the merchant in this message without
      * anybody having to remember this file - the WORDING is what is pinned here, not the list.
      *
+     * The middle clause is load-bearing and is the reason this helper is worth reading twice: it
+     * states what the CONFIGURATION is, and deliberately not what happened to any address. The
+     * caller emitting it is a once-per-batch pre-flight that runs before any row is decided, so a
+     * sentence naming an outcome can be false - it was, on an all-captured batch, which is what
+     * testAnAllCapturedBatchUnderAnUnreadableThresholdStillReportsTheConfigurationOnce() pins.
+     * That test also asserts the retired 'rejecting the address' clause is ABSENT, so a revert of
+     * the wording fails on its own terms and not only through this byte-for-byte helper.
+     *
      * @param mixed $threshold The unreadable configured value.
      * @return string
      */
@@ -1453,7 +1685,7 @@ class ValidatorImportRunDedupeTest extends TestCase
     {
         return sprintf(
             'Loqate: address_quality_index is not a recognised quality index (%s of type %s); '
-            . 'rejecting the address. Set it to one of %s.',
+            . 'no address can pass a quality bar that cannot be read. Set it to one of %s.',
             var_export($threshold, true),
             gettype($threshold),
             implode(', ', Validator::VALID_QUALITY_INDEXES)
@@ -1516,6 +1748,65 @@ class ValidatorImportRunDedupeTest extends TestCase
         $map->setAccessible(true);
 
         return (array)$map->getValue($request['validator']);
+    }
+
+    /**
+     * The number of rows Plugin\Admin\ValidateImportAddress::afterValidateData() puts in ONE
+     * verification batch, taken from that method's own array_chunk() call.
+     *
+     * WHY IT IS READ OUT OF THE PRODUCTION SOURCE. The LOQ-17015 residue bound is a claim about
+     * the worst case a real import can produce - "a chunk of N identical rows bills N" - so the N
+     * a test pins has to be the N the plugin actually assembles. A literal repeated in this file
+     * would keep passing while the plugin moved, leaving the worst case unmeasured but looking
+     * measured, which is the same failure that shipped a bound wrong by 99x.
+     *
+     * WHY BY SOURCE SCAN. The chunk size is an inline literal in a method body: there is no
+     * constant to reflect on and no accessor to call, and this file may not add one, so the source
+     * the code is compiled from is the only place the value exists. The scan is deliberately
+     * narrow - one array_chunk() call with an integer literal - and anything else FAILS rather
+     * than guesses, because a wrong guess here silently weakens the only test of the worst case.
+     *
+     * @return int
+     */
+    private function importChunkSize(): int
+    {
+        $pluginFile = (new ReflectionClass(ValidateImportAddress::class))->getFileName();
+        $this->assertIsString(
+            $pluginFile,
+            'Plugin\Admin\ValidateImportAddress must be a file-backed class: its chunk size is an inline '
+            . 'literal, so the source file is the only place the value can be read from.'
+        );
+
+        $matched = preg_match_all(
+            '/array_chunk\s*\(\s*\$\w+\s*,\s*(\d+)\s*\)/',
+            (string)file_get_contents($pluginFile),
+            $matches
+        );
+        $sizes = $matched ? array_values(array_unique(array_map('intval', $matches[1]))) : [];
+
+        $this->assertCount(
+            1,
+            $sizes,
+            'Plugin\Admin\ValidateImportAddress::afterValidateData() must chunk the import file with '
+            . 'exactly one array_chunk() call taking an integer literal, or this helper cannot tell what '
+            . 'size a real batch is. If the plugin now computes the size, or chunks in more than one place, '
+            . 'read it from there instead - do NOT fall back to a literal in the test, because the worst '
+            . 'case would then be measured at a size production never produces.'
+        );
+        $this->assertSame(
+            self::IMPORT_CHUNK_SIZE,
+            $sizes[0],
+            sprintf(
+                'The plugin now chunks at %d, and every fixture in this class is laid out for %d - the '
+                . 'headline file\'s three chunks, and its assertion that repeats fall only across chunk '
+                . 'boundaries. That layout has to be re-thought by a person rather than re-scaled silently, '
+                . 'so the disagreement stops the suite here.',
+                $sizes[0],
+                self::IMPORT_CHUNK_SIZE
+            )
+        );
+
+        return $sizes[0];
     }
 
     /**

--- a/Test/Unit/Helper/ValidatorImportRunDedupeTest.php
+++ b/Test/Unit/Helper/ValidatorImportRunDedupeTest.php
@@ -7,10 +7,10 @@ use Loqate\ApiIntegration\Helper\Data;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
 use Loqate\ApiIntegration\Model\Config\Source\AddressQualityIndex;
+use Loqate\ApiIntegration\Test\Support\ProductionSerializerDouble;
 use Magento\Customer\Model\Session;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Module\ModuleListInterface;
-use Magento\Framework\Serialize\SerializerInterface;
 use ArrayObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -53,19 +53,38 @@ use ReflectionProperty;
  * the threshold. testARejectionIsNeverReplayedToALaterRequest() is that half.
  *
  * THE ONE RULE THAT GOVERNS ALL OF IT: NEVER REMEMBER A VERDICT WE COULD NOT READ. An AQI that
- * could not be read, or a threshold that could not be read, produces a rejection that is a
- * FAULT REPORT rather than a verdict - so it is remembered nowhere, not even for the identical
- * address in the same run, and the row is billed again. One connector fault or one bad
- * credential must not brand every matching row in the file invalid for the rest of the run.
- * That is what testAnUnreadableQualityIndexIsRememberedNowhereSoTheRowIsBilledAgain() and
- * testAnUnreadableThresholdRejectsEveryRowAndIsRememberedNowhere() hold, and it is the
- * assertion to look at first if a dedupe change ever makes the headline test cheaper.
+ * could not be read, or a threshold that could not be read, produces a rejection that is a FAULT
+ * REPORT rather than a verdict - so it is remembered nowhere, not even for the identical address
+ * in the same run. One connector fault or one bad credential must not brand every matching row
+ * in the file invalid for the rest of the run. That is what
+ * testAnUnreadableQualityIndexIsRememberedNowhereSoTheRowIsBilledAgain() and
+ * testAnUnreadableThresholdRejectsEveryRowAndIsRememberedNowhere() hold, and it is the assertion
+ * to look at first if a dedupe change ever makes the headline test cheaper.
  *
- * Every count asserted here is ADDRESSES BILLED - count($payload['Addresses']) summed over
- * every connector invocation - and not requests, because that is what the invoice is.
+ * THE TWO FAULTS COST DIFFERENT AMOUNTS, and the difference is the point rather than an
+ * inconsistency. An unreadable RESPONSE is re-billed on the repeat, because only Loqate can
+ * settle that row and asking again is the cheaper mistake. An unreadable THRESHOLD is billed
+ * NOTHING, ever, because nothing Loqate could answer would change the outcome: the bar cannot be
+ * read, so every row is refused before the request is composed. "Remembered nowhere" is the
+ * same rule in both cases; what differs is whether buying an answer could tell us anything.
+ *
+ * Most counts asserted here are ADDRESSES BILLED - count($payload['Addresses']) summed over every
+ * connector invocation - and not requests, because that is what the invoice is. The pre-flight
+ * tests also assert the REQUEST count, which is a stronger claim than zero billed addresses: an
+ * empty 'Addresses' payload sent to a billable endpoint bills nothing and is still a round trip
+ * paid for and discarded.
  */
 class ValidatorImportRunDedupeTest extends TestCase
 {
+    /**
+     * The serializer double, shared with every other harness that reads a serialised payload
+     * back. What it buys THIS class: the session verdict store is read through it on every
+     * lookup, so a lenient double would make getCachedBatchVerifyResult()'s catch block
+     * unreachable from here and an import meeting a truncated payload would fatal in production
+     * while this file stayed green.
+     */
+    use ProductionSerializerDouble;
+
     /** Any non-empty key makes the batch path reach the billable call. */
     private const API_KEY = 'TEST-API-KEY-0000';
 
@@ -95,6 +114,9 @@ class ValidatorImportRunDedupeTest extends TestCase
 
     /** Session data key the SINGLE-address verdict cache lives under. */
     private const VERIFY_CACHE_SESSION_KEY = 'loqate_verified_addresses';
+
+    /** Session data key the captured-address store lives under. */
+    private const CAPTURED_ADDRESSES_SESSION_KEY = 'captured_addresses';
 
     /** Config path of the threshold batch verdicts are judged against. */
     private const AQI_CONFIG_PATH = 'loqate_settings/address_settings/address_quality_index';
@@ -188,11 +210,13 @@ class ValidatorImportRunDedupeTest extends TestCase
      * cache that was already there.
      *
      * WHAT THE FIXTURE DELIBERATELY DOES NOT CONTAIN, asserted rather than promised: no address
-     * appears twice inside ONE chunk. Two copies of an address in a single batch are both sent,
+     * appears twice inside ONE chunk. All k copies of an address in a single batch are sent,
      * because nothing is written until the response comes back - that is LOQ-17015, a separate
      * ticket with its own arithmetic (the row-count guard in verifyMultipleAddresses() depends
      * on one response row per sent item), and pulling it into this measurement would make the
-     * headline number unmeetable for a reason this ticket is not about.
+     * headline number unmeetable for a reason this ticket is not about. That bound is measured
+     * on its own fixture by
+     * testEveryCopyInTheChunkAnAddressFirstAppearsInIsBilledAndEveryLaterChunkIsFree().
      */
     public function testAnImportRunLargerThanTheCacheLimitBillsEachDistinctAddressOnce(): void
     {
@@ -433,19 +457,36 @@ class ValidatorImportRunDedupeTest extends TestCase
     }
 
     /**
-     * An UNREADABLE THRESHOLD rejects every row, and is remembered nowhere - so a repeated row
-     * is billed again.
+     * An UNREADABLE THRESHOLD rejects every row, is remembered nowhere - and is NOT PAID FOR.
      *
-     * The threshold side of the same rule, and the one that is easier to get wrong, because the
-     * rejection LOOKS like a verdict: the response was perfectly readable, and the only
-     * unreadable thing is the merchant's own configuration. It is still not a verdict. A value
-     * nobody can read cannot be said to admit or refuse any address, so remembering the
-     * refusal would keep refusing rows after the configuration was corrected - within the run
-     * for the run-scoped memory, and for the whole session had it been stored there.
+     * The threshold side of the "never remember a verdict we could not read" rule, and the one
+     * that is easier to get wrong, because the rejection LOOKS like a verdict: the response was
+     * perfectly readable, and the only unreadable thing is the merchant's own configuration. It
+     * is still not a verdict. A value nobody can read cannot be said to admit or refuse any
+     * address, so remembering the refusal would keep refusing rows after the configuration was
+     * corrected - within the run for the run-scoped memory, and for the whole session had it
+     * been stored there.
+     *
+     * THE BILLED COUNT IS ZERO, AND THAT IS THE CORRECTION LOQ-17148 MAKES HERE. This test used
+     * to assert FOUR - two rows, sent again in the repeat chunk - on the reasoning that a
+     * rejection nobody could read must be re-earned rather than replayed. That reasoning is
+     * sound for an unreadable RESPONSE, where only Loqate can settle the row (see
+     * testAnUnreadableQualityIndexIsRememberedNowhereSoTheRowIsBilledAgain(), which still bills
+     * twice). It is wrong for an unreadable THRESHOLD, because nothing Loqate could answer would
+     * change the outcome: the bar cannot be read, so EVERY row is refused whatever comes back,
+     * and the answer is settled by the configuration before the request is composed. Paying per
+     * address for it is paying for a guaranteed refusal - on every row of the file, on every
+     * "Check Data" click, for as long as the setting stays broken. So the threshold is read once
+     * before payload assembly and the whole file is answered without a request.
+     *
+     * The other three assertions are unchanged, and they are what stops "spend nothing" being
+     * implemented as "remember the refusal": both chunks still reject both rows, and the session
+     * store is still empty.
      *
      * 'E' is the AQI under test on purpose: the worst grade Loqate returns is the value that
      * must never pass a threshold nobody can read, and a test using 'A' would still pass if the
-     * guard regressed to comparing against the shipped default.
+     * guard regressed to comparing against the shipped default. It is now also the grade that is
+     * never asked for.
      *
      * @param mixed $threshold Configured address_quality_index that cannot be read as a grade.
      * @param string $why What this case protects, quoted into the failure message.
@@ -483,17 +524,29 @@ class ValidatorImportRunDedupeTest extends TestCase
             'The repeated rows must be rejected on their own answer, not on a remembered one.'
         );
         $this->assertSame(
-            4,
+            0,
             $this->addressesBilled($request),
-            'Both rows must be BILLED AGAIN in the later chunk. A rejection produced by a threshold we '
-            . 'could not read is a configuration fault report, not a verdict: remembered, it would keep '
-            . 'rejecting rows after the merchant corrected the setting, and it would do so for a whole '
-            . 'import run with no request made and nothing in the log for the rows after the first.'
+            'NOT ONE address may be billed. The answer is decided by the CONFIGURATION before the request '
+            . 'is composed - a threshold nobody can read refuses every row whatever Loqate replies - so '
+            . 'buying the reply is paying, per address and per "Check Data" click, for a refusal that was '
+            . 'already made. Contrast an unreadable RESPONSE, which IS re-billed on its repeat '
+            . '(testAnUnreadableQualityIndexIsRememberedNowhereSoTheRowIsBilledAgain()): there only Loqate '
+            . 'can settle the row, so paying to ask again is the cheaper mistake. Here nobody can.'
         );
         $this->assertSame(
             [],
             $this->batchStore($request),
             'And nothing may be written to the session store, where it would outlive the request entirely.'
+        );
+        $this->assertSame(
+            [],
+            $this->runScopedVerdicts($request),
+            'NOR to the run-scoped map, read here DIRECTLY and not inferred. That directness is the point: '
+            . 'while this test asserted four billed addresses, the re-billing was itself the evidence that '
+            . 'nothing had been remembered. At zero there is no such evidence left - a refusal that HAD '
+            . 'been remembered would produce the same zero and the same [false, false] - so the memory is '
+            . 'read instead. It has to stay empty, or a merchant who corrects the setting mid-run keeps '
+            . 'being refused by a rule that no longer applies.'
         );
     }
 
@@ -528,6 +581,286 @@ class ValidatorImportRunDedupeTest extends TestCase
                 . 'comparison anyone reasoned about',
             ],
         ];
+    }
+
+    /**
+     * An unreadable threshold issues NO REQUEST AT ALL, and says so EXACTLY ONCE PER BATCH.
+     *
+     * The wire-and-diagnostic half of the test above, which measures verdicts and memories. Two
+     * separate guarantees are pinned here and both are new in LOQ-17148:
+     *
+     * NO REQUEST, not merely no billed addresses. The distinction is not academic: an
+     * implementation that assembled the payload and then answered every slot false before
+     * sending would satisfy a per-address count of zero taken from the payloads while still
+     * making a call, and the endpoint is billable per address it carries - an empty
+     * 'Addresses' list to a billable endpoint is the worst version of that, since it pays for a
+     * round trip and discards the answer. The threshold is therefore read BEFORE payload
+     * assembly, and this asserts the request count itself.
+     *
+     * EXACTLY ONE LINE PER BATCH, which is a frequency and not just a presence. Zero would leave
+     * the merchant with a whole file of "Invalid address at row #N" and nothing anywhere saying
+     * their own setting refused it - the failure this line exists to prevent. One per ROW would
+     * bury it: a 100-row chunk would write 100 identical lines and a 10,000-row file 10,000, so
+     * the signal is lost in its own volume and the log costs real money to ship. The line is
+     * asserted BYTE FOR BYTE, because it is a merchant-facing artefact that support reads out of
+     * a log file: rewording it is a decision to make deliberately, which means updating this
+     * expectation, not one to have absorbed by a test matching a fragment.
+     *
+     * @param mixed $threshold Configured address_quality_index that cannot be read as a grade.
+     * @param string $why What this case protects, quoted into the failure message.
+     */
+    #[DataProvider('unreadableThresholdProvider')]
+    public function testAnUnreadableThresholdIssuesNoRequestAndSaysSoOncePerBatch($threshold, string $why): void
+    {
+        $request = $this->createRequest(
+            null,
+            new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => $threshold])),
+            static fn ($payload): array => array_map(
+                static fn (): array => [['AQI' => 'E', 'AVC' => self::CARRIED_AVC]],
+                (array)$payload['Addresses']
+            )
+        );
+        $rows = [$this->distinctAddress(1), $this->distinctAddress(2)];
+
+        $firstChunk = $request['validator']->verifyMultipleAddresses($rows, false);
+
+        $this->assertSame(
+            0,
+            $this->apiCallCount($request),
+            sprintf(
+                'A batch under a threshold nobody can read must issue NO REQUEST - not an empty '
+                . '\'Addresses\' payload to a billable endpoint, and not one carrying rows whose verdict '
+                . 'the configuration has already settled. This case pins that %s.',
+                $why
+            )
+        );
+        $this->assertSame(
+            [false, false],
+            array_values($firstChunk),
+            'And every row is still answered, and still answered false: spending nothing may not become '
+            . 'reporting nothing. A row with no verdict at all would be dropped from the merchant\'s '
+            . 'report entirely, or - on the admin order path - accepted unverified.'
+        );
+        $this->assertSame(
+            [$this->expectedBrokenThresholdLine($threshold)],
+            $this->thresholdLogLines($request),
+            'ONE line, and this exact line. It is the only signal a merchant has that their own quality '
+            . 'bar - not their data - is what refused the file, so it must name the offending value and '
+            . 'its type and say what the accepted values are. Zero lines is the defect this replaces; one '
+            . 'per ROW would bury the signal under a line per import row.'
+        );
+
+        $request['validator']->verifyMultipleAddresses($rows, false);
+
+        $this->assertSame(
+            0,
+            $this->apiCallCount($request),
+            'The repeat chunk must not buy the answer either. Nothing was remembered - there is nothing a '
+            . 'broken threshold could legitimately remember - so this has to be re-decided each time, and '
+            . 're-deciding it costs nothing.'
+        );
+        $this->assertSame(
+            2,
+            count($this->thresholdLogLines($request)),
+            'Once per BATCH: the second chunk gets its own line, because the merchant\'s bar is still '
+            . 'broken and each verified batch is an occasion on which it mattered. Two chunks, two lines - '
+            . 'not four (one per row) and not one (a per-instance latch that would go quiet on the very '
+            . 'file that needed the warning most).'
+        );
+    }
+
+    /**
+     * ...and the line still fires on a file Loqate answers with NO MATCHES AT ALL.
+     *
+     * THE SECOND DEFECT LOQ-17148 CLOSES, and it is easy to miss because it looks like the same
+     * test as the one above. It is not: the old code read the threshold only from
+     * checkQualityIndex(), on the RESPONSE side, and that method returns on an unreadable AQI
+     * BEFORE it ever looks at the threshold. "Matches":[] is Loqate's ordinary answer for an
+     * address it could not match, and on a poor file that is most of the file - so a merchant
+     * whose threshold was broken AND whose file matched badly got every row rejected and NOT ONE
+     * line telling them why. The two faults hid each other, and the worse-configured the install,
+     * the quieter it was.
+     *
+     * The response stub below is now never consulted, which is the point rather than a
+     * redundancy: the guarantee is that the diagnostic no longer depends on what comes back,
+     * because nothing comes back. If the pre-flight is ever narrowed or moved after the request,
+     * this fixture is the one that goes quiet again.
+     */
+    public function testAnUnreadableThresholdStillReportsItselfOnAFileLoqateMatchesNowhere(): void
+    {
+        $request = $this->createRequest(
+            null,
+            new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => 'zzz'])),
+            // "Matches":[] for every address - the shape that survives the connector's
+            // array_column() with the row count preserved, so it reaches the attribution loop
+            // as an AQI of null and used to return from checkQualityIndex() before the
+            // threshold was read.
+            static fn ($payload): array => array_map(
+                static fn (): array => [],
+                (array)$payload['Addresses']
+            )
+        );
+        $rows = [$this->distinctAddress(1), $this->distinctAddress(2)];
+
+        $verdicts = $request['validator']->verifyMultipleAddresses($rows, false);
+
+        $this->assertSame(
+            [$this->expectedBrokenThresholdLine('zzz')],
+            $this->thresholdLogLines($request),
+            'A file Loqate matches nowhere must STILL produce the broken-threshold line. It used to '
+            . 'produce none: the unreadable AQI returned from checkQualityIndex() before the threshold '
+            . 'was ever read, so the one diagnostic that would have told the merchant their setting was '
+            . 'the problem was suppressed by exactly the kind of file that makes it hardest to guess.'
+        );
+        $this->assertSame([false, false], array_values($verdicts), 'Every row is still rejected.');
+        $this->assertSame(
+            0,
+            $this->apiCallCount($request),
+            'And it is reported without asking Loqate anything, so the diagnostic no longer depends on '
+            . 'the answer at all.'
+        );
+    }
+
+    /**
+     * A CAPTURED address still passes under an unreadable threshold, and still costs no request.
+     *
+     * A DELIBERATE DEVIATION, pinned so it is a decision rather than an accident of where the
+     * guard was pasted. The pre-flight sits AFTER the captured-address short-circuit and not
+     * before it, so an address the Loqate lookup itself authored is answered true even while the
+     * merchant's quality bar is unreadable. Two reasons, both about not making things worse: a
+     * captured address never consults the AQI at all - it is trusted because Loqate produced it,
+     * not because it was graded - so refusing it would be a NEW refusal on a batch that passes
+     * today, on the one path where the module is most confident; and the alternative reading,
+     * "the configuration is broken so refuse everything", would turn a mis-set dropdown into a
+     * total block of admin order create for addresses picked from the lookup.
+     *
+     * The mixed batch is what makes it a deviation rather than a special case: the captured row
+     * passes and the typed row beside it is refused, in ONE call, so the guard demonstrably runs
+     * per row and after the short-circuit rather than as a whole-batch bail-out.
+     */
+    public function testACapturedAddressStillPassesUnderAnUnreadableThresholdAndStillCostsNoRequest(): void
+    {
+        $captured = $this->distinctAddress(1);
+        $typed = $this->distinctAddress(2);
+
+        $request = $this->createRequest(
+            null,
+            new ArrayObject(self::configWith([self::AQI_CONFIG_PATH => 'zzz'])),
+            static fn ($payload): array => array_map(
+                static fn (): array => [['AQI' => 'E', 'AVC' => self::CARRIED_AVC]],
+                (array)$payload['Addresses']
+            )
+        );
+        $request['session'][self::CAPTURED_ADDRESSES_SESSION_KEY] = [self::capturedEntry($captured)];
+
+        $verdicts = $request['validator']->verifyMultipleAddresses(
+            ['captured' => $captured, 'typed' => $typed],
+            true
+        );
+
+        $this->assertSame(
+            ['captured' => true, 'typed' => false],
+            $verdicts,
+            'The captured address must still PASS. The pre-flight threshold guard is deliberately placed '
+            . 'AFTER the captured-address short-circuit: a captured address never consults the AQI, so '
+            . 'refusing it would be a brand-new refusal on a batch that passes today, and a mis-set '
+            . 'dropdown would become a total block of every address picked from the Loqate lookup. The '
+            . 'typed row beside it is still refused, which is what shows the guard runs per row rather '
+            . 'than bailing the batch out.'
+        );
+        $this->assertSame(
+            0,
+            $this->apiCallCount($request),
+            'And nothing is bought either way: the captured row needs no verification and the typed row\'s '
+            . 'answer is already settled.'
+        );
+        $this->assertSame(
+            [],
+            $this->batchStore($request),
+            'Nor is the captured pass written to the verdict store: it is not a verdict, it is a bypass, '
+            . 'and it is keyed under a threshold nobody can read.'
+        );
+    }
+
+    /**
+     * THE LOQ-17015 RESIDUE BOUND, both halves, pinned so it cannot drift back into prose.
+     *
+     * WHAT THE BOUND IS. An address appearing k times in the chunk where it FIRST appears is
+     * billed k TIMES, up to the chunk size; every appearance in any LATER chunk is free. The
+     * pre-flight loop runs to completion over the whole chunk before the request is issued, and
+     * the only writer to either memory is rememberBatchVerdict(), which runs AFTER the response
+     * - so all k copies miss, and all k go on the wire.
+     *
+     * WHY IT IS PINNED RATHER THAN DESCRIBED. The bound published with the first half of this
+     * work said the residue was "ONE duplicate charge per distinct address per run", and
+     * labelled that verified. It was not: the two-copy case had been probed and generalised to
+     * all n without being run. Two reviewers then disproved it independently BY EXECUTION. A
+     * claim about a billing bound that nothing executes is a claim that will be wrong again, so
+     * both halves now have a test - three copies, not two, because three is the smallest count
+     * that tells "k copies cost k" from "the first copy plus one".
+     *
+     * BOTH POLARITIES IN ONE FIXTURE, deliberately. A rejected address is remembered only in the
+     * RUN map and a passing one in both memories, so an implementation that de-duplicated
+     * intra-chunk copies for one polarity and not the other would still satisfy a single-polarity
+     * test. Six rows, two distinct addresses, one accepted and one rejected.
+     *
+     * IF THIS TEST EVER GOES RED BECAUSE THE COUNT DROPPED, that is LOQ-17015 being fixed and it
+     * is good news - but read verifyMultipleAddresses()' ACCEPTED LIMITS first: collapsing
+     * duplicates into a single payload slot changes the row arithmetic the row-count guard and
+     * the positional attribution both depend on, so the dedupe and that guard have to change
+     * TOGETHER.
+     */
+    public function testEveryCopyInTheChunkAnAddressFirstAppearsInIsBilledAndEveryLaterChunkIsFree(): void
+    {
+        $accepted = $this->distinctAddress(1);
+        $rejected = $this->distinctAddress(2);
+        $this->apiVerdicts[$rejected['street'][0]] = 'fail';
+
+        $chunk = array_merge(array_fill(0, 3, $accepted), array_fill(0, 3, $rejected));
+
+        $firstChunk = $this->request['validator']->verifyMultipleAddresses($chunk, false);
+
+        $this->assertSame(
+            array_merge(
+                array_fill(0, 3, $accepted['street'][0]),
+                array_fill(0, 3, $rejected['street'][0])
+            ),
+            $this->streetsBilled($this->request),
+            'Read off the WIRE: all THREE copies of each address really were sent, in row order. Nothing '
+            . 'is written to either memory until the response comes back, and the pre-flight loop runs to '
+            . 'completion over the whole chunk before the request is issued, so every copy misses. That is '
+            . 'LOQ-17015, and its bound is the CHUNK SIZE - 100 identical rows in one chunk bill 100 - not '
+            . 'one charge per distinct address, which is what an earlier revision of this claim said.'
+        );
+        $this->assertSame(
+            [true, true, true, false, false, false],
+            array_values($firstChunk),
+            'And every copy is answered under its own row, with the verdict of the address on that row: '
+            . 'the row-count guard and the positional attribution both depend on ONE RESPONSE ROW PER SENT '
+            . 'ITEM, which is exactly what makes the copies cost what they cost.'
+        );
+
+        $laterChunk = $this->request['validator']->verifyMultipleAddresses($chunk, false);
+
+        $this->assertSame(
+            6,
+            $this->addressesBilled($this->request),
+            'THE OTHER HALF: an identical LATER chunk bills NOTHING. By then both memories hold both '
+            . 'addresses - the pass in the session store and the run map, the rejection in the run map '
+            . 'alone - so all six rows are answered from memory. Six billed addresses in total, not '
+            . 'twelve, and the residue is bounded by the chunk an address first appears in.'
+        );
+        $this->assertSame(
+            1,
+            $this->apiCallCount($this->request),
+            'And it issues no request at all, not even an empty one.'
+        );
+        $this->assertSame(
+            [true, true, true, false, false, false],
+            array_values($laterChunk),
+            'The replayed chunk must report the same verdicts under its own keys, including the rejections: '
+            . 'a de-duplicated row that loses its slot renumbers every import row after it.'
+        );
     }
 
     /**
@@ -792,7 +1125,7 @@ class ValidatorImportRunDedupeTest extends TestCase
                 count($chunk),
                 count(array_unique($chunk)),
                 sprintf(
-                    'Chunk #%d must not repeat an address WITHIN itself. Two copies in one batch are both '
+                    'Chunk #%d must not repeat an address WITHIN itself. ALL k copies in one batch are '
                     . 'sent - nothing is written until the response comes back - which is LOQ-17015 and its '
                     . 'own arithmetic, so including one here would make this measurement unmeetable for a '
                     . 'reason LOQ-17148 is not about.',
@@ -839,7 +1172,7 @@ class ValidatorImportRunDedupeTest extends TestCase
      * @param ArrayObject|null $config Live store configuration, config path => value.
      * @param callable|null $respond Replacement connector response builder, given the payload.
      * @return array{validator: Validator, connector: Verify&MockObject, requests: ArrayObject,
-     *     session: ArrayObject, config: ArrayObject}
+     *     session: ArrayObject, config: ArrayObject, logs: ArrayObject}
      */
     private function createRequest(
         ?ArrayObject $session = null,
@@ -850,7 +1183,17 @@ class ValidatorImportRunDedupeTest extends TestCase
         $requests = new ArrayObject();
         $configStore = $config ?? new ArrayObject(self::configWith([]));
 
+        // Every INFO record the Validator wrote, in order. Needed by the pre-flight tests: the
+        // "your quality bar is broken" line is the ONLY signal a merchant has that their
+        // configuration - and not their file - is what rejected every row, and its FREQUENCY is
+        // part of the guarantee (once per verified batch, not once per row and not never).
+        $logs = new ArrayObject();
         $logger = $this->createMock(Logger::class);
+        $logger->method('info')->willReturnCallback(
+            static function ($message, array $context = []) use ($logs) {
+                $logs[] = (string)$message;
+            }
+        );
 
         // The shared Test/stubs Session is a no-op (getData() returns null, setData() stores
         // nothing), so nothing could ever survive between calls and every "is this remembered"
@@ -922,30 +1265,8 @@ class ValidatorImportRunDedupeTest extends TestCase
         // mock returns 0 anyway, but relying on that hides which scope a key was built for.
         $helper->method('getCurrentStore')->willReturn(0);
 
-        // Fails the way the PRODUCTION serializer fails.
-        // Magento\Framework\Serialize\Serializer\Json::unserialize() THROWS
-        // \InvalidArgumentException on anything it cannot decode - the empty string and null
-        // included - rather than answering null. A lenient `fn ($v) => json_decode($v, true)`
-        // double makes getCachedBatchVerifyResult()'s catch block unreachable from the harness,
-        // so an import meeting a truncated session payload would fatal in production while this
-        // file stayed green. Mirrors CapturedAddressStoreTest::createSerializerDouble() and
-        // ValidatorBatchVerifyCacheTest::createSerializerDouble().
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
-        $serializer->method('unserialize')->willReturnCallback(
-            static function ($value) {
-                if ($value === false || $value === null || $value === '') {
-                    throw new \InvalidArgumentException('Unable to unserialize value.');
-                }
-
-                $decoded = json_decode($value, true);
-                if (json_last_error() !== JSON_ERROR_NONE) {
-                    throw new \InvalidArgumentException('Unable to unserialize value, string is corrupted.');
-                }
-
-                return $decoded;
-            }
-        );
+        // Fails the way the PRODUCTION serializer fails - see the trait for why that matters.
+        $serializer = $this->createSerializerDouble();
 
         $validator = new Validator($logger, $sessionMock, $regionFactory, $moduleList, $helper, $serializer);
 
@@ -981,6 +1302,7 @@ class ValidatorImportRunDedupeTest extends TestCase
             'requests' => $requests,
             'session' => $sessionStore,
             'config' => $configStore,
+            'logs' => $logs,
         ];
     }
 
@@ -1098,6 +1420,66 @@ class ValidatorImportRunDedupeTest extends TestCase
         return count($request['requests']);
     }
 
+    /**
+     * The broken-quality-bar INFO records a request emitted, in order.
+     *
+     * Filtered rather than taken whole, because the same logger carries unrelated INFO records
+     * (a missing API key, a response whose row count could not be attributed) and this file's
+     * subject is only the one line a merchant needs to see when their own setting is what
+     * refused the file.
+     *
+     * @param array $request Request harness from createRequest().
+     * @return string[]
+     */
+    private function thresholdLogLines(array $request): array
+    {
+        return array_values(array_filter(
+            iterator_to_array($request['logs']),
+            static fn (string $line): bool => str_contains($line, 'address_quality_index')
+        ));
+    }
+
+    /**
+     * The exact line Validator must write for a threshold it cannot read.
+     *
+     * The accepted grades come from Validator::VALID_QUALITY_INDEXES rather than being spelled
+     * out, so a grade added to the module is offered to the merchant in this message without
+     * anybody having to remember this file - the WORDING is what is pinned here, not the list.
+     *
+     * @param mixed $threshold The unreadable configured value.
+     * @return string
+     */
+    private function expectedBrokenThresholdLine($threshold): string
+    {
+        return sprintf(
+            'Loqate: address_quality_index is not a recognised quality index (%s of type %s); '
+            . 'rejecting the address. Set it to one of %s.',
+            var_export($threshold, true),
+            gettype($threshold),
+            implode(', ', Validator::VALID_QUALITY_INDEXES)
+        );
+    }
+
+    /**
+     * A captured-address store entry for a Magento-shaped address, as
+     * Helper\Controller::storeCapturedAddress() writes it: the ADDRESS_CAPTURE_MAPPING keys,
+     * serialised. Mirrors ValidatorBatchVerifyCacheTest::capturedEntry().
+     *
+     * @param array $address Magento-shaped address.
+     * @return string
+     */
+    private static function capturedEntry(array $address): string
+    {
+        return (string)json_encode([
+            'Address1' => $address['street'][0] ?? '',
+            'Address2' => $address['street'][1] ?? '',
+            'Address3' => $address['city'] ?? '',
+            'Address4' => $address['region'] ?? '',
+            'PostalCode' => $address['postcode'] ?? '',
+            'Country' => $address['country_id'] ?? '',
+        ]);
+    }
+
     /** The BATCH verdict cache as currently held in a request's session. */
     private function batchStore(array $request): array
     {
@@ -1112,6 +1494,28 @@ class ValidatorImportRunDedupeTest extends TestCase
         $store = $request['session'][self::VERIFY_CACHE_SESSION_KEY] ?? [];
 
         return is_array($store) ? $store : [];
+    }
+
+    /**
+     * The RUN-scoped verdict map of a request's Validator, read straight off the instance.
+     *
+     * The other memory, and the only way to see it. It is never serialised and never written to
+     * the session - that mortality is the feature - so unlike the session stores there is no
+     * artefact to inspect and no second request that could report on it: a fresh Validator
+     * simply has an empty one. Reflection is therefore not a shortcut past a public route, it is
+     * the only route. Used where "remembered nowhere" has to be asserted rather than inferred
+     * from a billed count, which stopped being evidence once the count under a broken threshold
+     * became zero.
+     *
+     * @param array $request Request harness from createRequest().
+     * @return array<string, bool> Batch cache key => remembered verdict.
+     */
+    private function runScopedVerdicts(array $request): array
+    {
+        $map = new ReflectionProperty(Validator::class, 'runScopedBatchVerdicts');
+        $map->setAccessible(true);
+
+        return (array)$map->getValue($request['validator']);
     }
 
     /**

--- a/Test/Unit/Model/Config/Source/AddressQualityIndexTest.php
+++ b/Test/Unit/Model/Config/Source/AddressQualityIndexTest.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Model\Config\Source;
+
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Model\Config\Source\AddressQualityIndex;
+use Magento\Framework\Data\OptionSourceInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use SimpleXMLElement;
+
+/**
+ * THE CONFIGURABILITY GUARANTEE of the address quality index threshold (LOQ-17148).
+ *
+ * WHAT IS BEING GUARANTEED, in the merchant's terms. Every quality bar a merchant can choose in
+ * the admin form is a bar the verifier will actually accept addresses against, and every bar the
+ * verifier accepts can be chosen. The first direction stops a selectable value that silently
+ * rejects EVERY address - the merchant would set a quality bar, watch every import row come back
+ * "Invalid address at row #N", and find nothing anywhere saying the value itself was the problem.
+ * The second stops a value the verifier honours being unreachable, which is a setting that exists
+ * only for whoever knows the config path.
+ *
+ * WHY IT MATTERS HERE AND NOW. Until LOQ-17148 the threshold was reachable only through
+ * etc/config.xml's default, a data patch or bin/magento config:set - etc/adminhtml/system.xml
+ * exposed no field for it - while the value is a plain core_config_data row that any of those can
+ * put anything into. checkQualityIndex() compares it with <=, a STRING comparison, so a value
+ * sorting above 'E' ('zzz', a lowercase 'c', 'C+') passed EVERY address and a value below 'A'
+ * rejected every one; the verifier now refuses to judge against anything outside its accepted
+ * list. Exposing the field as a SELECT over that same list is what stops the two lists drifting:
+ * a free-text field would hand the merchant the whole space of values back again.
+ *
+ * WHY THIS TEST READS THE REAL ARTEFACTS. Both sides are derived, not restated: the selectable
+ * values come from the source model the admin field is actually wired to, and the accepted values
+ * from Validator's own list by reflection. A test that spelled out A-E would agree with itself
+ * forever while the shipped XML said something else.
+ *
+ * FIRST TEST IN THIS SUITE TO PARSE etc/*.xml, so it is kept to the two questions that cannot be
+ * answered any other way - is the field there, and is it a select over the right source - rather
+ * than becoming a schema validator. Everything behavioural about the threshold is asserted where
+ * behaviour belongs: Test\Unit\Helper\ValidatorImportRunDedupeTest verifies an address at every
+ * selectable grade, and ValidatorBatchVerifyCacheTest pins what an unreadable one does.
+ */
+class AddressQualityIndexTest extends TestCase
+{
+    /** Admin section, group and field the threshold must be configurable under. */
+    private const SECTION_ID = 'loqate_settings';
+    private const GROUP_ID = 'address_settings';
+    private const FIELD_ID = 'address_quality_index';
+
+    /**
+     * The admin field must be a SELECT over a source model.
+     *
+     * Two assertions in one place because they are one guarantee: a field the merchant TYPES
+     * into can hold any string, which is exactly the state LOQ-17148 is closing - a threshold
+     * that either passes every address or rejects every address, chosen by a typo, with no
+     * feedback anywhere. A select whose options come from a source model can only ever hold a
+     * value that list contains.
+     *
+     * The group matters as well as the section: the threshold belongs beside the other
+     * address-verification settings a merchant is looking at when they change it, and the config
+     * path the verifier reads
+     * (loqate_settings/address_settings/address_quality_index, via
+     * Validator::resolveQualityIndexThreshold()) is composed of section/group/field - so a field
+     * in the right section but the wrong group writes to a path nothing reads.
+     */
+    public function testTheThresholdIsAdminSelectableRatherThanFreeText(): void
+    {
+        $fields = $this->systemXml()->xpath(sprintf(
+            '/config/system/section[@id="%s"]/group[@id="%s"]/field[@id="%s"]',
+            self::SECTION_ID,
+            self::GROUP_ID,
+            self::FIELD_ID
+        ));
+
+        $this->assertCount(
+            1,
+            (array)$fields,
+            sprintf(
+                'etc/adminhtml/system.xml must expose exactly one "%s" field in the "%s" group of the "%s" '
+                . 'section. With no field at all the threshold is reachable only by data patch or CLI, so a '
+                . 'value that rejects every address (or passes every address) can only be set - and can '
+                . 'only be discovered - by someone who knows the config path; with more than one, two '
+                . 'fields write the single path the verifier reads and the merchant cannot tell which one '
+                . 'won. The path is composed of section/group/field, so the group is part of the '
+                . 'requirement and not decoration.',
+                self::FIELD_ID,
+                self::GROUP_ID,
+                self::SECTION_ID
+            )
+        );
+
+        $field = $fields[0];
+        $this->assertSame(
+            'select',
+            (string)($field['type'] ?? ''),
+            'The field must be type="select". A free-text field lets a merchant configure a threshold the '
+            . 'verifier cannot read, and an unreadable threshold rejects EVERY address on the batch paths '
+            . '- every import row and every admin order - which is a total block presented as a data '
+            . 'problem in their file.'
+        );
+        $this->assertSame(
+            AddressQualityIndex::class,
+            trim((string)$field->source_model),
+            'The select must draw its options from the module\'s own address-quality-index source model. '
+            . 'That is what ties what the merchant is OFFERED to what the verifier ACCEPTS; a hand-written '
+            . 'option list in the XML would be a second copy of that list, free to drift.'
+        );
+    }
+
+    /**
+     * Every threshold a merchant can select must be one the verifier accepts.
+     *
+     * This is the direction that produces the silent total block: a selectable value outside the
+     * verifier's accepted list makes checkQualityIndex() refuse to judge at all, so EVERY address
+     * is rejected - reported to the merchant as an invalid row rather than as a bad setting.
+     */
+    public function testEverySelectableThresholdIsOneTheVerifierAccepts(): void
+    {
+        $selectable = $this->selectableThresholds();
+        $accepted = $this->thresholdsTheVerifierAccepts();
+
+        $this->assertSame(
+            [],
+            array_values(array_diff($selectable, $accepted)),
+            'Every option the admin form offers must be a value the verifier is willing to judge against. '
+            . 'One that is not rejects every address the moment it is chosen: the merchant sees their whole '
+            . 'import fail row by row, and nothing points at the setting they just changed.'
+        );
+        $this->assertNotSame(
+            [],
+            $selectable,
+            'Fixture guard: the source model must offer something. An empty option list would satisfy the '
+            . 'subset assertion above while leaving the merchant a select box they cannot choose anything '
+            . 'in.'
+        );
+    }
+
+    /**
+     * ...and every threshold the verifier accepts must be selectable.
+     *
+     * The other direction, and not symmetric with the first: a value the verifier honours but the
+     * form does not offer is a setting only whoever knows the config path can reach, which is the
+     * state this ticket found the threshold in. Keeping the two lists equal is also what makes
+     * the source model's list DERIVED from the verifier's rather than a copy of it.
+     */
+    public function testEveryThresholdTheVerifierAcceptsIsSelectable(): void
+    {
+        $selectable = $this->selectableThresholds();
+        $accepted = $this->thresholdsTheVerifierAccepts();
+
+        $this->assertSame(
+            [],
+            array_values(array_diff($accepted, $selectable)),
+            'Every quality index the verifier accepts must be offered in the admin form. One that is not '
+            . 'is a threshold only a data patch or a CLI call can select, which is precisely the situation '
+            . 'LOQ-17148 exists to end - and it means the two lists have started to drift, so the next '
+            . 'grade added to one of them will not reach the other either.'
+        );
+    }
+
+    /**
+     * The threshold etc/config.xml SHIPS must be one of the selectable options.
+     *
+     * The default is what a merchant runs until they change it, and it is what they see
+     * pre-selected when they open the form. A default outside the option list shows the form
+     * defaulting to something else entirely, so opening the page and saving it silently changes
+     * the quality bar every import is judged against.
+     */
+    public function testTheShippedDefaultThresholdIsSelectable(): void
+    {
+        $defaults = $this->configXml()->xpath(sprintf(
+            '/config/default/%s/%s/%s',
+            self::SECTION_ID,
+            self::GROUP_ID,
+            self::FIELD_ID
+        ));
+
+        $this->assertCount(
+            1,
+            (array)$defaults,
+            'etc/config.xml must ship exactly one default for the threshold: with none, a fresh install '
+            . 'reads it as null, which the verifier cannot judge against and which therefore rejects every '
+            . 'address on the batch paths.'
+        );
+        $this->assertContains(
+            trim((string)$defaults[0]),
+            $this->selectableThresholds(),
+            'The shipped default must be one of the options the admin form offers. If it is not, the form '
+            . 'shows a different value pre-selected than the one in force, and merely opening the page and '
+            . 'saving changes the quality bar every import row is judged against.'
+        );
+    }
+
+    /**
+     * Every option must carry a label a merchant can act on, and no two may read the same.
+     *
+     * A select of unlabelled or identically-labelled entries is a setting nobody can choose
+     * deliberately, which is not much better than the unexposed field this ticket replaces.
+     */
+    public function testEverySelectableThresholdIsLabelledDistinctly(): void
+    {
+        $labels = [];
+        foreach ((new AddressQualityIndex())->toOptionArray() as $option) {
+            $labels[] = trim((string)($option['label'] ?? ''));
+        }
+
+        $this->assertNotContains(
+            '',
+            $labels,
+            'Every quality index offered must have a label: the merchant chooses a quality bar, not a '
+            . 'letter grade out of the Cleansing API\'s response format.'
+        );
+        $this->assertSame(
+            $labels,
+            array_values(array_unique($labels)),
+            'Two options may not read the same. Duplicated labels make the choice a guess, and a merchant '
+            . 'who guesses wrong gets either a bar that admits everything or one that admits nothing.'
+        );
+    }
+
+    /**
+     * The values the admin form offers, read from the source model the field is wired to.
+     *
+     * @return string[]
+     */
+    private function selectableThresholds(): array
+    {
+        $source = new AddressQualityIndex();
+        $this->assertInstanceOf(
+            OptionSourceInterface::class,
+            $source,
+            'The source model must be an option source, or Magento cannot render the select from it at all.'
+        );
+
+        $values = [];
+        foreach ($source->toOptionArray() as $option) {
+            $this->assertArrayHasKey(
+                'value',
+                (array)$option,
+                'Every option must carry a value: an option without one is an entry the merchant can pick '
+                . 'that saves nothing.'
+            );
+            $values[] = (string)$option['value'];
+        }
+
+        return $values;
+    }
+
+    /**
+     * The thresholds the verifier is willing to judge an address against, read from
+     * Validator's own list rather than restated, so the two sides of this comparison cannot be
+     * kept in agreement by editing the test.
+     *
+     * @return string[]
+     */
+    private function thresholdsTheVerifierAccepts(): array
+    {
+        $reflection = new ReflectionClass(Validator::class);
+        if (!$reflection->hasConstant('VALID_QUALITY_INDEXES')) {
+            $this->fail(
+                'Validator::VALID_QUALITY_INDEXES is not defined. It is the list checkQualityIndex() '
+                . 'requires the configured threshold to be in; without it an unreadable threshold is judged '
+                . 'by a bare string comparison, in which any text sorting above "E" passes every address.'
+            );
+        }
+
+        $accepted = $reflection->getConstant('VALID_QUALITY_INDEXES');
+        $this->assertIsArray($accepted, 'The verifier\'s accepted quality indexes must be a list.');
+
+        return array_map(static fn ($value): string => (string)$value, $accepted);
+    }
+
+    /** etc/adminhtml/system.xml, parsed. */
+    private function systemXml(): SimpleXMLElement
+    {
+        return $this->xml(self::modulePath('etc/adminhtml/system.xml'));
+    }
+
+    /** etc/config.xml, parsed. */
+    private function configXml(): SimpleXMLElement
+    {
+        return $this->xml(self::modulePath('etc/config.xml'));
+    }
+
+    /**
+     * Parse one of the module's XML files, failing with the path rather than with a warning if
+     * it is missing or malformed - a malformed one would break the admin form itself, so it is
+     * worth its own message.
+     *
+     * @param string $path Absolute path to the file.
+     * @return SimpleXMLElement
+     */
+    private function xml(string $path): SimpleXMLElement
+    {
+        $this->assertFileExists($path, sprintf('%s is part of the module\'s shipped configuration.', $path));
+
+        $xml = simplexml_load_string((string)file_get_contents($path));
+        if ($xml === false) {
+            $this->fail(sprintf('%s is not parseable XML, so Magento cannot read it either.', $path));
+        }
+
+        return $xml;
+    }
+
+    /**
+     * Absolute path of a file inside the module, from this test's location: Test/Unit/Model/
+     * Config/Source is five levels below the module root.
+     *
+     * @param string $relative Path relative to the module root.
+     * @return string
+     */
+    private static function modulePath(string $relative): string
+    {
+        return dirname(__DIR__, 5) . '/' . $relative;
+    }
+}

--- a/Test/Unit/Model/Config/Source/AddressQualityIndexTest.php
+++ b/Test/Unit/Model/Config/Source/AddressQualityIndexTest.php
@@ -34,11 +34,13 @@ use SimpleXMLElement;
  * from Validator's own list by reflection. A test that spelled out A-E would agree with itself
  * forever while the shipped XML said something else.
  *
- * FIRST TEST IN THIS SUITE TO PARSE etc/*.xml, so it is kept to the two questions that cannot be
- * answered any other way - is the field there, and is it a select over the right source - rather
- * than becoming a schema validator. Everything behavioural about the threshold is asserted where
- * behaviour belongs: Test\Unit\Helper\ValidatorImportRunDedupeTest verifies an address at every
- * selectable grade, and ValidatorBatchVerifyCacheTest pins what an unreadable one does.
+ * FIRST TEST IN THIS SUITE TO PARSE etc/*.xml, so it is kept to the questions that cannot be
+ * answered any other way rather than becoming a schema validator. There are four: is the field
+ * there, is it a select over the right source, do its section/group/field ids compose the path
+ * the verifier reads, and is it offered at the scope the readers can actually honour. Everything
+ * behavioural about the threshold is asserted where behaviour belongs:
+ * Test\Unit\Helper\ValidatorImportRunDedupeTest verifies an address at every selectable grade,
+ * and ValidatorBatchVerifyCacheTest pins what an unreadable one does.
  */
 class AddressQualityIndexTest extends TestCase
 {
@@ -46,6 +48,36 @@ class AddressQualityIndexTest extends TestCase
     private const SECTION_ID = 'loqate_settings';
     private const GROUP_ID = 'address_settings';
     private const FIELD_ID = 'address_quality_index';
+
+    /**
+     * The config path Validator::resolveQualityIndexThreshold() actually reads, spelled out as
+     * the literal it is in the production source.
+     *
+     * SHARED, ON PURPOSE, with Test\Unit\Helper\ValidatorImportRunDedupeTest::AQI_CONFIG_PATH -
+     * the two are the same string and are meant to be. That class's behavioural half writes this
+     * path into a live configuration double and shows the verifier's verdict change, so it is
+     * evidence that this literal is the one the verifier reads; this class then ties the admin
+     * SECTION/GROUP/FIELD to it. Neither half is worth much alone: without the tie, renaming the
+     * group in both the XML and this file's constants leaves the field writing to a path nothing
+     * reads and the suite green; without the behavioural half, this is a string compared with
+     * itself.
+     */
+    private const VERIFIER_CONFIG_PATH = 'loqate_settings/address_settings/address_quality_index';
+
+    /**
+     * The scope attributes the field must ship with, and etc/adminhtml/system.xml's own reason
+     * for each: both callers of the threshold are adminhtml plugins reading it through
+     * Helper\Data::getConfigValue(), a SCOPE_STORE read with NO STORE NAMED, so a per-website or
+     * per-store-view override would be a knob that either does nothing or silently applies to a
+     * different store view than the merchant set it against.
+     *
+     * @var array<string, string>
+     */
+    private const REQUIRED_FIELD_SCOPE = [
+        'showInDefault' => '1',
+        'showInWebsite' => '0',
+        'showInStore' => '0',
+    ];
 
     /**
      * The admin field must be a SELECT over a source model.
@@ -56,25 +88,23 @@ class AddressQualityIndexTest extends TestCase
      * feedback anywhere. A select whose options come from a source model can only ever hold a
      * value that list contains.
      *
-     * The group matters as well as the section: the threshold belongs beside the other
-     * address-verification settings a merchant is looking at when they change it, and the config
-     * path the verifier reads
-     * (loqate_settings/address_settings/address_quality_index, via
-     * Validator::resolveQualityIndexThreshold()) is composed of section/group/field - so a field
-     * in the right section but the wrong group writes to a path nothing reads.
+     * The group matters as well as the section, and the third assertion is what makes that
+     * matter TESTABLE. Magento composes the config path a field writes to as
+     * section/group/field, and Validator::resolveQualityIndexThreshold() reads one literal
+     * path - so a field in the right section but the wrong group writes somewhere nothing reads,
+     * and the merchant's chosen quality bar has no effect at all. Until that third assertion
+     * existed, renaming the group in BOTH the XML and this file's constants left the suite
+     * entirely green while doing exactly that; the field's coordinates were only ever compared
+     * with themselves. See self::VERIFIER_CONFIG_PATH for the other half of the argument - why
+     * that literal is known to be the one the verifier reads.
      */
     public function testTheThresholdIsAdminSelectableRatherThanFreeText(): void
     {
-        $fields = $this->systemXml()->xpath(sprintf(
-            '/config/system/section[@id="%s"]/group[@id="%s"]/field[@id="%s"]',
-            self::SECTION_ID,
-            self::GROUP_ID,
-            self::FIELD_ID
-        ));
+        $fields = $this->thresholdField();
 
         $this->assertCount(
             1,
-            (array)$fields,
+            $fields,
             sprintf(
                 'etc/adminhtml/system.xml must expose exactly one "%s" field in the "%s" group of the "%s" '
                 . 'section. With no field at all the threshold is reachable only by data patch or CLI, so a '
@@ -105,6 +135,69 @@ class AddressQualityIndexTest extends TestCase
             . 'That is what ties what the merchant is OFFERED to what the verifier ACCEPTS; a hand-written '
             . 'option list in the XML would be a second copy of that list, free to drift.'
         );
+        $this->assertSame(
+            self::VERIFIER_CONFIG_PATH,
+            implode('/', [self::SECTION_ID, self::GROUP_ID, self::FIELD_ID]),
+            'The field\'s section/group/field coordinates must COMPOSE the path the verifier reads. '
+            . 'Magento derives a field\'s config path from exactly those three ids, and '
+            . 'Validator::resolveQualityIndexThreshold() reads one literal path, so a field placed in '
+            . 'another group is a form control that writes to a row nothing ever loads: the merchant '
+            . 'chooses a quality bar, saves, sees no error and gets no change - the shipped default keeps '
+            . 'deciding every import row. Without this assertion the three ids above were only ever '
+            . 'compared with the XML they were copied from, so renaming the group in both places was '
+            . 'silently green.'
+        );
+    }
+
+    /**
+     * The field is DEFAULT SCOPE ONLY: showInDefault="1", showInWebsite="0", showInStore="0".
+     *
+     * THE ONLY MERCHANT-VISIBLE DECISION THIS TICKET MAKES, and until now the only one with no
+     * test: mutating both zeros to "1" left the whole suite green. etc/adminhtml/system.xml
+     * calls the choice "a deliberate choice rather than a copied line" and gives its reason at
+     * length, so it is exactly the kind of decision that must fail loudly when reversed rather
+     * than be reversed by someone copying the 1/1/1 of the AVC thresholds directly below it.
+     *
+     * WHY IT IS THIS AND NOT 1/1/1. Both callers of the threshold are adminhtml plugins -
+     * Plugin\Admin\OrderSave and Plugin\Admin\ValidateImportAddress - and both read it through
+     * Helper\Data::getConfigValue(), which is a SCOPE_STORE read with NO STORE NAMED. Neither
+     * names the store view of the order it is judging or of the customers being imported, so
+     * whatever store the admin area resolves as current decides the value. Offering a per-website
+     * or per-store-view override would therefore be a control that either does nothing or
+     * silently applies to a different store view than the merchant set it against - the same
+     * class of defect, a setting whose effect cannot be predicted from the form, that LOQ-17148
+     * exists to close.
+     *
+     * IF YOU ARE HERE BECAUSE THIS FAILED: widening the scope needs the READERS changed first,
+     * to name the store they are judging (Helper\Data::getConfigValueForStore() exists for
+     * precisely that). The cache key already namespaces per store view and does not need
+     * touching. Widening the field alone ships the knob without the behaviour.
+     */
+    public function testTheThresholdIsConfigurableAtDefaultScopeOnly(): void
+    {
+        $field = $this->thresholdField()[0];
+
+        $scope = [];
+        foreach (array_keys(self::REQUIRED_FIELD_SCOPE) as $attribute) {
+            $scope[$attribute] = (string)($field[$attribute] ?? '');
+        }
+
+        $this->assertSame(
+            self::REQUIRED_FIELD_SCOPE,
+            $scope,
+            'The threshold field must be shown at DEFAULT scope only. showInWebsite="1" or showInStore="1" '
+            . 'offers the merchant an override that cannot work: both readers resolve the value through a '
+            . 'SCOPE_STORE read with no store named, so a per-view value applies to whichever store view '
+            . 'the admin area happens to resolve as current - not to the one the merchant set it against, '
+            . 'and not to the order or the import being judged.'
+        );
+        $this->assertSame(
+            ['showInDefault' => '1', 'showInWebsite' => '0', 'showInStore' => '0'],
+            self::REQUIRED_FIELD_SCOPE,
+            'Guard on the expectation itself, spelled out rather than referenced: this test is worth '
+            . 'nothing if the constant it compares against is edited to match a widened field. Changing '
+            . 'BOTH lines is the deliberate act the XML comment asks for.'
+        );
     }
 
     /**
@@ -113,6 +206,18 @@ class AddressQualityIndexTest extends TestCase
      * This is the direction that produces the silent total block: a selectable value outside the
      * verifier's accepted list makes checkQualityIndex() refuse to judge at all, so EVERY address
      * is rejected - reported to the merchant as an invalid row rather than as a bad setting.
+     *
+     * WHAT THIS PAIR OF TESTS ACTUALLY IS, said plainly because the name suggests more. It is a
+     * DRIFT GUARD ON A DERIVATION, not a comparison of two independent artefacts.
+     * AddressQualityIndex::toOptionArray() derives its values FROM Validator::VALID_QUALITY_INDEXES,
+     * so as long as the derivation is a straight projection both directions hold by construction
+     * and this one in particular cannot fail. It is kept for what it catches when that stops
+     * being true: the day the source model is hand-written, filtered, re-ordered into a
+     * hard-coded list, or given a placeholder option, the two sides stop being one artefact and
+     * these become real comparisons. Direction 2 -
+     * testEveryThresholdTheVerifierAcceptsIsSelectable() - has teeth sooner, because a FILTERED
+     * derivation (a "Not recommended" grade quietly dropped from the dropdown) still satisfies
+     * this direction while hiding a value the verifier honours.
      */
     public function testEverySelectableThresholdIsOneTheVerifierAccepts(): void
     {
@@ -142,6 +247,13 @@ class AddressQualityIndexTest extends TestCase
      * form does not offer is a setting only whoever knows the config path can reach, which is the
      * state this ticket found the threshold in. Keeping the two lists equal is also what makes
      * the source model's list DERIVED from the verifier's rather than a copy of it.
+     *
+     * THIS IS THE HALF WITH TEETH, for the reason set out on the test above: both sides derive
+     * from Validator::VALID_QUALITY_INDEXES, so a straight projection satisfies both directions
+     * by construction - but a FILTERED derivation does not. A source model that dropped a grade
+     * from the dropdown ("Poor" hidden as not recommended) would still offer only values the
+     * verifier accepts, and only this direction would notice that a threshold the verifier
+     * honours had become unreachable from the form.
      */
     public function testEveryThresholdTheVerifierAcceptsIsSelectable(): void
     {
@@ -168,7 +280,7 @@ class AddressQualityIndexTest extends TestCase
      */
     public function testTheShippedDefaultThresholdIsSelectable(): void
     {
-        $defaults = $this->configXml()->xpath(sprintf(
+        $defaults = self::xpathMatches($this->configXml(), sprintf(
             '/config/default/%s/%s/%s',
             self::SECTION_ID,
             self::GROUP_ID,
@@ -177,7 +289,7 @@ class AddressQualityIndexTest extends TestCase
 
         $this->assertCount(
             1,
-            (array)$defaults,
+            $defaults,
             'etc/config.xml must ship exactly one default for the threshold: with none, a fresh install '
             . 'reads it as null, which the verifier cannot judge against and which therefore rejects every '
             . 'address on the batch paths.'
@@ -270,6 +382,42 @@ class AddressQualityIndexTest extends TestCase
         return array_map(static fn ($value): string => (string)$value, $accepted);
     }
 
+    /**
+     * The shipped threshold field, as a list of matching elements.
+     *
+     * @return SimpleXMLElement[] Empty when the field is absent, which the callers report.
+     */
+    private function thresholdField(): array
+    {
+        return self::xpathMatches($this->systemXml(), sprintf(
+            '/config/system/section[@id="%s"]/group[@id="%s"]/field[@id="%s"]',
+            self::SECTION_ID,
+            self::GROUP_ID,
+            self::FIELD_ID
+        ));
+    }
+
+    /**
+     * Evaluate an xpath and answer a real list of elements.
+     *
+     * SimpleXMLElement::xpath() answers FALSE on a malformed expression, and `(array) false` is
+     * `[false]` - a one-element array. So `assertCount(1, (array)$xml->xpath(...))` PASSES for a
+     * query that never ran, which is the assertion this replaces at both of its call sites: a
+     * typo'd expression, or a query against a document whose structure changed under it, read as
+     * "exactly one match found". Normalising to [] here means the count assertions count
+     * matches.
+     *
+     * @param SimpleXMLElement $xml Parsed document.
+     * @param string $expression Xpath expression.
+     * @return SimpleXMLElement[]
+     */
+    private static function xpathMatches(SimpleXMLElement $xml, string $expression): array
+    {
+        $matched = $xml->xpath($expression);
+
+        return is_array($matched) ? $matched : [];
+    }
+
     /** etc/adminhtml/system.xml, parsed. */
     private function systemXml(): SimpleXMLElement
     {
@@ -287,6 +435,16 @@ class AddressQualityIndexTest extends TestCase
      * it is missing or malformed - a malformed one would break the admin form itself, so it is
      * worth its own message.
      *
+     * THE libxml SUPPRESSION IS WHAT MAKES THE fail() BELOW REACHABLE. simplexml_load_string()
+     * reports a parse error by RAISING E_WARNING as well as by returning false, and this suite
+     * runs with failOnWarning="true" - so on a malformed file PHPUnit would fail the test on the
+     * warning before the false was ever examined, and the message explaining that Magento cannot
+     * read the file either would never be printed. libxml_use_internal_errors() diverts the
+     * warning into libxml's own buffer, which this then clears and does not read: the message
+     * below is the diagnostic worth having, and leaving the buffer dirty would leak parse errors
+     * into whatever ran next. The previous state is restored rather than assumed, because it is
+     * process-global.
+     *
      * @param string $path Absolute path to the file.
      * @return SimpleXMLElement
      */
@@ -294,7 +452,11 @@ class AddressQualityIndexTest extends TestCase
     {
         $this->assertFileExists($path, sprintf('%s is part of the module\'s shipped configuration.', $path));
 
+        $previous = libxml_use_internal_errors(true);
         $xml = simplexml_load_string((string)file_get_contents($path));
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
         if ($xml === false) {
             $this->fail(sprintf('%s is not parseable XML, so Magento cannot read it either.', $path));
         }

--- a/Test/Unit/Plugin/Admin/ValidateImportAddressRowAttributionTest.php
+++ b/Test/Unit/Plugin/Admin/ValidateImportAddressRowAttributionTest.php
@@ -7,11 +7,11 @@ use Loqate\ApiIntegration\Helper\Data;
 use Loqate\ApiIntegration\Helper\Validator;
 use Loqate\ApiIntegration\Logger\Logger;
 use Loqate\ApiIntegration\Plugin\Admin\ValidateImportAddress;
+use Loqate\ApiIntegration\Test\Support\ProductionSerializerDouble;
 use Magento\Customer\Model\Session;
 use Magento\CustomerImportExport\Model\Import\Address;
 use Magento\Directory\Model\RegionFactory;
 use Magento\Framework\Module\ModuleListInterface;
-use Magento\Framework\Serialize\SerializerInterface;
 use Magento\ImportExport\Model\Import;
 use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingError;
 use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregator;
@@ -60,6 +60,14 @@ use ReflectionProperty;
  */
 class ValidateImportAddressRowAttributionTest extends TestCase
 {
+    /**
+     * The serializer double, shared with every other harness that reads a serialised payload
+     * back - see the trait. This class is the one that most needs it: it is the only end-to-end
+     * harness in the suite, so a lenient double would leave the entire import path's recovery
+     * from an unreadable session payload untested anywhere.
+     */
+    use ProductionSerializerDouble;
+
     /** Any non-empty key makes the import path reach the billable call. */
     private const API_KEY = 'TEST-API-KEY-0000';
 
@@ -199,27 +207,67 @@ class ValidateImportAddressRowAttributionTest extends TestCase
             );
         }
 
-        // Fixture preconditions, read off the WIRE rather than claimed: the file really did span
-        // the chunk boundary, and the rows the row numbers above depend on really were the ones
-        // repeated. Without these, a fixture that quietly stopped repeating anything would leave
-        // every assertion above trivially satisfiable.
-        $this->assertSame(
-            [self::CHUNK_SIZE, self::FILE_ROWS - self::CHUNK_SIZE],
-            array_map(
-                static fn (array $chunk): int => count($chunk),
-                array_chunk($rows, self::CHUNK_SIZE)
-            ),
-            'The file must span two chunks of the plugin\'s 100 rows, or the boundary this test is about '
-            . 'is not in it.'
+        // PRECONDITION 1, READ OFF THE WIRE: the PLUGIN really did cut this file at row 100.
+        //
+        // This is the load-bearing premise of everything above - the docblock's whole subject is
+        // the boundary at offset 99/100 - and it can only be established from the connector
+        // payloads, because that is the only place the plugin's chunking is observable. An
+        // earlier revision asserted it from array_chunk($rows, self::CHUNK_SIZE): the test
+        // chunking its OWN array by its OWN constant, which cannot fail and says nothing about
+        // the plugin. If the plugin chunked at 50 that assertion stayed green while every
+        // sentence around it was false.
+        $this->assertCount(
+            2,
+            $this->apiRequests,
+            'A 150-row file must reach the connector as exactly TWO batches. One means the plugin stopped '
+            . 'chunking and there is no boundary in this fixture at all; three or more means it chunks '
+            . 'smaller than 100 and the boundary is not where every row number above was counted from.'
         );
+        $this->assertSame(
+            array_map(
+                static fn (array $row): string => (string)$row['street'][0],
+                array_slice($rows, 0, self::CHUNK_SIZE)
+            ),
+            array_column($this->apiRequests[0]['Addresses'], 'Address1'),
+            'The FIRST batch must be exactly the file\'s first 100 rows, in file order. Chunk 1 repeats '
+            . 'nothing within itself and nothing is remembered before it, so every one of its rows is sent '
+            . '- which makes the first payload a faithful picture of where the plugin cut, and of the '
+            . 'order it sends in, which the positional attribution depends on.'
+        );
+        $this->assertSame(
+            [],
+            array_values(array_diff(
+                array_column($this->apiRequests[1]['Addresses'], 'Address1'),
+                array_map(
+                    static fn (array $row): string => (string)$row['street'][0],
+                    array_slice($rows, self::CHUNK_SIZE)
+                )
+            )),
+            'And the SECOND batch may carry nothing but rows from beyond the boundary. Together with the '
+            . 'assertion above that fixes the cut at offset 99/100 from the wire alone: a plugin that '
+            . 'chunked anywhere else would put a row on the wrong side of it.'
+        );
+
+        // PRECONDITION 2, a FIXTURE SELF-CHECK and not a wire reading: the rows the row numbers
+        // above depend on really are repeats of one another. It derives from self::PLANNED_ROWS,
+        // so what it can catch is a plan edited into one that no longer repeats anything across
+        // the boundary - after which the billed count would be met by a file with nothing to
+        // de-duplicate. It is deliberately NOT read off the wire, because most of these rows are
+        // not on the wire: being absent from it is the very thing being measured.
+        //
+        // Offset 103 is excluded on purpose. It is id 5, the row whose AQI is present but
+        // unreadable, and it appears in chunk 2 ONLY - it exists to cover a fault that first
+        // occurs after other rows have already been remembered, not to be a cross-boundary
+        // repeat. Including it would add a fifth street and assert the opposite of what this
+        // check is for.
         $this->assertSame(
             ['1 Test Street', '2 Test Street', '3 Test Street', '4 Test Street'],
             array_values(array_unique(array_map(
                 static fn (int $offset): string => (string)$rows[$offset]['street'][0],
                 [0, 5, 50, 99, 100, 101, 102, 104, 149]
             ))),
-            'The rows either side of the boundary must really be repeats of one another, or nothing is '
-            . 'being de-duplicated and the billed count proves nothing.'
+            'Nine planned offsets either side of the boundary must resolve to only FOUR distinct '
+            . 'addresses, or nothing is being de-duplicated and the billed count proves nothing.'
         );
     }
 
@@ -389,9 +437,11 @@ class ValidateImportAddressRowAttributionTest extends TestCase
         $moduleList = $this->createMock(ModuleListInterface::class);
         $moduleList->method('getOne')->willReturn(['setup_version' => '9.9.9']);
 
-        $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
-        $serializer->method('unserialize')->willReturnCallback(static fn ($value) => json_decode($value, true));
+        // Fails the way the PRODUCTION serializer fails. This harness is the only one in the
+        // suite driving the real plugin over the real Validator over a real session store end to
+        // end, so a lenient double here would be the single place where the whole import path
+        // could meet an unreadable session payload and look safe.
+        $serializer = $this->createSerializerDouble();
 
         $validator = new Validator(
             $this->createMock(Logger::class),

--- a/Test/Unit/Plugin/Admin/ValidateImportAddressRowAttributionTest.php
+++ b/Test/Unit/Plugin/Admin/ValidateImportAddressRowAttributionTest.php
@@ -1,0 +1,513 @@
+<?php
+
+namespace Loqate\ApiIntegration\Test\Unit\Plugin\Admin;
+
+use Loqate\ApiConnector\Client\Verify;
+use Loqate\ApiIntegration\Helper\Data;
+use Loqate\ApiIntegration\Helper\Validator;
+use Loqate\ApiIntegration\Logger\Logger;
+use Loqate\ApiIntegration\Plugin\Admin\ValidateImportAddress;
+use Magento\Customer\Model\Session;
+use Magento\CustomerImportExport\Model\Import\Address;
+use Magento\Directory\Model\RegionFactory;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\ImportExport\Model\Import;
+use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingError;
+use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregator;
+use ArrayIterator;
+use ArrayObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+
+/**
+ * THE ROW-ATTRIBUTION GUARANTEE of the customer import, asserted over the REAL Validator
+ * (LOQ-17148).
+ *
+ * NO ROW'S VERDICT IS EVER ATTRIBUTED TO ANOTHER ROW. That is the guarantee a merchant reads
+ * when the import report says "Invalid address at row #101": row 101 of their file, and no
+ * other. Getting it wrong is worse than getting the billing wrong, and worse than blocking the
+ * import: the merchant is sent to edit a row that is perfectly valid while the genuinely bad
+ * one imports unnoticed, and the report gives them no reason to doubt it.
+ *
+ * WHY THIS FILE EXISTS ALONGSIDE ValidateImportAddressTest. That class stubs the Validator out,
+ * which is right for what it asserts - the plugin's handling of the three return shapes - but
+ * it means the row numbers it pins are computed from verdict arrays the test itself wrote. The
+ * risk LOQ-17148 introduces lives in the seam BETWEEN the two units: verifyMultipleAddresses()
+ * pre-seeds one result slot per input row and filters out any slot still holding null, and
+ * afterValidateData() array_merge()s the per-chunk arrays and derives the row number from the
+ * merged offset. array_merge() renumbers integer keys BY INSERTION ORDER, so ONE dropped slot
+ * silently shifts every row number after it - across chunk boundaries included. Adding a new
+ * way to skip a row (a verdict remembered from earlier in the run) is exactly the kind of
+ * change that can leave a slot unfilled, and no test that stubs either side can see it. So this
+ * one wires the real plugin to the real Validator and reads the row numbers out of the
+ * merchant's own error report.
+ *
+ * The file under test mixes all four kinds of row that the run-scoped memory has to tell apart,
+ * and places them either side of the 100-row chunk boundary the plugin cuts at:
+ *  - rows Loqate PASSES, one of which repeats in a later chunk (a remembered pass);
+ *  - rows Loqate REJECTS on a readable AQI, repeating in a later chunk (a remembered
+ *    rejection - the case LOQ-17148 adds, and the one that must not cost a row its slot);
+ *  - rows whose AQI could NOT BE READ, repeating in a later chunk (never remembered, so
+ *    verified again and rejected again - a fault report is not a verdict);
+ *  - filler rows, distinct and passing, so the boundary sits where the plugin's arithmetic puts
+ *    it rather than at the end of a short fixture.
+ *
+ * The billed count is asserted in the same test on purpose. Row numbers alone would still be
+ * right if nothing were de-duplicated at all, so without it this file would pass against the
+ * unfixed code and stop being evidence of anything.
+ */
+class ValidateImportAddressRowAttributionTest extends TestCase
+{
+    /** Any non-empty key makes the import path reach the billable call. */
+    private const API_KEY = 'TEST-API-KEY-0000';
+
+    /** Config path gating the import verification feature. */
+    private const IMPORT_ENABLED = 'loqate_settings/address_settings/enable_customer_import';
+
+    /** Config path of the threshold batch verdicts are judged against. */
+    private const AQI_CONFIG_PATH = 'loqate_settings/address_settings/address_quality_index';
+
+    /** Threshold the fixture's grades are judged against: 'A' passes it, 'E' does not. */
+    private const AQI_THRESHOLD = 'C';
+
+    /** AQI better than the threshold => the row passes. */
+    private const PASSING_AQI = 'A';
+
+    /** AQI poorer than the threshold => the row is rejected on a READABLE verdict. */
+    private const FAILING_AQI = 'E';
+
+    /** Rows in the import file: two chunks of the plugin's 100, 100 + 50. */
+    private const FILE_ROWS = 150;
+
+    /** Rows per verification batch, as ValidateImportAddress::afterValidateData() chunks them. */
+    private const CHUNK_SIZE = 100;
+
+    /**
+     * The rows that are NOT filler, as file offset => [address id, what Loqate answers].
+     *
+     * Placed so that every kind of row appears on both sides of the chunk boundary at offset
+     * 99/100, which is where an off-by-one in the merge hides:
+     *  - id 1 passes at the file's FIRST row and repeats at its LAST;
+     *  - id 2 is rejected at offset 5 and repeats TWICE in chunk 2 (offsets 100 and 104), the
+     *    second of those being a repeat of a row already repeated - a remembered verdict served
+     *    twice from one chunk;
+     *  - id 4 is rejected at the LAST row of chunk 1 and repeats at the SECOND row of chunk 2,
+     *    the adjacent pair an off-by-one collapses onto one number;
+     *  - id 3's AQI cannot be read, and repeats in chunk 2, where it must be asked about again;
+     *  - id 5's AQI is present but unreadable, and appears in chunk 2 only, so a fault that
+     *    first occurs AFTER rows have already been remembered is covered too.
+     *
+     * @var array<int, array{0: int, 1: string}>
+     */
+    private const PLANNED_ROWS = [
+        0 => [1, 'pass'],
+        5 => [2, 'fail'],
+        50 => [3, 'no-readable-aqi'],
+        99 => [4, 'fail'],
+        100 => [2, 'fail'],
+        101 => [4, 'fail'],
+        102 => [3, 'no-readable-aqi'],
+        103 => [5, 'unreadable-aqi'],
+        104 => [2, 'fail'],
+        149 => [1, 'pass'],
+    ];
+
+    /**
+     * The 1-based file row numbers the merchant must be shown, and nothing else.
+     *
+     * Written out rather than derived from self::PLANNED_ROWS, because a derivation would share
+     * its arithmetic with the code under test's and the two would be wrong together. Every
+     * number here is "the file position of a row Loqate did not pass", counted by hand:
+     * offsets 5, 50 and 99 in chunk 1 and offsets 100 to 104 in chunk 2.
+     *
+     * @var int[]
+     */
+    private const EXPECTED_INVALID_ROW_NUMBERS = [6, 51, 100, 101, 102, 103, 104, 105];
+
+    /**
+     * Addresses distinct enough to be told apart, of which one - the row whose AQI cannot be
+     * read - has to be asked about a second time because a fault report is never remembered.
+     */
+    private const EXPECTED_DISTINCT_ADDRESSES = 145;
+
+    /** @var ArrayObject Payloads of every connector call, in order. */
+    private $apiRequests;
+
+    /** @var ArrayObject Live store configuration, config path => value. */
+    private $config;
+
+    /**
+     * THE test: an import file whose rows repeat across the chunk boundary, mixing passes,
+     * readable rejections, unreadable answers and de-duplicated rows, must report EXACTLY the
+     * right row numbers - and must bill each distinct address once.
+     *
+     * Both halves in one test deliberately. They are the two failure modes of the same change
+     * and they trade off against each other: skip too little and the merchant is over-billed,
+     * skip a row's SLOT rather than only its billable call and every row number after it is
+     * wrong. A test that asserted either alone would be satisfied by the bug the other one
+     * catches.
+     */
+    public function testEveryInvalidRowIsReportedUnderItsOwnFileRowNumberWhileEachAddressIsBilledOnce(): void
+    {
+        $rows = $this->importFileRows();
+
+        $report = $this->runImport($rows);
+
+        $this->assertSame(
+            self::EXPECTED_INVALID_ROW_NUMBERS,
+            array_column($report->recordedErrors, 'rowNumber'),
+            'Every invalid row must be reported under ITS OWN 1-based file position. The merged verdicts '
+            . 'are renumbered by insertion order, so a row that loses its slot - which is what happens if a '
+            . 'de-duplicated or skipped row is ever left holding null and filtered out of '
+            . 'verifyMultipleAddresses()\' result - shifts every row number after it. The merchant is then '
+            . 'sent to edit a VALID row while the bad one imports unnoticed, and nothing in the report '
+            . 'suggests otherwise. Note rows 100 and 101 are the last row of chunk 1 and the first of '
+            . 'chunk 2: the pair an off-by-one anywhere in the chunking, the merge or the skip collapses.'
+        );
+        $this->assertSame(
+            self::EXPECTED_DISTINCT_ADDRESSES + 1,
+            $this->addressesBilled(),
+            sprintf(
+                'The file holds %d distinct addresses, and exactly ONE of them - the row whose AQI could '
+                . 'not be read - may be sent twice, because a fault report is never remembered and its '
+                . 'repeat has to be asked about again. Anything more means a rejected row was re-billed in '
+                . 'a later chunk, which is the defect LOQ-17148 fixes; anything less means a row was '
+                . 'skipped that nobody had a verdict for.',
+                self::EXPECTED_DISTINCT_ADDRESSES
+            )
+        );
+
+        $this->assertSame(
+            array_map(
+                static fn (int $row): string => 'Invalid address at row #' . $row,
+                self::EXPECTED_INVALID_ROW_NUMBERS
+            ),
+            array_map(
+                static fn (array $error): string => (string)$error['errorMessage'],
+                $report->recordedErrors
+            ),
+            'The message the merchant reads must name the same row as the machine-readable row number.'
+        );
+        foreach ($report->recordedErrors as $error) {
+            $this->assertSame(
+                ProcessingError::ERROR_LEVEL_CRITICAL,
+                $error['errorLevel'],
+                'An invalid address must block the import rather than merely annotate it, whether its '
+                . 'verdict was earned in this chunk or remembered from an earlier one.'
+            );
+        }
+
+        // Fixture preconditions, read off the WIRE rather than claimed: the file really did span
+        // the chunk boundary, and the rows the row numbers above depend on really were the ones
+        // repeated. Without these, a fixture that quietly stopped repeating anything would leave
+        // every assertion above trivially satisfiable.
+        $this->assertSame(
+            [self::CHUNK_SIZE, self::FILE_ROWS - self::CHUNK_SIZE],
+            array_map(
+                static fn (array $chunk): int => count($chunk),
+                array_chunk($rows, self::CHUNK_SIZE)
+            ),
+            'The file must span two chunks of the plugin\'s 100 rows, or the boundary this test is about '
+            . 'is not in it.'
+        );
+        $this->assertSame(
+            ['1 Test Street', '2 Test Street', '3 Test Street', '4 Test Street'],
+            array_values(array_unique(array_map(
+                static fn (int $offset): string => (string)$rows[$offset]['street'][0],
+                [0, 5, 50, 99, 100, 101, 102, 104, 149]
+            ))),
+            'The rows either side of the boundary must really be repeats of one another, or nothing is '
+            . 'being de-duplicated and the billed count proves nothing.'
+        );
+    }
+
+    /**
+     * The import file: the planned rows at their planned offsets, everything else a distinct
+     * passing row so the chunk boundary falls where the plugin's arithmetic puts it.
+     *
+     * @return array<int, array> Magento-shaped import rows, in file order.
+     */
+    private function importFileRows(): array
+    {
+        $rows = [];
+        for ($offset = 0; $offset < self::FILE_ROWS; $offset++) {
+            $id = self::PLANNED_ROWS[$offset][0] ?? (1000 + $offset);
+            $rows[$offset] = $this->addressForId($id);
+        }
+
+        return $rows;
+    }
+
+    /**
+     * What Loqate answers for the address with the given id: whatever the plan says the first
+     * time that id appears, and the same thing every later time - the API's opinion of an
+     * address does not change mid-file.
+     *
+     * @param int $id Address id.
+     * @return string 'pass', 'fail', 'no-readable-aqi' or 'unreadable-aqi'.
+     */
+    private function apiVerdictForId(int $id): string
+    {
+        foreach (self::PLANNED_ROWS as $planned) {
+            if ($planned[0] === $id) {
+                return $planned[1];
+            }
+        }
+
+        return 'pass';
+    }
+
+    /** A distinct, fully-formed import row per address id. */
+    private function addressForId(int $id): array
+    {
+        return [
+            'street' => [$id . ' Test Street'],
+            'city' => 'London',
+            'postcode' => 'SW1A ' . $id . 'AA',
+            'country_id' => 'GB',
+        ];
+    }
+
+    /**
+     * Run the REAL plugin, wired to the REAL Validator, over an import file - one admin request,
+     * so all of its chunks share one Validator exactly as a real import does.
+     *
+     * @param array<int, array> $rows Import rows, in file order.
+     * @return ProcessingErrorAggregator&object{recordedErrors: array} The merchant's report.
+     */
+    private function runImport(array $rows)
+    {
+        $this->apiRequests = new ArrayObject();
+        $this->config = new ArrayObject([
+            'loqate_settings/settings/api_key' => self::API_KEY,
+            self::IMPORT_ENABLED => '1',
+            self::AQI_CONFIG_PATH => self::AQI_THRESHOLD,
+        ]);
+
+        $subject = $this->createMock(Address::class);
+        $subject->method('getBehavior')->willReturn(Import::BEHAVIOR_ADD_UPDATE);
+        $subject->method('getSource')->willReturn(new ArrayIterator($rows));
+
+        $aggregator = self::errorAggregator();
+        $result = $this->createPlugin()->afterValidateData($subject, $aggregator);
+
+        $this->assertSame(
+            $aggregator,
+            $result,
+            'afterValidateData() must return the aggregator it was given, whatever happened: it is an '
+            . 'after-plugin, and its return value replaces validateData()\'s.'
+        );
+
+        return $result;
+    }
+
+    /**
+     * The plugin under test, built WITHOUT its constructor and holding a REAL Validator.
+     *
+     * AbstractPlugin's constructor wants three framework collaborators this plugin never reads
+     * and this bootstrap does not have, so the two it does read are injected into their declared
+     * properties instead - the same approach ValidateImportAddressTest takes. The difference
+     * that matters is the Validator: a real one, so the chunk loop's shared instance is a real
+     * request lifetime and the result shape crossing the seam is the real one.
+     *
+     * @return ValidateImportAddress
+     */
+    private function createPlugin(): ValidateImportAddress
+    {
+        $config = $this->config;
+        $helper = $this->createMock(Data::class);
+        $helper->method('getConfigValue')->willReturnCallback(
+            static fn ($configPath) => $config->offsetExists($configPath) ? $config[$configPath] : ''
+        );
+        $helper->method('getCurrentStore')->willReturn(0);
+
+        $plugin = (new ReflectionClass(ValidateImportAddress::class))->newInstanceWithoutConstructor();
+        foreach (['validator' => $this->createValidator($helper), 'helper' => $helper] as $property => $value) {
+            $reflection = new ReflectionProperty(ValidateImportAddress::class, $property);
+            $reflection->setAccessible(true);
+            $reflection->setValue($plugin, $value);
+        }
+
+        return $plugin;
+    }
+
+    /**
+     * A real Validator with a live session store and a mocked billable connector, sharing the
+     * plugin's configuration helper because in production they read the same configuration.
+     *
+     * @param Data $helper Configuration helper, shared with the plugin.
+     * @return Validator
+     */
+    private function createValidator(Data $helper): Validator
+    {
+        $sessionStore = new ArrayObject();
+
+        // The shared Test/stubs Session is a no-op, so nothing would ever be remembered between
+        // chunks and the de-duplication under test could not be observed at all. getData() and
+        // setData() have to be *added* when the real Magento\Customer\Model\Session is present,
+        // because it does not declare them; the stub does, and PHPUnit refuses to "add" an
+        // existing method - hence the method_exists() filter.
+        $sessionBuilder = $this->getMockBuilder(Session::class)->disableOriginalConstructor();
+        $undeclared = array_values(array_filter(
+            ['getData', 'setData'],
+            static fn (string $method): bool => !method_exists(Session::class, $method)
+        ));
+        if ($undeclared) {
+            $sessionBuilder->addMethods($undeclared);
+        }
+        $sessionMock = $sessionBuilder->getMock();
+        $sessionMock->method('getData')->willReturnCallback(
+            static fn ($key = '', $clear = false) => $sessionStore[$key] ?? null
+        );
+        $sessionMock->method('setData')->willReturnCallback(
+            static function ($key, $value = null) use ($sessionStore, $sessionMock) {
+                $sessionStore[$key] = $value;
+
+                return $sessionMock;
+            }
+        );
+
+        $regionFactory = $this->createMock(RegionFactory::class);
+        $regionFactory->method('create')->willReturnCallback(
+            static function () {
+                return new class {
+                    public function load($regionId)
+                    {
+                        return $this;
+                    }
+
+                    public function getName()
+                    {
+                        return '';
+                    }
+                };
+            }
+        );
+
+        $moduleList = $this->createMock(ModuleListInterface::class);
+        $moduleList->method('getOne')->willReturn(['setup_version' => '9.9.9']);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('serialize')->willReturnCallback(static fn ($value) => json_encode($value));
+        $serializer->method('unserialize')->willReturnCallback(static fn ($value) => json_decode($value, true));
+
+        $validator = new Validator(
+            $this->createMock(Logger::class),
+            $sessionMock,
+            $regionFactory,
+            $moduleList,
+            $helper,
+            $serializer
+        );
+
+        // The connector is built inside the constructor (new Verify($apiKey)), so the only way to
+        // intercept the billable call is to swap the private property afterwards.
+        $requests = $this->apiRequests;
+        $connector = $this->createMock(Verify::class);
+        $connector->method('verifyAddress')->willReturnCallback(
+            function ($payload) use ($requests) {
+                $requests[] = $payload;
+
+                // One row per address SENT, in the order they were sent: that positional
+                // correspondence is what verifyMultipleAddresses() attributes verdicts by, and it
+                // is how the Cleansing API answers a batch. Getting this wrong here would make
+                // the row-count guard fail the batch instead of exercising the attribution.
+                $rows = [];
+                foreach ((array)($payload['Addresses'] ?? []) as $address) {
+                    $rows[] = $this->responseRowFor((array)$address);
+                }
+
+                return $rows;
+            }
+        );
+        $reflection = new ReflectionProperty(Validator::class, 'apiConnector');
+        $reflection->setAccessible(true);
+        $reflection->setValue($validator, $connector);
+
+        return $validator;
+    }
+
+    /**
+     * One response row for a parsed address, in the shape verifyMultipleAddresses() reads:
+     * $response[$n][0]['AQI'].
+     *
+     * The two unreadable shapes are the two routes to "no readable AQI" and both survive the
+     * connector's array_column($response, 'Matches') with the row count preserved, so neither is
+     * caught by the row-count guard: "Matches":[] is Loqate saying "no match for this address",
+     * and "AQI":"" is a value that is really there but is not a grade.
+     *
+     * The return type is deliberately left off rather than declared array: a row can legitimately
+     * arrive as [].
+     *
+     * @param array $address One entry of the payload's 'Addresses' list.
+     * @return mixed One response row.
+     */
+    private function responseRowFor(array $address)
+    {
+        $street = (string)($address['Address1'] ?? '');
+        $id = (int)strtok($street, ' ');
+
+        switch ($this->apiVerdictForId($id)) {
+            case 'no-readable-aqi':
+                return [];
+            case 'unreadable-aqi':
+                return [['AQI' => '']];
+            case 'fail':
+                return [['AQI' => self::FAILING_AQI]];
+            default:
+                return [['AQI' => self::PASSING_AQI]];
+        }
+    }
+
+    /**
+     * Number of ADDRESSES the run put on the invoice: the Cleansing API is billed per address,
+     * not per request.
+     *
+     * @return int
+     */
+    private function addressesBilled(): int
+    {
+        $billed = 0;
+        foreach ($this->apiRequests as $payload) {
+            $billed += count((array)($payload['Addresses'] ?? []));
+        }
+
+        return $billed;
+    }
+
+    /**
+     * A ProcessingErrorAggregator that records what was reported to it, in order, keeping the
+     * real parameter names so a failure reads like the merchant's import report.
+     *
+     * @return ProcessingErrorAggregator&object{recordedErrors: array}
+     */
+    private static function errorAggregator()
+    {
+        return new class extends ProcessingErrorAggregator {
+            /** @var array<int, array> */
+            public $recordedErrors = [];
+
+            public function addError(
+                $errorCode,
+                $errorLevel = ProcessingError::ERROR_LEVEL_CRITICAL,
+                $rowNumber = null,
+                $columnName = null,
+                $errorMessage = null,
+                $errorDescription = null
+            ) {
+                $this->recordedErrors[] = [
+                    'errorCode' => $errorCode,
+                    'errorLevel' => $errorLevel,
+                    'rowNumber' => $rowNumber,
+                    'columnName' => $columnName,
+                    'errorMessage' => $errorMessage,
+                    'errorDescription' => $errorDescription,
+                ];
+
+                return $this;
+            }
+        };
+    }
+}

--- a/Test/stubs/Magento/Framework/Data/OptionSourceInterface.php
+++ b/Test/stubs/Magento/Framework/Data/OptionSourceInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Lightweight test stub — defined only when the real interface is absent.
+ * One type per file so Magento's DI PhpScanner can parse it.
+ *
+ * Needed so the admin-field source models under Model/Config/Source can be LOADED by a test
+ * at all: every one of them declares `implements OptionSourceInterface`, so without this the
+ * class cannot be autoloaded outside a Magento instance and nothing can assert what a
+ * merchant is offered in the admin form. The method signature mirrors the framework's,
+ * because Model\Config\Source\AddressQualityIndex::toOptionArray() is what
+ * Test\Unit\Model\Config\Source\AddressQualityIndexTest reads the selectable address quality
+ * indexes out of (LOQ-17148).
+ */
+
+namespace Magento\Framework\Data;
+
+if (!interface_exists(\Magento\Framework\Data\OptionSourceInterface::class, false)) {
+    interface OptionSourceInterface
+    {
+        /**
+         * @return array
+         */
+        public function toOptionArray();
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -63,6 +63,48 @@
                     <label>Enable on Customer Import (ADMIN)</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <!--
+                    LOQ-17148: the Address Quality Index threshold, exposed here for the first
+                    time. It was previously reachable only through etc/config.xml's default, a
+                    data patch or bin/magento config:set, while the verifier compares it as a
+                    STRING - so a value sorting above "E" accepted every address and one below
+                    "A" rejected every address, either of them set (and only discoverable) by
+                    whoever knew the config path. A SELECT over the module's own source model,
+                    whose values are derived from Helper\Validator::VALID_QUALITY_INDEXES, is
+                    what stops what the merchant is OFFERED drifting from what the verifier
+                    ACCEPTS.
+
+                    DEFAULT SCOPE ONLY (showInWebsite="0" showInStore="0"), matching the three
+                    ADMIN toggles above rather than the 1/1/1 of the AVC thresholds below, and
+                    this is a deliberate choice rather than a copied line.
+
+                    Both callers of Validator::checkQualityIndex() are adminhtml plugins -
+                    Plugin\Admin\OrderSave (admin order create) and
+                    Plugin\Admin\ValidateImportAddress (customer import) - and BOTH read the
+                    threshold through Helper\Data::getConfigValue(), which is a SCOPE_STORE read
+                    with NO STORE NAMED. Neither names the store view of the order it is judging
+                    or of the customers being imported; OrderSave has the order in hand and still
+                    does not. So whatever store the admin area resolves as current is what
+                    decides the value - see Helper\Data::getConfigValueForStore(), which exists
+                    precisely because a per-store-view override is invisible to getConfigValue()
+                    from the admin. Offering a per-website or per-store-view override here would
+                    therefore be a knob that either does nothing or silently applies to a
+                    different store view than the merchant set it against, which is the same
+                    class of defect - a setting whose effect cannot be predicted from the form -
+                    that this ticket closes.
+
+                    (Validator::buildBatchVerifyCacheKey() still namespaces cached verdicts per
+                    store view. That is because getConfigValue() is a SCOPE_STORE read in general
+                    and one browser session can span store views, NOT a claim that this field is
+                    per-view. If the AQI is ever judged on a frontend path, or if these plugins
+                    are ever changed to name their store, widen this field then - the cache key
+                    already accommodates it.)
+                -->
+                <field id="address_quality_index" translate="label" type="select" sortOrder="0" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Minimum Address Quality Index</label>
+                    <source_model>Loqate\ApiIntegration\Model\Config\Source\AddressQualityIndex</source_model>
+                    <comment>The poorest address quality Loqate may report for an address to be accepted on the ADMIN batch paths - Create Order (Admin) and Customer Import (Admin). An address graded worse than this is reported as invalid, and on an import that blocks the file. "Excellent" is the strictest setting and the one shipped by default, so loosening it accepts addresses that were previously rejected. Checkout and the customer account are judged against the AVC thresholds below instead, not against this setting.</comment>
+                </field>
             </group>
             <group id="verify_threshold_settings" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Address Verification - Thresholds</label>


### PR DESCRIPTION
Fixes [LOQ-17148](https://gbg.atlassian.net/browse/LOQ-17148).

> **Stacked PR.** Base is `fix/LOQ-16976-dedupe-multi-address-verify` (#41), not `master`. Retarget as the stack merges. [LOQ-17149](https://github.com/loqate/loqate-magento/pull/43) stacks on top of this one.

LOQ-16976 (#41) was raised for two over-billing paths, **admin order create** and **customer import**, and delivered only the first. Its own code says so: *"DO NOT MEASURE THIS AGAINST THE IMPORT PATH … The practical dedupe on the import path is consequently near nil."* This is the import half.

## What the measurement changed

The obvious fix — cache failing verdicts too, since most import rows fail — was implemented, measured, and **rejected as a billing regression**.

`BATCH_VERIFY_CACHE_LIMIT` is 200 and eviction is FIFO. For 1000 distinct rows at a 5% pass rate:

| | run 2 billed |
| --- | --- |
| today (passes only) | **950** — run 1's 50 passes fit in the store and all hit |
| caching failures too | **1000** — run 1 writes 1000 entries through a 200-slot FIFO; run 2 is a sequential cyclic scan whose hit rate is **exactly 0%** |

Caching failures is *safe* — a cached failure is fail-closed and can only ever cause a rejection — but it makes the number this ticket exists to reduce strictly worse, because failures crowd out the sparse passes FIFO currently preserves.

Two other options were priced and rejected: **retain-on-full** (one Check Data click on a 200-row file permanently fills a store that is never flushed in adminhtml, destroying LOQ-16976's delivered order-create win) and **sizing the store to the file** (~147 bytes/entry, so ~1.4 MB of session read+write on every unrelated admin page load for the session's life).

## What ships instead

A **run-scoped verdict map**, holding both polarities, unbounded by the cache limit, deduplicating every repeat across the chunks of one run and dying with the request. The session store is left exactly as it is.

Measured on the acceptance fixture: 260 rows, 210 distinct, spread so repeats cross chunk boundaries → **210 billed instead of 260, a 19.2% reduction**. The fixture asserts distinct rows > `BATCH_VERIFY_CACHE_LIMIT`, so the session store cannot be credited with any of the win.

The map is scoped to **ownership**, not to the request: it is discarded on both the read and the write path whenever the shopper changes, and it consults the seam's own `ownershipGeneration()` rather than bolting a second identity check onto the call site. That matters on the import path, where `$checkForCaptured` is false and no session attribute is touched first.

`checkQualityIndex()` now returns `?bool` with `null` meaning *unreadable*. An unreadable verdict is remembered **nowhere** — collapsing that distinction fails 13 tests.

## Cross-run dedupe is descoped, with the numbers

The ticket permits *"the import path is explicitly descoped with the residual billing exposure quantified"*, and that is the branch taken, for a structural reason rather than a shrug: under CLI, cron or programmatic import each process calls `session_start()` with a fresh session id, so nothing written by one run is ever found by the next. **Cross-run dedupe there is 0% by construction.** Raised as [LOQ-17197](https://gbg.atlassian.net/browse/LOQ-17197), which records the three rejected approaches so they are not re-attempted, and names the risk any persistent store must design for — a verdict held outside the session is replayable across identities, the exact leak LOQ-16978 closed.

## Three corrections to the ticket text

Recorded in the commit bodies, because the ticket I wrote was wrong on all three:

1. The interception point is `Address::validateData()`, not `Import::validateSource()`.
2. Stock Magento Open Source ships **no** `bin/magento import:run`; that path comes from custom modules.
3. The admin-UI session **does** persist — the admin auth session and the customer session are two namespaces of one PHP session, so the cache works there. Only CLI/cron is structurally dead.

**LOQ-17015's bound was also corrected, by up to 99×.** It was published as "one duplicate charge per distinct address per run". The truth is that an address appearing *k* times in the chunk where it first appears is billed *k* times, up to the full chunk size of 100. That is now pinned at the real chunk size, read out of the production source rather than hard-coded, so the test fails loud if the chunking changes.

## Also fixed, because both were billing holes on this exact path

- **An unreadable `address_quality_index` billed the entire file** for a refusal the configuration had already decided.
- **The terminal `array_filter` was fail-open on `OrderSave`** — a dropped key meant an address reached an order unverified and silent.

## Merchant-visible

`address_quality_index` is now exposed in the admin (`Stores → Configuration → Loqate`), as a dropdown constrained to `A`–`E` rather than free text, wired to the existing-but-unreferenced `Model/Config/Source/AddressQualityIndex.php`. Previously the field could only be set by data patch, `config:set` or SQL — and an unrecognised value used to pass every address. `CHANGELOG.md` carries the detail.

## Tests

`OK (373 tests, 1645 assertions)`, green under `--order-by=random`, from a `328/1419` baseline. Container only — the suite needs `ext-dom`/`ext-mbstring`/`ext-xmlwriter`:

```
docker run --rm -v "$PWD":/app -w /app php:8.3-cli ./vendor/bin/phpunit
```

**A green suite is not offered as evidence.** Three defects survived a fully green suite on this branch and were caught by mutation testing: the ownership counter never advancing on adoption (a cross-identity verdict leak reachable via `logout()`); a session-store test that passed with the session read **deleted entirely**; and the `system.xml` scope, which could be widened with 360/360 green. Every acceptance criterion is mutation-verified, and the adversarial review reproduced the arithmetic above independently from the code rather than from the prose.
