### PR TITLE
chore(devcontainer): make the admin area reachable and stop the sync breaking di:compile

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -30,7 +30,12 @@ services:
       - "3306:3306"
     volumes:
       - dbdata:/var/lib/mysql
-    command: --default-authentication-plugin=mysql_native_password --ssl=0
+    # log-bin-trust-function-creators is required by Magento's setup:upgrade, which creates
+    # triggers for the indexer changelog tables and otherwise fails with "You do not have the
+    # SUPER privilege and binary logging is enabled" (SQLSTATE HY000 1419). setup-magento.sh
+    # sets it with SET GLOBAL, but that is lost whenever this container restarts - so the very
+    # next setup:upgrade fails. Set it here so it survives restarts.
+    command: --default-authentication-plugin=mysql_native_password --ssl=0 --log-bin-trust-function-creators=1
 
   opensearch:
     image: opensearchproject/opensearch:2.19.3

--- a/.devcontainer/nginx.conf
+++ b/.devcontainer/nginx.conf
@@ -38,6 +38,16 @@ http {
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             include fastcgi_params;
+            # Restore the port in HTTP_HOST. Debian's fastcgi_params sets
+            # "fastcgi_param HTTP_HOST $host;" as a security workaround, and $host drops the
+            # port - so PHP sees "localhost" for a request to localhost:8080. Magento's
+            # Backend\App\Area\FrontNameResolver::isHostBackend() compares the configured
+            # base_url host:port ("localhost:8080") against the request's, defaulting the
+            # missing port to 80 ("localhost:80"). They never match, isHostBackend() returns
+            # false, AreaList resolves /admin to the FRONTEND area, and the whole admin panel
+            # answers 404 with the Luma theme's 404 page - no exception, nothing in the logs.
+            # Must come AFTER the include so it wins.
+            fastcgi_param HTTP_HOST $http_host;
         }
 
         location /static/ {

--- a/.devcontainer/sync-extension.sh
+++ b/.devcontainer/sync-extension.sh
@@ -41,11 +41,23 @@ echo "Syncing $EXTENSION_DIR -> $TARGET (real copy)"
 rm -rf "$TARGET"
 mkdir -p "$TARGET"
 # Mirror the module, excluding VCS / dev-container / nested composer + node deps.
+#
+# .claude is excluded because it can hold git WORKTREES (.claude/worktrees/<id>/), each a
+# full second copy of this module INCLUDING its own vendor/ with phpunit in it. --exclude=./vendor
+# is anchored at the top level and does not catch those. Copying them in breaks the build twice
+# over: setup:di:compile walks vendor/ and dies on phpunit's classes ("Class
+# SebastianBergmann\CodeUnit\CodeUnit not found"), and the whole-module source scans in
+# Test/Unit (ShopperScopedSessionStoresTest, ValidatorImportRunDedupeTest) count every call site
+# twice per worktree. Excluded rather than exclude=vendor globbed, so a worktree cannot
+# contribute source either.
 tar --exclude=.git \
     --exclude=.devcontainer \
     --exclude=./vendor \
     --exclude=node_modules \
     --exclude=.github \
+    --exclude=.claude \
+    --exclude=.phpunit.cache \
+    --exclude=.naas \
     -C "$EXTENSION_DIR" -cf - . | tar -C "$TARGET" -xf -
 
 cd "$MAGENTO_DIR"
@@ -54,7 +66,15 @@ composer dump-autoload >/dev/null 2>&1 || true
 
 case "$MODE" in
   none)  echo "Copied (no build). Run 'bin/magento setup:upgrade && setup:di:compile' as needed." ;;
-  full)  bin/magento setup:upgrade && bin/magento setup:di:compile && bin/magento cache:flush ;;
+  # One command per line, NOT an && chain. Under `set -e` a failure in any position of an
+  # `a && b && c` list except the last does NOT abort the script, so a failing setup:upgrade
+  # used to skip di:compile and cache:flush and then print "Done." - reporting success while
+  # leaving the copied source uncompiled and the old code still live.
+  full)
+    bin/magento setup:upgrade
+    bin/magento setup:di:compile
+    bin/magento cache:flush
+    ;;
   flush) bin/magento cache:flush ;;
 esac
 


### PR DESCRIPTION
## 🎫 Jira ticket

None — local devcontainer tooling only. No module code is touched, so nothing ships to merchants.

## 📝 Description

Deploying master (v2.1.0) onto a devcontainer that was still serving v2.0.16 hit three separate
devcontainer defects. All three are pre-existing, none is caused by the module, and each one costs
real time because **none of them reports itself as the thing that is wrong**:

1. **The entire admin area returned 404.** Debian's `/etc/nginx/fastcgi_params` ships
   `fastcgi_param HTTP_HOST $host;` as a deliberate security workaround, and `$host` **drops the
   port** — so PHP sees `localhost` for a request to `localhost:8080`.
   `Magento\Backend\App\Area\FrontNameResolver::isHostBackend()` compares the configured base URL's
   host:port against the request's, defaulting a missing port to 80:

   * configured `web/unsecure/base_url` → `localhost:8080`
   * request `HTTP_HOST` → `localhost` → `localhost:80`

   They never match, so `isHostBackend()` returns `false` and
   `AreaList::getCodeByFrontName('admin')` resolves to **`frontend`** instead of `adminhtml`. Every
   admin URL is then an unknown frontend route: HTTP 404 rendered with the **Luma theme**, and
   because it is a routing miss rather than an error, **nothing appears in `var/log/` or
   `var/report/`**. The storefront works perfectly throughout, so a frontend-only smoke check
   shows nothing. This mattered here because most of v2.1.0 is admin-side.

2. **`setup:upgrade` failed** with `SQLSTATE[HY000] 1419 You do not have the SUPER privilege and
   binary logging is enabled` while creating the indexer changelog triggers. `setup-magento.sh`
   enables `log_bin_trust_function_creators` with `SET GLOBAL`, which is **lost on every db
   container restart** — so the next `setup:upgrade` fails. Core catalog indexer setup, unrelated
   to Loqate.

3. **`sync-extension.sh` copied `.claude/worktrees/` into Magento's `vendor/`.** Git worktrees are
   each a full second copy of the module *including their own `vendor/` with PHPUnit in it*, and
   the existing `--exclude=./vendor` is anchored at the top level so it does not catch nested ones.
   `setup:di:compile` walks `vendor/` and dies on PHPUnit's classes:

   ```
   There is an error in …/loqate-integration/.claude/worktrees/agent-…/vendor/sebastian/code-unit/src/InterfaceMethodUnit.php
   Class "SebastianBergmann\CodeUnit\CodeUnit" not found
   ```

   The copy was 31 MB instead of 2.4 MB. Same root cause makes the unit suite report a false
   failure: the whole-module source scans in `ShopperScopedSessionStoresTest` and
   `ValidatorImportRunDedupeTest` deliberately walk the entire module, so every worktree
   double-counts every call site.

Plus a fourth, which is why (2) was diagnosed as "the sync worked" for a while: **the sync script
reported success after failing.**

## 🔧 What changed

- **`.devcontainer/nginx.conf`** — add `fastcgi_param HTTP_HOST $http_host;` after
  `include fastcgi_params;` in the `location ~* \.(php)$` block, so the port survives and the admin
  area resolves. Placed *after* the include so it wins.
- **`.devcontainer/docker-compose.yml`** — add `--log-bin-trust-function-creators=1` to the `db`
  service `command:` so the flag survives container restarts instead of being set once by
  `setup-magento.sh` via `SET GLOBAL`.
- **`.devcontainer/sync-extension.sh`** — add `--exclude=.claude --exclude=.phpunit.cache
  --exclude=.naas` to the mirror, so worktrees and local tool state cannot reach Magento's
  `vendor/` or be walked by `di:compile`.
- **`.devcontainer/sync-extension.sh`** — split the `--full` branch from
  `a && b && c` into one command per line. Under `set -e`, a failure anywhere in an `&&` list
  **except the last position does not abort the script**, so the failing `setup:upgrade` from (2)
  skipped `di:compile` *and* `cache:flush` and the script still printed `Done.` — reporting success
  while leaving the copied source uncompiled and the old code live. This is the change most worth a
  second pair of eyes: it converts a silent no-op into a visible failure.

Each change carries a comment explaining the failure mode, because all four are the kind that look
like something else.

### Non-obvious for the reviewer

- **The `nginx.conf` change only takes effect when the container is recreated.** It is a
  *single-file* bind mount, and single-file mounts do not follow the host file when an editor
  replaces it (the inode changes). Editing it on a running container appears to do nothing.
- To fix a running container without a rebuild, patch the file that is not mounted read-only:
  ```bash
  docker exec -u root loqate-magento_devcontainer-php-1 bash -lc \
    'echo "fastcgi_param HTTP_HOST \$http_host;" >> /etc/nginx/fastcgi_params && nginx -t && nginx -s reload'
  ```
  That is a local-only workaround and deliberately **not** part of this PR; `nginx.conf` is the
  durable form.

## ✅ Tests

- [x] Unit tests pass locally (`vendor/bin/phpunit`) — 428 tests, 1928 assertions. One failure,
      `ShopperScopedSessionStoresTest::testEveryStatementThatCanTripTheEnrolmentAssertionIsAccountedForByClass`,
      is the worktree artifact described in (3): every diff entry is a `.claude/worktrees/…` key and
      the real per-class counts match the expectation exactly. It does not occur on CI (fresh clone,
      no worktrees) and clears once stale worktrees are removed. No test changes in this PR.
- [ ] New/changed behaviour is covered by tests — n/a, devcontainer configuration has no test
      harness in this repo.
- [x] Manually verified.

Verified after the changes, with v2.1.0 synced over v2.0.16:

| Check | Result |
| --- | --- |
| Live module version | `2.1.0` (was `2.0.16`) |
| Source vs live `diff -rq` | Identical (excluding dev-only dirs) |
| Stray dirs in `vendor/` copy | None; 2.4 MB (was 31 MB) |
| `setup:upgrade` | Completes |
| `setup:di:compile` | Completes; `UnverifiedAdminOrderMessage` present in `generated/metadata/adminhtml.php` |
| Frontend `http://localhost:8080/` | 200 |
| Admin `http://localhost:8080/admin/` | 200 — "Magento Admin" |
| Module static asset (`capture.js`) | 200 |
| `var/log/exception.log` | Empty |

The `HTTP_HOST` override idiom was verified explicitly rather than assumed: with the Debian `$host`
line left in place and the override appended after it — the same ordering `nginx.conf` produces —
PHP receives `localhost:8080` and `/admin/` returns 200.

Procedure and rationale are documented on the wiki:
[Testing the Loqate module in the local Magento devcontainer](https://github.com/loqate/loqate-magento/wiki/Testing-the-Loqate-module-in-the-local-Magento-devcontainer).

## 📦 Conventional commits & versioning

- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] **Version impact needs a decision before merge.** The commit on this branch is
      `fix: nginx and dev extension on local`. `auto-tag.yml` computes the bump from commit messages
      (merges here are merge commits, not squashes), so a `fix:` on master cuts a **patch release —
      v2.1.1, a new tag, a GitHub release and a `composer.json` bump** for a change that touches
      only `.devcontainer/` and ships no module code. PR #39, the comparable devcontainer change,
      used `chore(devcontainer):` precisely to avoid this.

      Recommendation: amend the commit to `chore(devcontainer): …` (force-push required) so no
      release is cut. This PR is titled `chore(devcontainer):` on that basis — retitle it to `fix:`
      instead if a release is actually wanted.

## 👀 Reviewer checklist

- [ ] Code is readable and follows the conventions of the surrounding code
- [ ] Change matches the linked Jira ticket's scope (no unrelated changes)
- [ ] Tests are present and meaningful; CI is green
- [ ] Commit messages / PR title are correct Conventional Commits
- [ ] No secrets, credentials, or debug code committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
