### PR TITLE
fix(LOQ-17502): dispatch the input event Hyvä Checkout needs on populate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 # ==============================================================================
-# CI - Unit Tests
+# CI - Test Suites
 # ==============================================================================
-# Runs the module's PHPUnit unit test suite on every pull request and on pushes
-# to master. The tests run in isolation (no full Magento install) via the
-# stub-backed bootstrap in Test/bootstrap.php.
+# Runs the module's two test suites on every pull request and on pushes to
+# master:
+#
+#   unit-tests    PHPUnit, for the PHP module code. Runs in isolation (no full
+#                 Magento install) via the stub-backed bootstrap in
+#                 Test/bootstrap.php.
+#   js-tests      node:test + jsdom, for the vendored capture SDK in
+#                 view/base/web/capture.js. Loads the real script into a jsdom
+#                 document and asserts its DOM event contract (LOQ-17502).
 # ==============================================================================
 
 name: CI
@@ -58,3 +64,46 @@ jobs:
 
       - name: Run unit tests
         run: vendor/bin/phpunit --colors=never
+
+  # ============================================================================
+  # JavaScript tests - the vendored Loqate capture SDK
+  # ============================================================================
+  # jsdom-based, so there is no browser to download. The suite injects the real
+  # view/base/web/capture.js into a jsdom document, stubs the find/retrieve
+  # endpoints with a local node:http server, and asserts the input/change events
+  # the SDK dispatches. See Test/js/.
+  # ============================================================================
+  js-tests:
+    name: JS tests (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22', '24']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache npm downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.npm-cache.outputs.dir }}
+          key: npm-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-${{ matrix.node-version }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run JS tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,13 @@ composer.lock
 
 # Local code-review reports — working notes, not product
 /.naas/
+
+# JavaScript / npm / node:test
+# `package-lock.json` IS committed, unlike composer.lock above. The asymmetry is
+# deliberate: composer.json is the manifest consumers install this module with,
+# so pinning its resolution would fight their own dependency graph. package.json
+# is dev-only test tooling that is never shipped in the Magento package, so
+# locking it costs nothing and buys deterministic CI (`npm ci`).
+/node_modules/
+/coverage/
+npm-debug.log*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,19 +144,53 @@ predate it and are described by their git tags and commit history.
   street field looked like it survived, on both front ends, only because the shopper
   typed into it and real `input` events had already fired.
 
-  The module's own wrapper now dispatches, from the capture control's `populate`
-  event, the one event the SDK omits: a bubbling `input` for an input or textarea,
-  `change` for anything else. It is strictly additive — nothing the SDK already
-  dispatches is repeated, and each populated field still sees exactly one `input`
-  and one `change` — so **Luma, multishipping, the customer address book and the
-  admin order-create and customer-edit screens are unchanged**. The country field
-  and the region `<select>` are untouched: both are populated by paths that already
-  fire a native `change` of their own.
+  The bundled SDK's own event dispatcher, `pca.reactTriggerChange`, now sends both
+  events for a text input: one bubbling `input`, then one bubbling `change`, in the
+  order a browser would (`input` while editing, `change` on commit). The value the
+  shopper picked therefore reaches Hyvä's component state, survives the next
+  re-render, and is the address the order is placed with. Fixing it in the dispatcher
+  rather than on the capture control's `populate` event also closes three sibling
+  write paths a `populate` hook missed — the drill-down write back to the search
+  field, the country list restoring the search text when it is dismissed, and
+  clearing the address — and it removes a re-vendor trap: a hook that added only
+  `input` would have depended on a separate local change further down the same file to
+  keep supplying `change`, so the next clean re-vendor of the SDK would have broken
+  Luma silently.
 
-  This is a front-end-only change with no automated coverage — the repository has no
-  JS test runner. It ships with a standalone Alpine harness that reproduces the wipe
-  and proves the fix without needing a Hyvä install, plus a manual pass covering
-  every screen the script serves; see `Test/manual/LOQ-17502-manual-qa.md`.
+  **Luma, multishipping, the customer address book and the admin order-create and
+  customer-edit screens behave the same for every consumer of `change`.** The
+  dispatcher still sends `change` for every node type it already sent it for, in the
+  same cases, and `select`, `input[type=file]`, checkbox, radio and textarea are not
+  touched at all — a text input is the only node type whose behaviour changed.
+
+  What is new on those screens too is that **every text input the SDK writes now also
+  receives one native bubbling `input`, immediately before the `change`** — the event
+  a browser would have sent and the SDK never did. No Magento binding on those screens
+  acts on `input`: Luma's Knockout `value` binding, the address-book and multishipping
+  forms and the admin UI components all listen for `change`. So no shopper-visible
+  behaviour is expected to change there, but a custom listener or third-party
+  extension bound to both events on a captured field will now run twice, and any
+  integration that treats an `input` on those fields as "the shopper typed" will now
+  see one. The regression steps for each of those screens are in
+  `Test/manual/LOQ-17502-manual-qa.md`.
+
+  The event contract is now asserted by an automated test: exactly one `input`, then
+  exactly one `change`, per populated text field. The country field and the region
+  `<select>` are unaffected; both are populated by paths that fire their own `change`.
+
+  This is a front-end-only change, and it now has automated coverage: a JavaScript
+  suite run by `npm test` — Node's built-in test runner with jsdom and the real Alpine
+  package, in `Test/js/`, wired into CI as its own job — which loads the real
+  `capture.js` rather than a re-implementation and asserts the event contract above,
+  that an Alpine `x-model` component ends up holding the populated city and postcode
+  and keeps them across a simulated Magewire commit and re-render, that the drill-down
+  and country-list-cancel paths dispatch `input` as well, that the extra event starts
+  no lookup loop, and that the capture control is constructed only once. Nothing
+  automated runs against a real Hyvä Checkout, so a manual pass over every screen the
+  script serves is still required before release; see
+  `Test/manual/LOQ-17502-manual-qa.md`. The standalone Alpine harness that ships
+  alongside it demonstrates the binding behaviour that caused the defect, but it does
+  not load `capture.js` and so proves nothing about the shipped code.
 - Repeated billable `/Cleansing/International/Batch` requests for the same address
   in one session, at checkout and on admin order create (LOQ-16969, LOQ-16976).
   Verify verdicts are cached per shopper for the session, keyed on the region value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,37 @@ predate it and are described by their git tags and commit history.
 
 ### Fixed
 
+- **An address picked from the lookup no longer empties itself again on Hyvä
+  Checkout** (LOQ-17502). The shopper searched, picked a suggestion, watched city,
+  postcode and region fill in, and then lost them the moment focus moved to another
+  field — leaving the checkout without the data it had just shown. Reported on
+  Magento 2.4.8-p5 with module 2.0.16, reproducible on Hyvä's own default theme, and
+  not reproducible once the checkout was switched to Luma. Every release up to and
+  including v2.1.1 is affected; upgrading alone does not fix it.
+
+  Hyvä Checkout's fields are Magewire `wire:model.defer`, which Magewire rewrites
+  into an Alpine `x-model`, and Alpine syncs a text input to the component state on
+  `input` — `change` only on a select, checkbox or radio. The bundled capture SDK
+  dispatched `change` and nothing else for a text input, so the component never
+  learned the field had been filled in, and its next render morphed the stale empty
+  value back over what the shopper could see. Luma is unaffected because Knockout's
+  `value` binding listens for `change`, which is exactly what was being sent. The
+  street field looked like it survived, on both front ends, only because the shopper
+  typed into it and real `input` events had already fired.
+
+  The module's own wrapper now dispatches, from the capture control's `populate`
+  event, the one event the SDK omits: a bubbling `input` for an input or textarea,
+  `change` for anything else. It is strictly additive — nothing the SDK already
+  dispatches is repeated, and each populated field still sees exactly one `input`
+  and one `change` — so **Luma, multishipping, the customer address book and the
+  admin order-create and customer-edit screens are unchanged**. The country field
+  and the region `<select>` are untouched: both are populated by paths that already
+  fire a native `change` of their own.
+
+  This is a front-end-only change with no automated coverage — the repository has no
+  JS test runner. It ships with a standalone Alpine harness that reproduces the wipe
+  and proves the fix without needing a Hyvä install, plus a manual pass covering
+  every screen the script serves; see `Test/manual/LOQ-17502-manual-qa.md`.
 - Repeated billable `/Cleansing/International/Batch` requests for the same address
   in one session, at checkout and on admin order create (LOQ-16969, LOQ-16976).
   Verify verdicts are cached per shopper for the session, keyed on the region value

--- a/Test/js/capture-alpine.test.mjs
+++ b/Test/js/capture-alpine.test.mjs
@@ -1,0 +1,228 @@
+/**
+ * LOQ-17502 - Hyva Checkout survival test.
+ *
+ * Hyva Checkout binds its address fields with Magewire's `wire:model.defer`, which
+ * Alpine turns into `x-model`. Alpine syncs a text input into component state on
+ * `input` only (it uses `change` for select/checkbox/radio). Before LOQ-17502 the
+ * SDK dispatched `change` alone, so a Loqate-populated field was never committed
+ * and the next Magewire re-render morphed the blank server value back over it.
+ *
+ * This test uses REAL Alpine (`alpinejs` from npm, the browser build) and the REAL,
+ * unmodified `view/base/web/capture.js`. The only thing simulated is Magewire's
+ * commit + morph, which is clearly marked below.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createHarness,
+  retrieveItem,
+  CODE_MATCHED_REGION_OPTIONS,
+} from "./support/harness.mjs";
+
+/** form field name -> the x-model expression bound to it in the harness form. */
+const MODEL_KEYS = {
+  "street[0]": "street0",
+  "street[1]": "street1",
+  company: "company",
+  city: "city",
+  region: "region",
+  region_id: "regionId",
+  postcode: "postcode",
+};
+
+/**
+ * Simulates one Magewire round trip: read the Alpine component state (what
+ * `wire:model.defer` would commit), serialise it over the wire, and morph the
+ * returned values back over the DOM.
+ *
+ * This is the only simulated part of this test. It is deliberately dumb: it just
+ * writes the committed state back. If the SDK failed to notify Alpine, the
+ * committed state is blank and the morph blanks the field - which is exactly the
+ * LOQ-17502 bug.
+ */
+function commitAndMorph(harness, component) {
+  // Commit: Magewire serialises the component state to JSON and posts it.
+  // (Alpine's `$data` is a merge proxy - JSON.stringify goes through its own
+  // `toJSON` trap, which is how Magewire reads a component's state too.)
+  const committed = JSON.parse(JSON.stringify(component));
+
+  // Morph: the server response carries those values back as the new markup.
+  for (const [name, key] of Object.entries(MODEL_KEYS)) {
+    const element = harness.field(name);
+    const value = committed[key] ?? "";
+    if (element.tagName === "SELECT") {
+      element.value = value;
+    } else {
+      element.setAttribute("value", value);
+      element.value = value;
+    }
+  }
+
+  return committed;
+}
+
+describe("(b) Alpine x-model survives a Loqate populate, a commit and a morph", () => {
+  test("jsdom provides the browser APIs Alpine requires", async () => {
+    const harness = await createHarness({ alpine: true });
+    try {
+      const w = harness.window;
+      for (const api of [
+        "MutationObserver",
+        "Proxy",
+        "queueMicrotask",
+        "requestAnimationFrame",
+      ]) {
+        assert.equal(
+          typeof w[api],
+          "function",
+          `jsdom must provide window.${api} for Alpine`
+        );
+      }
+      assert.equal(typeof w.Alpine, "object", "real Alpine booted in the document");
+      assert.ok(
+        harness.document.getElementById("address-form")._x_dataStack,
+        "Alpine initialised the address form component"
+      );
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("populate reaches Alpine state, and the state survives commit + morph", async () => {
+    // Arrange.
+    const harness = await createHarness({ alpine: true });
+
+    try {
+      const form = harness.document.getElementById("address-form");
+      const component = harness.window.Alpine.$data(form);
+      const recorder = harness.recordEvents(["city", "postcode"]);
+
+      assert.equal(component.city, "", "starts blank");
+      assert.equal(component.postcode, "", "starts blank");
+
+      // Act: drive the real SDK - type, then click the suggestion it renders.
+      await harness.searchAndPick();
+      // Wait on Alpine having actually synced, rather than sleeping for a
+      // scheduler turn: Alpine batches x-model writes through its own reactivity
+      // queue, and how many turns that takes is not ours to assume.
+      await harness.waitFor(
+        () => component.city === "London" && component.postcode === "SW1A 2AA",
+        { label: "Alpine to sync the populated values into component state" }
+      );
+
+      // Assert 1: the populate reached Alpine's component state. This is only
+      // possible because the SDK dispatched `input`.
+      assert.deepEqual(recorder.types("city"), ["input", "change"]);
+      assert.deepEqual(recorder.types("postcode"), ["input", "change"]);
+      assert.equal(component.city, "London");
+      assert.equal(component.postcode, "SW1A 2AA");
+
+      // Act: Magewire commits the component state and morphs the response back.
+      const committed = commitAndMorph(harness, component);
+      // Fixed wait on purpose: the morph is synchronous, so the values are
+      // already in place; what this window is for is letting any late SDK timer
+      // or Alpine effect blank them again, which is the failure being excluded.
+      await harness.tick(50);
+
+      // Assert 2: the committed payload carried the retrieved address...
+      assert.equal(committed.city, "London");
+      assert.equal(committed.postcode, "SW1A 2AA");
+      // ...so the morph re-wrote the same values, not blanks.
+      assert.equal(harness.field("city").value, "London");
+      assert.equal(harness.field("postcode").value, "SW1A 2AA");
+      assert.equal(harness.field("city").getAttribute("value"), "London");
+      assert.equal(harness.field("street[0]").value, "10 Downing Street");
+      // The region select is committed too, off the back of its `change`.
+      assert.equal(committed.regionId, "1");
+      assert.equal(harness.field("region_id").value, "1");
+
+      // And Alpine's state is still consistent after the morph.
+      assert.equal(harness.window.Alpine.$data(form).city, "London");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("negative control: a value written with no event is lost by the same morph", async () => {
+    // This proves the commit + morph simulation above has teeth rather than
+    // passing vacuously. It uses the real SDK's own `pca.setValue` with the
+    // `simulateReactTrigger` flag off - the pre-LOQ-17502 situation, where the
+    // field is written but no event is dispatched - and shows that the identical
+    // morph blanks the field.
+    const harness = await createHarness({ alpine: true });
+
+    try {
+      const form = harness.document.getElementById("address-form");
+      const component = harness.window.Alpine.$data(form);
+      const recorder = harness.recordEvents(["city"]);
+
+      // Act: the SDK writes the value silently.
+      harness.window.pca.setValue(harness.field("city"), "London", false);
+      // Fixed wait: the assertion is that NO event and NO Alpine sync happen, so
+      // there is no condition to poll for.
+      await harness.tick(50);
+
+      // Assert: DOM has it, no event was dispatched, Alpine never heard about it.
+      assert.equal(harness.field("city").value, "London");
+      assert.deepEqual(recorder.types("city"), []);
+      assert.equal(component.city, "", "Alpine state was not updated");
+
+      // Act: the very same commit + morph.
+      const committed = commitAndMorph(harness, component);
+      await harness.tick(50);
+
+      // Assert: the value is gone - the LOQ-17502 bug, reproduced.
+      assert.equal(committed.city, "");
+      assert.equal(
+        harness.field("city").value,
+        "",
+        "the morph must blank a field that never reached Alpine state"
+      );
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("the pre-existing double change on an unmatched select converges in Alpine state", async () => {
+    /*
+     * The companion to the "PRE-EXISTING: ... two change events" test in
+     * capture-events.test.mjs. There the double-fire is pinned at the DOM level;
+     * here it is checked against a real Alpine `x-model` on the select, because
+     * "it converges, so it is not a defect" is only true if the LAST event wins.
+     * Alpine syncs a select on `change`, so it sees change("") then change("43")
+     * and must end on "43".
+     */
+    const harness = await createHarness({
+      alpine: true,
+      regionOptions: CODE_MATCHED_REGION_OPTIONS,
+      retrieve: [retrieveItem({ ProvinceName: "KEN" })],
+    });
+
+    try {
+      const form = harness.document.getElementById("address-form");
+      const component = harness.window.Alpine.$data(form);
+      const recorder = harness.recordEvents(["region_id"]);
+
+      // Act.
+      await harness.searchAndPick();
+      await harness.waitFor(() => component.regionId === "43", {
+        label: "Alpine to settle on the correctly matched region option",
+      });
+
+      // Assert: two change events reached Alpine, the stale one first...
+      assert.deepEqual(recorder.entries("region_id"), [
+        { type: "change", value: "" },
+        { type: "change", value: "43" },
+      ]);
+      // ...and the state converged on the second, both before and after a commit.
+      assert.equal(component.regionId, "43");
+      const committed = commitAndMorph(harness, component);
+      assert.equal(committed.regionId, "43");
+      assert.equal(harness.field("region_id").value, "43");
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/Test/js/capture-events.test.mjs
+++ b/Test/js/capture-events.test.mjs
@@ -1,0 +1,479 @@
+/**
+ * LOQ-17502 - event contract of the vendored Loqate capture SDK.
+ *
+ * These tests load the REAL, unmodified `view/base/web/capture.js` into a jsdom
+ * document and drive the SDK's own UI. Nothing about the SDK's event behaviour is
+ * re-implemented here: every assertion is an observation of the real script. If
+ * `pca.reactTriggerChange` stopped dispatching `input` (Hyva/Alpine) or `change`
+ * (Luma/Knockout and the admin UI components), these tests fail.
+ */
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createHarness,
+  findItem,
+  retrieveItem,
+  CODE_MATCHED_REGION_OPTIONS,
+} from "./support/harness.mjs";
+
+/** The text fields the `default` mapping populates (capture.js:7787-7817). */
+const POPULATED_TEXT_FIELDS = [
+  "street[0]",
+  "street[1]",
+  "company",
+  "city",
+  "postcode",
+  "region",
+];
+
+describe("(a) populate event contract", () => {
+  let harness;
+  let recorder;
+
+  before(async () => {
+    // Arrange: real SDK, Magento-shaped form, stubbed find/retrieve endpoints.
+    harness = await createHarness();
+    recorder = harness.recordEvents([...POPULATED_TEXT_FIELDS, "region_id"]);
+
+    // Act: type into the search field and click the suggestion the SDK renders.
+    await harness.searchAndPick();
+  });
+
+  after(async () => {
+    await harness.close();
+  });
+
+  test("the SDK actually reached its endpoints and populated the form", () => {
+    // Non-vacuity guard: if the stub server or the UI drive silently did nothing,
+    // every "exactly one event" assertion below would pass for the wrong reason.
+    assert.equal(harness.server.requests.find, 1, "one find request");
+    assert.equal(harness.server.requests.retrieve, 1, "one retrieve request");
+    assert.equal(harness.field("city").value, "London");
+    assert.equal(harness.field("postcode").value, "SW1A 2AA");
+    assert.equal(harness.field("street[0]").value, "10 Downing Street");
+    assert.deepEqual(harness.consoleErrors, []);
+  });
+
+  for (const name of POPULATED_TEXT_FIELDS) {
+    test(`text field ${name} receives exactly one input then exactly one change`, () => {
+      assert.deepEqual(
+        recorder.types(name),
+        ["input", "change"],
+        `${name} event sequence`
+      );
+    });
+  }
+
+  test("the input event carries the retrieved value, not an intermediate one", () => {
+    // Alpine reads event.target.value when it handles `input`, so the value must
+    // already be the retrieved one by the time the event is dispatched.
+    const [input, change] = recorder.entries("city");
+    assert.equal(input.value, "London");
+    assert.equal(change.value, "London");
+  });
+
+  test("the region_id select still receives its change event", () => {
+    // Load-bearing: pca.setValue matches the "Kent" option on its TEXT and returns
+    // early for a SELECT (capture.js:3364-3372), so the change comes from
+    // mapRegionSelectValue's own dispatch (capture.js:7961, via
+    // mapRegionSelectValueWithRetry). Knockout, the admin UI components and
+    // Alpine all need it. A select must NOT get an `input`.
+    assert.deepEqual(recorder.types("region_id"), ["change"]);
+    assert.equal(harness.field("region_id").value, "1", "matched the Kent option");
+  });
+});
+
+describe("(c) F2 regression paths that bypass the populate event", () => {
+  test("drill-down (filterSearch) emits input then change on the search field", async () => {
+    // Arrange: a non-Address suggestion, which sends address.select down the
+    // filterSearch branch (capture.js:7181-7187 -> 7164-7169).
+    const harness = await createHarness({
+      find: [
+        findItem({
+          Id: "GB|RM|ENG|LONDON",
+          Type: "Container",
+          Text: "Downing Street, London",
+          Description: "12 addresses",
+        }),
+      ],
+    });
+
+    try {
+      const recorder = harness.recordEvents(["street[0]"]);
+      await harness.search("Downing");
+      const findsBefore = harness.server.requests.find;
+      recorder.reset(); // scope the recording to the drill-down itself
+
+      // Act: click the container suggestion, exactly as a shopper would.
+      harness.clickSuggestion(0);
+      // filterSearch rewrites the field and THEN searches (capture.js:7165-7178),
+      // so waiting on the follow-up find also guarantees the rewrite has landed.
+      // A fixed sleep here would be a race on a loaded runner.
+      await harness.waitFor(
+        () => harness.server.requests.find > findsBefore,
+        { label: "the drill-down's follow-up find request to arrive" }
+      );
+
+      // Assert: the search field was rewritten by
+      // pca.setValue(field, searchText + " ", simulateReactEvents) and therefore
+      // got both events; and the drill-down did issue its follow-up search.
+      assert.deepEqual(recorder.types("street[0]"), ["input", "change"]);
+      assert.equal(harness.field("street[0]").value, "Downing ");
+      assert.ok(
+        harness.server.requests.find > findsBefore,
+        "the drill-down issues a follow-up find (this one is expected and correct)"
+      );
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("country-list cancel restores the stored search with input then change", async () => {
+    // NOTE ON HOW THIS PATH IS DRIVEN: the flag button / country list is not
+    // clicked here. The country list is opened and closed by calling the SDK's own
+    // `switchToCountrySelect()` and `countrylist.autocomplete.hide()`. `hide()` is
+    // the method the real UI calls, and it fires the `hide` event whose listener
+    // (capture.js:6548-6552) is the code under test. So the handler under test is
+    // the real one, but the route into it is an SDK API call rather than a click.
+    const harness = await createHarness();
+
+    try {
+      const recorder = harness.recordEvents(["street[0]"]);
+      await harness.search("10 Downing");
+
+      harness.control.switchToCountrySelect();
+      assert.equal(
+        harness.control.storedSearch,
+        "10 Downing",
+        "the SDK stored the in-progress search"
+      );
+      assert.equal(
+        harness.field("street[0]").value,
+        "",
+        "the SDK cleared the search field when switching to the country list"
+      );
+      recorder.reset(); // scope the recording to the cancel
+
+      // Act: close the country list, which restores the stored search.
+      harness.control.countrylist.autocomplete.hide();
+      await harness.waitFor(
+        () => harness.field("street[0]").value === "10 Downing",
+        { label: "the stored search to be restored into the search field" }
+      );
+
+      // Assert.
+      assert.equal(harness.field("street[0]").value, "10 Downing");
+      assert.deepEqual(recorder.types("street[0]"), ["input", "change"]);
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("(d) a synthetic input event is never billable", () => {
+  test("dispatching input on the mapped fields issues no find or retrieve request", async () => {
+    const harness = await createHarness();
+
+    try {
+      // Arrange.
+      assert.deepEqual(harness.server.requests, {
+        find: 0,
+        retrieve: 0,
+        other: 0,
+      });
+
+      // Act: a bubbling `input` on the search field and on a populated field,
+      // which is what Alpine/Magewire re-renders produce.
+      for (const name of ["street[0]", "city"]) {
+        const element = harness.field(name);
+        element.value = "SW1A 2AA";
+        element.dispatchEvent(
+          new harness.window.Event("input", { bubbles: true })
+        );
+      }
+      // This one stays a fixed wait on purpose: the assertion is that NOTHING
+      // happens, and there is no condition to wait for. 200ms is comfortably more
+      // than the SDK's own search delay.
+      await harness.tick(200);
+
+      // Assert: capture.js binds keyup/keydown/keypress/paste/click/dblclick/
+      // change (capture.js:1762-1788, 1812-1837) and never `input`, so nothing
+      // was requested.
+      assert.equal(harness.server.requests.find, 0, "no find request");
+      assert.equal(harness.server.requests.retrieve, 0, "no retrieve request");
+
+      // Non-vacuity guard: the counters DO move when the SDK is really driven.
+      // `city` is reset first because the arrange step above left "SW1A 2AA" in
+      // it, and `searchAndPick` waits for `city` to become non-empty - with the
+      // stale value still there that wait would return instantly and the guard
+      // would prove nothing about whether the populate landed.
+      harness.field("city").value = "";
+      await harness.searchAndPick("10 Downing");
+      await harness.waitFor(
+        () => harness.server.requests.retrieve === 1,
+        { label: "the retrieve request to arrive" }
+      );
+      assert.equal(harness.server.requests.find, 1);
+      assert.equal(harness.server.requests.retrieve, 1);
+      // ...and the populate really landed, which is what makes the counters above
+      // meaningful rather than incidental.
+      assert.equal(harness.field("city").value, "London");
+      assert.equal(harness.field("postcode").value, "SW1A 2AA");
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("(e) the control is constructed once", () => {
+  test("a single street[0] yields one pca.Address, and DOM churn does not add more", async () => {
+    const harness = await createHarness();
+
+    try {
+      // Arrange / Assert: one instance after the module's bootstrap.
+      assert.equal(harness.addressConstructions, 1);
+
+      // Act: wake the MutationObserver (capture.js:8071-8079, debounced 50ms)
+      // with unrelated DOM churn, twice, and wait well past the debounce. These
+      // waits stay time-based deliberately: the assertion is that a debounced
+      // callback did NOT construct a second control, so there is no condition to
+      // poll for - only a window in which the wrong thing could have happened.
+      for (let i = 0; i < 2; i++) {
+        const noise = harness.document.createElement("div");
+        noise.textContent = `magewire morph ${i}`;
+        harness.document.body.appendChild(noise);
+        await harness.tick(10);
+        noise.remove();
+        await harness.tick(120);
+      }
+      await harness.tick(200);
+
+      // Assert: no re-init loop.
+      assert.equal(
+        harness.addressConstructions,
+        1,
+        "pca.Address must not be reconstructed on unrelated DOM mutations"
+      );
+
+      // And the single instance still works end to end.
+      await harness.searchAndPick();
+      assert.equal(harness.field("city").value, "London");
+      assert.equal(harness.addressConstructions, 1);
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("(f) region select matched by data attribute, not by option text", () => {
+  // The form used here is the OTHER shape Magento renders in the wild: the option
+  // text is a display label ("Kent County") that does not equal the Loqate
+  // ProvinceName, and the region code lives in a data attribute. `pca.setValue`
+  // compares only `option.value` and `option.text` (capture.js:3364-3372), so it
+  // matches nothing at all; `mapRegionSelectValue` also tries `data-title`,
+  // `data-code` and `data-region-code` (capture.js:7946-7952), and it is those
+  // attributes - not the text - that resolve the option here. The text-matching
+  // shape stays covered by suite (a), which uses the default form.
+
+  test("data-code resolves the option when the option text does not match", async () => {
+    // Arrange: ProvinceName "KEN" matches option 1 only on data-code.
+    const harness = await createHarness({
+      regionOptions: CODE_MATCHED_REGION_OPTIONS,
+      retrieve: [retrieveItem({ ProvinceName: "KEN" })],
+    });
+
+    try {
+      const recorder = harness.recordEvents(["region_id", "region"]);
+
+      // Act.
+      await harness.searchAndPick();
+
+      // Assert: the right option is selected, by value and by index.
+      const select = harness.field("region_id");
+      assert.equal(select.value, "43", "the Kent County option is selected");
+      assert.equal(select.selectedIndex, 1);
+      // capture.js:7960 also mirrors the value onto the attribute, which is what
+      // survives a Magewire morph that re-reads attributes.
+      assert.equal(select.getAttribute("value"), "43");
+
+      // Assert the matcher really was the data attribute and not the text: the
+      // option's text differs from the retrieved ProvinceName, so a text-only
+      // matcher (i.e. pca.setValue on its own) could not have selected it.
+      const option = select.options[select.selectedIndex];
+      assert.equal(option.text, "Kent County");
+      assert.equal(option.getAttribute("data-code"), "KEN");
+      assert.notEqual(
+        option.text.trim().toLowerCase(),
+        "ken",
+        "if the text matched, this test would not be exercising data-code"
+      );
+
+      // And the select still ends up notifying its listeners.
+      assert.ok(
+        recorder.types("region_id").includes("change"),
+        "the select must still get a change event"
+      );
+      assert.ok(
+        !recorder.types("region_id").includes("input"),
+        "a select must never get an input event"
+      );
+
+      // The `region` TEXT input is mapped to ProvinceName too, and pca.setValue
+      // writes it verbatim - so it holds the raw code, not the display label.
+      // Pinned as observed behaviour of the current mapping, not as an ideal.
+      assert.equal(harness.field("region").value, "KEN");
+      assert.deepEqual(recorder.types("region"), ["input", "change"]);
+      assert.deepEqual(harness.consoleErrors, []);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("data-region-code resolves the option when data-code is absent", async () => {
+    // Arrange: ProvinceName "SRY" matches option 2 only on data-region-code -
+    // the last candidate before `option.value` (capture.js:7946-7952).
+    const harness = await createHarness({
+      regionOptions: CODE_MATCHED_REGION_OPTIONS,
+      retrieve: [retrieveItem({ ProvinceName: "SRY" })],
+    });
+
+    try {
+      // Act.
+      await harness.searchAndPick();
+
+      // Assert.
+      const select = harness.field("region_id");
+      assert.equal(select.value, "44", "the Surrey County option is selected");
+      const option = select.options[select.selectedIndex];
+      assert.equal(option.text, "Surrey County");
+      assert.equal(option.getAttribute("data-code"), null);
+      assert.equal(option.getAttribute("data-region-code"), "SRY");
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("an unmatchable ProvinceName leaves the select on its placeholder", async () => {
+    // The complement of the two tests above, and the reason the "stale first
+    // change" below is a real risk rather than a theoretical one: when nothing
+    // matches, the ONLY change dispatched is the stale one, and the select is
+    // left empty. This is pre-existing SDK behaviour and correct - there is no
+    // option to select - but it means a consumer must not treat the first change
+    // as final.
+    const harness = await createHarness({
+      regionOptions: CODE_MATCHED_REGION_OPTIONS,
+      retrieve: [retrieveItem({ ProvinceName: "Nowhereshire" })],
+    });
+
+    try {
+      const recorder = harness.recordEvents(["region_id"]);
+      await harness.searchAndPick();
+      // mapRegionSelectValueWithRetry retries at 75/150/300/600ms and then gives
+      // up (capture.js:7971-7989); wait past the whole ladder. Time-based on
+      // purpose: the assertion is that nothing further happens.
+      await harness.tick(1400);
+
+      assert.equal(harness.field("region_id").value, "");
+      assert.deepEqual(
+        recorder.entries("region_id"),
+        [{ type: "change", value: "" }],
+        "one stale change and nothing else; the retry ladder never matches"
+      );
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("PRE-EXISTING: a select pca.setValue cannot match gets two change events, stale then correct", async () => {
+    /*
+     * DOCUMENTED, NOT A DEFECT TO FIX. capture.js is the vendored SDK and is not
+     * to be changed for this.
+     *
+     * When `pca.setValue`'s SELECT loop matches an option it sets `selectedIndex`
+     * and RETURNS (capture.js:3364-3372) - that is the text-matching case covered
+     * by suite (a), where the select gets exactly one change. When it matches
+     * NOTHING it does not return: it falls through to capture.js:3382-3387 and
+     * calls `pca.reactTriggerChange(element)`, which for a select dispatches a
+     * `change` (capture.js:3202-3217) while the select still holds its OLD value.
+     * `mapRegionSelectValue` then resolves the option properly and dispatches a
+     * second `change` with the correct value (capture.js:7961).
+     *
+     * So a consumer sees change("") then change("43"). Both Knockout and Alpine
+     * re-read `event.target.value` on every change, so they converge on the
+     * correct value; the first event is redundant, not wrong. This double-fire is
+     * exactly what Test/manual/LOQ-17502-manual-qa.md asks a human tester to hunt
+     * for, and it predates LOQ-17502: `reactTriggerChange` has always been called
+     * on a no-match fall-through. It is pinned here so the next person who sees
+     * two events knows it is expected and where each one comes from.
+     */
+    const harness = await createHarness({
+      regionOptions: CODE_MATCHED_REGION_OPTIONS,
+      retrieve: [retrieveItem({ ProvinceName: "KEN" })],
+    });
+
+    try {
+      const recorder = harness.recordEvents(["region_id"]);
+
+      // Act.
+      await harness.searchAndPick();
+
+      // Assert the exact observed sequence, values included.
+      assert.deepEqual(recorder.entries("region_id"), [
+        // 1. pca.setValue matched no option, fell through, and
+        //    reactTriggerChange fired with the select's stale (placeholder) value.
+        { type: "change", value: "" },
+        // 2. mapRegionSelectValue resolved the option via data-code and fired
+        //    again, this time with the correct value.
+        { type: "change", value: "43" },
+      ]);
+
+      // It converges: the last event and the DOM agree.
+      assert.equal(harness.field("region_id").value, "43");
+    } finally {
+      await harness.close();
+    }
+  });
+});
+
+describe("retrieve payload shape", () => {
+  test("an empty retrieve response leaves the form untouched", async () => {
+    // address.retrieve's success does `response.length ? populate : fail`.
+    const harness = await createHarness({ retrieve: [] });
+
+    try {
+      await harness.search("10 Downing");
+      harness.clickSuggestion(0);
+      // Wait on the request itself rather than sleeping for it...
+      await harness.waitFor(
+        () => harness.server.requests.retrieve === 1,
+        { label: "the retrieve request for the picked suggestion to arrive" }
+      );
+      // ...and only then sleep, because the remaining assertion is that no
+      // populate follows, for which there is no condition to wait on.
+      await harness.tick(100);
+
+      assert.equal(harness.field("city").value, "");
+      assert.equal(harness.server.requests.retrieve, 1);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  test("a second retrieve item is ignored - only the first is populated", async () => {
+    const harness = await createHarness({
+      retrieve: [
+        retrieveItem({ City: "London" }),
+        retrieveItem({ City: "Manchester" }),
+      ],
+    });
+
+    try {
+      await harness.searchAndPick();
+      assert.equal(harness.field("city").value, "London");
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/Test/js/support/harness.mjs
+++ b/Test/js/support/harness.mjs
@@ -1,0 +1,477 @@
+/**
+ * Test harness for the vendored Loqate capture SDK.
+ *
+ * The single rule of this file: it must never model, re-implement or stand in for
+ * anything `view/base/web/capture.js` does. It only
+ *
+ *   1. serves stub `find`/`retrieve` HTTP responses,
+ *   2. builds a Magento-shaped address form,
+ *   3. injects the *real, unmodified* `capture.js` source into a jsdom document, and
+ *   4. records DOM events and drives the SDK's own UI.
+ *
+ * Every assertion in the suite is therefore an observation of the real script
+ * running. If `capture.js` stopped dispatching an event, the tests would fail.
+ */
+
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { inspect } from "node:util";
+import { JSDOM, VirtualConsole } from "jsdom";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+
+const CAPTURE_JS_PATH = path.join(
+  REPO_ROOT,
+  "view",
+  "base",
+  "web",
+  "capture.js"
+);
+const ALPINE_JS_PATH = path.join(
+  REPO_ROOT,
+  "node_modules",
+  "alpinejs",
+  "dist",
+  "cdn.js"
+);
+
+/** The real SDK source, read once. Never edited, never patched. */
+const CAPTURE_JS_SOURCE = fs.readFileSync(CAPTURE_JS_PATH, "utf8");
+
+/**
+ * The SDK is injected verbatim into an inline `<script>` in the harness document
+ * (see `createHarness`), so its text must not contain anything that takes the
+ * HTML parser out of script context: `</script` closes the element early and
+ * `<!--` opens an HTML comment inside it. Neither appears in the SDK today, but a
+ * re-vendor could introduce either, and the failure would surface as "pca is not
+ * defined" in every test rather than as anything pointing at the injection. Fail
+ * loudly at load instead.
+ */
+assert.ok(
+  !/<\/script|<!--/i.test(CAPTURE_JS_SOURCE),
+  `${CAPTURE_JS_PATH} contains "</script" or "<!--", which the harness cannot ` +
+    "inline: it injects the SDK verbatim into an inline <script> element, and " +
+    "either sequence ends or comments out script context in the HTML parser. " +
+    "Serve the SDK from the stub HTTP server (or a Blob/data URL) instead of " +
+    "inlining it."
+);
+
+/**
+ * Real Alpine, the browser build, as shipped on npm - read lazily, on the first
+ * `alpine: true` harness. Reading it at module load would make every test that
+ * imports this harness depend on the `alpinejs` package being installed, even
+ * `capture-events.test.mjs`, which never uses Alpine.
+ */
+let alpineJsSource;
+function alpineSource() {
+  if (alpineJsSource === undefined) {
+    alpineJsSource = fs.readFileSync(ALPINE_JS_PATH, "utf8");
+  }
+  return alpineJsSource;
+}
+
+/** Renders console arguments roughly the way a devtools line would read. */
+function formatConsoleArgs(args) {
+  return args
+    .map((arg) => (typeof arg === "string" ? arg : inspect(arg, { depth: 2 })))
+    .join(" ");
+}
+
+/**
+ * A `find` response item. `Type: "Address"` makes `address.select` retrieve it;
+ * any other type sends it down the drill-down / `filterSearch` path.
+ */
+export function findItem(overrides = {}) {
+  return {
+    Id: "GB|RM|A|52509479",
+    Type: "Address",
+    Text: "10 Downing Street",
+    Description: "London, SW1A 2AA",
+    Highlight: "0-2",
+    ...overrides,
+  };
+}
+
+/** A `retrieve` response item, shaped like the real Loqate retrieve payload. */
+export function retrieveItem(overrides = {}) {
+  return {
+    Id: "GB|RM|A|52509479",
+    Line1: "10 Downing Street",
+    Line2: "Westminster",
+    Company: "Loqate Ltd",
+    City: "London",
+    ProvinceName: "Kent",
+    PostalCode: "SW1A 2AA",
+    CountryIso2: "GB",
+    CountryName: "United Kingdom",
+    Label: "10 Downing Street\nWestminster\nLondon\nSW1A 2AA",
+    ...overrides,
+  };
+}
+
+/**
+ * A tiny stub of the two Magento controller endpoints the module points the SDK
+ * at. Runs on an ephemeral port; the jsdom document is given the same origin so
+ * that jsdom's XMLHttpRequest treats the calls as same-origin.
+ *
+ * `capture.js` is configured with `endpoint.literal: true`, so the request URL is
+ * the configured URL verbatim plus `?<query>` - we therefore match on pathname
+ * and ignore the query string. `endpoint.unwrapped: true` means the body must be
+ * a bare JSON array, not `{"Items": [...]}`.
+ */
+async function startStubServer({ find, retrieve }) {
+  /** Per-path request counters, used by the "no billable request" assertion. */
+  const requests = { find: 0, retrieve: 0, other: 0 };
+  /** Every request URL seen, for diagnostics. */
+  const urls = [];
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://127.0.0.1");
+    urls.push(req.url);
+
+    let body;
+    if (url.pathname === "/find") {
+      requests.find++;
+      body = typeof find === "function" ? find(url.searchParams) : find;
+    } else if (url.pathname === "/retrieve") {
+      requests.retrieve++;
+      body = typeof retrieve === "function" ? retrieve(url.searchParams) : retrieve;
+    } else {
+      requests.other++;
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end("not found");
+      return;
+    }
+
+    const payload = JSON.stringify(body);
+    res.writeHead(200, {
+      "content-type": "application/json",
+      "content-length": Buffer.byteLength(payload),
+    });
+    res.end(payload);
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  return {
+    requests,
+    urls,
+    origin: `http://127.0.0.1:${port}`,
+    async close() {
+      // Drop sockets before closing: `server.close()` stops accepting but waits
+      // for every open connection to end, and jsdom's XMLHttpRequest leaves a
+      // keep-alive socket behind, so the close callback can stall indefinitely.
+      // Multiplied by the ~9 harnesses the suite creates, that is a CI hang.
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+/**
+ * `region_id` options in which the region name is in BOTH the option text and
+ * `data-title`. This is the shape Magento renders for GB, and it is matched by
+ * `pca.setValue` itself: its SELECT loop compares `option.text` and
+ * `option.value` (capture.js:3364-3372), finds "Kent", sets `selectedIndex` and
+ * returns early - which is exactly why the select never gets an event from
+ * `pca.reactTriggerChange` and needs `mapRegionSelectValue` to dispatch one.
+ */
+export const TEXT_MATCHED_REGION_OPTIONS = `
+      <option value="1" data-title="Kent">Kent</option>
+      <option value="2" data-title="Surrey">Surrey</option>`;
+
+/**
+ * `region_id` options in which the option TEXT is a display label that does not
+ * equal the Loqate ProvinceName, and the region code lives in a data attribute.
+ * This is the other shape Magento renders in the wild, and it is the one
+ * `pca.setValue` cannot match at all - only `mapRegionSelectValue`'s
+ * `data-code` / `data-region-code` candidates do (capture.js:7946-7952).
+ *
+ * Retrieve `ProvinceName: "KEN"` matches option 1 on `data-code`;
+ * `ProvinceName: "SRY"` matches option 2 on `data-region-code`. Neither matches
+ * on text or on `data-title`, so the data-attribute path really is the matcher.
+ */
+export const CODE_MATCHED_REGION_OPTIONS = `
+      <option value="43" data-title="Kent" data-code="KEN">Kent County</option>
+      <option value="44" data-title="Surrey" data-region-code="SRY">Surrey County</option>`;
+
+/**
+ * The `default` field mapping from capture.js:7787-7817 expects exactly these
+ * `name` attributes. The anchor is `input[name="street[0]"]` and the lookup
+ * context is `anchorElement.closest("form")`, hence the `<form>` wrapper.
+ *
+ * `region` (text input) and `region_id` (select) are BOTH mapped to
+ * ProvinceName, which is why both are present.
+ */
+function addressFormHtml({
+  alpine = false,
+  regionOptions = TEXT_MATCHED_REGION_OPTIONS,
+} = {}) {
+  const x = (name) => (alpine ? ` x-model="${name}"` : "");
+
+  return `
+    <form id="address-form"${
+      alpine
+        ? ` x-data="{ street0: '', street1: '', company: '', city: '', region: '', regionId: '', postcode: '' }"`
+        : ""
+    }>
+      <input type="text" name="street[0]" id="street_1"${x("street0")}>
+      <input type="text" name="street[1]" id="street_2"${x("street1")}>
+      <input type="text" name="company" id="company"${x("company")}>
+      <input type="text" name="city" id="city"${x("city")}>
+      <input type="text" name="region" id="region"${x("region")}>
+      <select name="region_id" id="region_id"${x("regionId")}>
+        <option value="">Please select a region, state or province.</option>${regionOptions}
+      </select>
+      <input type="text" name="postcode" id="postcode"${x("postcode")}>
+      <select name="country_id" id="country_id">
+        <option value="GB">United Kingdom</option>
+        <option value="US">United States</option>
+      </select>
+    </form>`;
+}
+
+/**
+ * Wraps `pca.Address` so the tests can reach the control instance the module's
+ * own bootstrap creates, and can count how many times it is constructed.
+ *
+ * This is safe to do from a separate <script> because capture.js resolves
+ * `pca.Address` as a property lookup at call time (`new pca.Address(...)`,
+ * capture.js:8097), and `loqateInit` is deferred to DOMContentLoaded - i.e. it
+ * runs after this script has installed the wrapper.
+ */
+const ADDRESS_SPY_SOURCE = `
+  window.__pcaAddressCalls = 0;
+  window.__pcaControls = [];
+  (function () {
+    var real = window.pca.Address;
+    window.pca.Address = function (fields, options) {
+      window.__pcaAddressCalls++;
+      var inst = new real(fields, options);
+      window.__pcaControls.push(inst);
+      return inst;
+    };
+  })();
+`;
+
+/** Resolves after one macrotask, letting queued timers/microtasks drain. */
+function tick(window, ms = 0) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+/** Polls `predicate` until it is truthy, or throws once `timeout` elapses. */
+async function waitFor(window, predicate, { timeout = 2000, label = "condition" } = {}) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    let value;
+    try {
+      value = predicate();
+    } catch (error) {
+      value = false;
+      if (Date.now() > deadline) throw error;
+    }
+    if (value) return value;
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out after ${timeout}ms waiting for ${label}`);
+    }
+    await tick(window, 5);
+  }
+}
+
+/**
+ * Boots a jsdom document containing the address form and the real capture.js.
+ *
+ * Script order in the document matters and is deliberate:
+ *   1. (optional) Alpine, so it owns the form before the SDK reshuffles it;
+ *   2. capture.js - the code under test, injected verbatim;
+ *   3. the `pca.Address` spy, which must be installed before DOMContentLoaded.
+ * All three run while `document.readyState === "loading"`, so capture.js's
+ * `loqateInit` is deferred to DOMContentLoaded and sees the spy.
+ */
+export async function createHarness({
+  find = [findItem()],
+  retrieve = [retrieveItem()],
+  alpine = false,
+  regionOptions = TEXT_MATCHED_REGION_OPTIONS,
+} = {}) {
+  const server = await startStubServer({ find, retrieve });
+
+  // In-page diagnostics. `jsdomError` alone is not enough: the SDK reports a
+  // misconfigured harness through `console.error` - capture.js:7999,
+  // 'Element with ID "loqate-urls" not found', after which it returns and never
+  // initialises - and swallowing that turns a configuration mistake into a
+  // mysterious assertion failure several lines later. `console.warn` is captured
+  // for the same reason. Both are exposed on the harness so a test can assert on
+  // them (see the non-vacuity guard in capture-events.test.mjs).
+  const consoleErrors = [];
+  const consoleWarnings = [];
+  const virtualConsole = new VirtualConsole();
+  virtualConsole.on("jsdomError", (error) => consoleErrors.push(error));
+  virtualConsole.on("error", (...args) =>
+    consoleErrors.push(formatConsoleArgs(args))
+  );
+  virtualConsole.on("warn", (...args) =>
+    consoleWarnings.push(formatConsoleArgs(args))
+  );
+
+  const html = `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>Loqate capture harness</title></head>
+  <body>
+    <!-- capture.js refuses to initialise without this element. -->
+    <div id="loqate-urls" data-find-url="/find" data-retrieve-url="/retrieve"></div>
+    ${addressFormHtml({ alpine, regionOptions })}
+    ${alpine ? `<script>${alpineSource()}<\/script>` : ""}
+    <script>${CAPTURE_JS_SOURCE}<\/script>
+    <script>${ADDRESS_SPY_SOURCE}<\/script>
+  </body>
+</html>`;
+
+  /*
+   * CI stays hermetic, and it is the ABSENCE of a `resources` option that keeps
+   * it that way - this is load-bearing, so do not add `resources: "usable"`:
+   *
+   *   - jsdom's default resource loader fetches nothing external, so the SDK's
+   *     four `preloadImage` calls (capture.js:7771-7778), which point at
+   *     `//services.postcodeanywhere.co.uk/images/...`, never leave the process:
+   *     `new Image(); img.src = url` is inert without a usable resource loader.
+   *   - the only other outbound call the SDK can make on its own is IP
+   *     geolocation, and `options.setCountryByIP` defaults to `false`
+   *     (documented capture.js:6150, defaulted capture.js:6224-6227) and is not
+   *     enabled here, so `address.setCountryByIP` (capture.js:6700-6701) is
+   *     never reached.
+   *
+   * Every request the suite makes therefore goes to the local stub server, and
+   * `server.requests.other` would catch it if one did not.
+   */
+  const dom = new JSDOM(html, {
+    url: `${server.origin}/checkout/`,
+    runScripts: "dangerously",
+    pretendToBeVisual: true,
+    virtualConsole,
+  });
+
+  const { window } = dom;
+
+  // Wait for the document to finish loading, so DOMContentLoaded (and therefore
+  // loqateInit and pca.ready) has run.
+  if (window.document.readyState !== "complete") {
+    await new Promise((resolve) => window.addEventListener("load", resolve));
+  }
+  await tick(window);
+
+  const field = (name) => window.document.querySelector(`[name="${name}"]`);
+
+  const harness = {
+    dom,
+    window,
+    document: window.document,
+    server,
+    consoleErrors,
+    consoleWarnings,
+    field,
+    /** The control instance created by the module's own bootstrap. */
+    get control() {
+      return window.__pcaControls[0];
+    },
+    get addressConstructions() {
+      return window.__pcaAddressCalls;
+    },
+    tick: (ms) => tick(window, ms),
+    waitFor: (predicate, options) => waitFor(window, predicate, options),
+
+    /**
+     * Attaches capturing `input`/`change` listeners to the named fields and
+     * returns a recorder. Listeners are attached before any interaction, so the
+     * recorded sequence is exactly what the SDK dispatched.
+     */
+    recordEvents(names) {
+      const log = new Map(names.map((name) => [name, []]));
+
+      for (const name of names) {
+        const element = field(name);
+        if (!element) throw new Error(`No field named ${name} in the form`);
+        for (const type of ["input", "change"]) {
+          element.addEventListener(
+            type,
+            (event) => {
+              log.get(name).push({ type: event.type, value: event.target.value });
+            },
+            true // capture phase
+          );
+        }
+      }
+
+      return {
+        /** Event types recorded on a field, in dispatch order. */
+        types: (name) => log.get(name).map((entry) => entry.type),
+        entries: (name) => log.get(name).slice(),
+        reset: () => {
+          for (const name of names) log.set(name, []);
+        },
+      };
+    },
+
+    /**
+     * Drives the SDK's own search UI: puts text in the search field and fires
+     * the keyup that capture.js binds (capture.js:1762-1788 - it binds
+     * keyup/keydown/keypress/paste/click/dblclick/change and nothing else).
+     * Returns once the SDK has rendered suggestion items.
+     */
+    async search(text, { fieldName = "street[0]" } = {}) {
+      const element = field(fieldName);
+      element.focus();
+      // keydown first: that is the handler which tells the SDK's autocomplete
+      // which field is being typed into (capture.js:2138-2143 -> autocomplete.focus).
+      element.dispatchEvent(
+        new window.KeyboardEvent("keydown", { bubbles: true, key: "g" })
+      );
+      element.value = text;
+      element.dispatchEvent(
+        new window.KeyboardEvent("keyup", { bubbles: true, key: "g" })
+      );
+      await this.waitFor(
+        () => this.suggestionElements().length > 0,
+        { label: "the SDK to render suggestion items" }
+      );
+    },
+
+    /** The suggestion elements the SDK rendered in its own autocomplete list. */
+    suggestionElements() {
+      const list = this.control?.autocomplete?.list?.element;
+      return list ? Array.from(list.querySelectorAll(".pcaitem")) : [];
+    },
+
+    /** Clicks a rendered suggestion, exactly as a shopper would. */
+    clickSuggestion(index = 0) {
+      const items = this.suggestionElements();
+      if (!items[index]) throw new Error(`No suggestion at index ${index}`);
+      items[index].dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    },
+
+    /** Search, click the first suggestion, and wait for the populate to land. */
+    async searchAndPick(text = "10 Downing") {
+      await this.search(text);
+      this.clickSuggestion(0);
+      await this.waitFor(() => field("city").value !== "", {
+        label: "the retrieved address to be written to the form",
+      });
+      // Let the region-select retry timer and Alpine's queue drain.
+      await this.tick(120);
+    },
+
+    async close() {
+      window.close();
+      await server.close();
+    },
+  };
+
+  return harness;
+}

--- a/Test/manual/LOQ-17502-alpine-repro.html
+++ b/Test/manual/LOQ-17502-alpine-repro.html
@@ -1,0 +1,266 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>LOQ-17502 — Alpine x-model populate harness</title>
+<!--
+  LOQ-17502 reproduction harness.
+
+  Purpose
+  -------
+  Reproduce, WITHOUT a Magento or Hyva install, the defect reported in LOQ-17502:
+  address fields populated by the Loqate capture script revert to empty as soon as
+  the shopper moves on, on Hyva Checkout but not on Luma.
+
+  Why this harness is faithful to the real thing
+  ----------------------------------------------
+  Hyva Checkout binds its address fields with Magewire's `wire:model.defer`.
+  Magewire (Livewire v3 derived) rewrites that into an Alpine `x-model` with the
+  `defer`/`lazy` modifiers stripped, and Alpine chooses its listener as:
+
+      el.tagName === 'select' || ['checkbox','radio'].includes(el.type)
+          || modifiers.includes('lazy')  ?  'change'  :  'input'
+
+  So a plain text input is synced to the component state on `input` ONLY. A
+  `change` event is never observed. On the next commit Magewire re-renders the
+  section from its own (still empty) state and morphs the stale value back into
+  the DOM — the wipe.
+
+  This page uses real Alpine `x-model` bindings, so the binding half is not
+  simulated at all. The only simulated part is the Magewire commit/morph, modelled
+  by `commitAndRerender()`: take whatever Alpine holds, round-trip it through a
+  fake server, write it back into the DOM. That is what morphdom does.
+
+  Usage
+  -----
+  Open this file in a browser (needs network access for the Alpine CDN script)
+  and press "Run both scenarios". Expected result after the fix in
+  view/base/web/capture.js: scenario A FAILs (that is the bug) and scenario B
+  PASSes on every text field.
+
+  See Test/manual/LOQ-17502-manual-qa.md for the in-Magento verification steps.
+-->
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 2rem; max-width: 60rem; }
+  h1 { font-size: 1.25rem; margin: 0 0 .25rem; }
+  h2 { font-size: 1rem; margin: 2rem 0 .5rem; }
+  p.lede { margin: 0 0 1.5rem; opacity: .75; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); gap: .75rem 1rem; }
+  label { display: block; font-weight: 600; font-size: .8rem; margin-bottom: .2rem; }
+  input, select { width: 100%; box-sizing: border-box; padding: .4rem .5rem; font: inherit; }
+  .actions { display: flex; flex-wrap: wrap; gap: .5rem; margin: 1rem 0; }
+  button { padding: .5rem .8rem; font: inherit; cursor: pointer; }
+  button.primary { font-weight: 600; }
+  pre { padding: .75rem; overflow-x: auto; border: 1px solid currentColor; border-radius: 4px; opacity: .9; }
+  .pass { color: #0a7d33; font-weight: 700; }
+  .fail { color: #b3261e; font-weight: 700; }
+  .note { opacity: .7; font-size: .85rem; }
+  fieldset { border: 1px solid currentColor; border-radius: 4px; padding: 1rem; margin: 0 0 1rem; }
+  legend { font-weight: 700; padding: 0 .4rem; }
+</style>
+</head>
+<body>
+
+<h1>LOQ-17502 — does the populate reach Alpine's <code>x-model</code>?</h1>
+<p class="lede">
+  Every field below is bound with a real Alpine <code>x-model</code>, exactly as Magewire
+  rewrites Hyv&auml; Checkout's <code>wire:model.defer</code>. "Component state" is what a
+  Magewire commit would send to the server — if a populated value is missing from it,
+  that value is already lost.
+</p>
+
+<div x-data="harness()" x-init="init()">
+
+  <fieldset>
+    <legend>Shipping address (Alpine <code>x-model</code> bound)</legend>
+    <div class="grid">
+      <div>
+        <label for="street0">street[0] &mdash; <span class="note">text</span></label>
+        <input id="street0" name="street[0]" type="text" x-model="form.street0">
+      </div>
+      <div>
+        <label for="street1">street[1] &mdash; <span class="note">text</span></label>
+        <input id="street1" name="street[1]" type="text" x-model="form.street1">
+      </div>
+      <div>
+        <label for="company">company &mdash; <span class="note">text, POPULATE|PRESERVE</span></label>
+        <input id="company" name="company" type="text" x-model="form.company">
+      </div>
+      <div>
+        <label for="city">city &mdash; <span class="note">text</span></label>
+        <input id="city" name="city" type="text" x-model="form.city">
+      </div>
+      <div>
+        <label for="postcode">postcode &mdash; <span class="note">text</span></label>
+        <input id="postcode" name="postcode" type="text" x-model="form.postcode">
+      </div>
+      <div>
+        <label for="region_id">region_id &mdash; <span class="note">select</span></label>
+        <select id="region_id" name="region_id" x-model="form.region_id">
+          <option value="">Please select a region</option>
+          <option value="121">Noord-Brabant</option>
+          <option value="122">Noord-Holland</option>
+          <option value="123">Zuid-Holland</option>
+        </select>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Somewhere else on the form</legend>
+    <label for="telephone">telephone &mdash; <span class="note">focusing this commits, like Hyv&auml;'s wire:auto-save</span></label>
+    <input id="telephone" name="telephone" type="text" x-model="form.telephone"
+           @focus="commitAndRerender('focus moved to telephone')">
+  </fieldset>
+
+  <div class="actions">
+    <button class="primary" @click="runBothScenarios()">Run both scenarios (automated)</button>
+    <button @click="reset(); populate('current')">Populate &mdash; current behaviour</button>
+    <button @click="reset(); populate('fixed')">Populate &mdash; proposed fix</button>
+    <button @click="commitAndRerender('manual commit')">Commit + re-render</button>
+    <button @click="reset()">Reset</button>
+  </div>
+
+  <h2>Component state <span class="note">(what a Magewire commit would send)</span></h2>
+  <pre x-text="JSON.stringify(form, null, 2)"></pre>
+
+  <h2>Result</h2>
+  <pre x-html="report"></pre>
+
+</div>
+
+<script>
+/**
+ * The address the Loqate retrieve service returns for "Fatimastraat 19", as the
+ * capture script would map it onto the module's `default` field mapping.
+ */
+const RETRIEVED = {
+  street0:   'Fatimastraat 19',
+  street1:   '',
+  company:   '',
+  city:      'Oss',
+  postcode:  '5348 LC',
+  region_id: '121'
+};
+
+/** Text fields whose value the populate must survive a commit. */
+const TEXT_FIELDS = ['street0', 'city', 'postcode'];
+
+function harness() {
+  return {
+    form: {},
+    server: {},
+    report: 'Press "Run both scenarios".',
+
+    init() { this.reset(); },
+
+    reset() {
+      this.form = {
+        street0: '', street1: '', company: '', city: '',
+        postcode: '', region_id: '', telephone: ''
+      };
+      this.server = { ...this.form };
+    },
+
+    /* ------------------------------------------------------------------ *
+     * The two populate strategies.
+     *
+     * 'current' mirrors view/base/web/capture.js as shipped in v2.1.1:
+     *   - text inputs: pca.setValue() writes .value, then reactTriggerChange()
+     *     takes its `input[type=text]` branch and dispatches ONLY `change`
+     *     (capture.js:3190-3199).
+     *   - the region select: pca.setValue()'s SELECT branch returns early
+     *     (capture.js:3335-3344) so the SDK dispatches nothing, but the module's
+     *     own mapRegionSelectValueWithRetry() does dispatch `change` — which is
+     *     what Alpine listens for on a select, so this one already works.
+     *
+     * 'fixed' adds what dispatchPopulateEvents() in capture.js adds, and only
+     *   that: a bubbling `input` on an input/textarea, dispatched from the
+     *   control's `populate` event — i.e. after the SDK's own `change`. Nothing
+     *   the SDK already dispatches is duplicated.
+     * ------------------------------------------------------------------ */
+    populate(strategy) {
+      Object.keys(RETRIEVED).forEach((key) => {
+        const el = document.getElementById(key);
+        const value = RETRIEVED[key];
+        if (!el || value === '') return;
+
+        el.value = value;
+
+        if (el.tagName === 'SELECT') {
+          // Both strategies dispatch `change` here — see note above.
+          el.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+          return;
+        }
+
+        // What the SDK does today, in both scenarios.
+        el.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+
+        // What the fix adds, from the control's populate event.
+        if (strategy === 'fixed') {
+          el.dispatchEvent(new Event('input', { bubbles: true, cancelable: false }));
+        }
+      });
+    },
+
+    /**
+     * Stand-in for a Magewire commit: whatever the component holds is sent to the
+     * server, and the response is morphed back over the DOM. Values the component
+     * never learned about are overwritten with the stale ones — the reported wipe.
+     */
+    commitAndRerender(trigger) {
+      this.server = { ...this.form };                       // request
+      Object.keys(this.server).forEach((key) => {           // morph the response in
+        const el = document.getElementById(key);
+        if (el) el.value = this.server[key];
+        this.form[key] = this.server[key];
+      });
+      console.log('[LOQ-17502] commit + re-render (' + trigger + ')', { ...this.server });
+    },
+
+    /** Automated before/after check over the text fields. */
+    runBothScenarios() {
+      const lines = [];
+      let brokeAsExpected = false;
+      let fixedHolds = true;
+
+      ['current', 'fixed'].forEach((strategy) => {
+        this.reset();
+        this.populate(strategy);
+        this.commitAndRerender('automated ' + strategy);
+
+        const survived = TEXT_FIELDS.filter((k) => this.form[k] === RETRIEVED[k]);
+        const lost     = TEXT_FIELDS.filter((k) => this.form[k] !== RETRIEVED[k]);
+        const ok       = lost.length === 0;
+
+        if (strategy === 'current') brokeAsExpected = !ok;
+        if (strategy === 'fixed')   fixedHolds = ok;
+
+        lines.push(
+          (strategy === 'current'
+            ? 'A. Current behaviour (change only)     '
+            : 'B. With the fix (SDK change + our input)') +
+          (ok ? '<span class="pass">values survived</span>'
+              : '<span class="fail">values wiped: ' + lost.join(', ') + '</span>') +
+          (survived.length ? '\n   survived: ' + survived.join(', ') : '') +
+          '\n   region_id (select): ' +
+          (this.form.region_id === RETRIEVED.region_id
+            ? '<span class="pass">survived</span>' : '<span class="fail">wiped</span>')
+        );
+      });
+
+      const verdict = (brokeAsExpected && fixedHolds)
+        ? '<span class="pass">HARNESS PASS</span> — the bug reproduces on A and the fix holds on B.'
+        : '<span class="fail">HARNESS INCONCLUSIVE</span> — expected A to wipe and B to survive. '
+          + 'Check that Alpine loaded (the CDN script needs network access).';
+
+      this.reset();
+      this.report = lines.join('\n\n') + '\n\n' + verdict;
+    }
+  };
+}
+</script>
+</body>
+</html>

--- a/Test/manual/LOQ-17502-alpine-repro.html
+++ b/Test/manual/LOQ-17502-alpine-repro.html
@@ -2,18 +2,29 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>LOQ-17502 — Alpine x-model populate harness</title>
+<title>LOQ-17502 — Alpine x-model binding demonstration (not a test of capture.js)</title>
 <!--
-  LOQ-17502 reproduction harness.
+  LOQ-17502 — Alpine `x-model` binding demonstration.
 
-  Purpose
-  -------
-  Reproduce, WITHOUT a Magento or Hyva install, the defect reported in LOQ-17502:
-  address fields populated by the Loqate capture script revert to empty as soon as
-  the shopper moves on, on Hyva Checkout but not on Luma.
+  READ THIS FIRST: this page does NOT verify the fix
+  -------------------------------------------------
+  It never loads `view/base/web/capture.js`. The event dispatch it exercises is a
+  dozen lines of its own, in `populate()` below. So it can show what Alpine does
+  when it is given, or not given, an `input` event — and nothing more. It cannot
+  show that the shipped script sends one.
 
-  Why this harness is faithful to the real thing
-  ----------------------------------------------
+  What does exercise the real script is the automated JS suite: `npm test` (Node's
+  built-in test runner, jsdom plus real Alpine from npm) over `Test/js/`. Those
+  tests load the actual `capture.js` and assert the event contract on it. CI runs
+  the suite as its own job. A manual pass on a real Hyva Checkout is still
+  required on top of both — nothing automated runs against Hyva Checkout itself.
+  See `Test/manual/LOQ-17502-manual-qa.md`.
+
+  What this page IS for
+  ---------------------
+  Understanding WHY the defect happened, which neither a unit test nor a QA script
+  explains well.
+
   Hyva Checkout binds its address fields with Magewire's `wire:model.defer`.
   Magewire (Livewire v3 derived) rewrites that into an Alpine `x-model` with the
   `defer`/`lazy` modifiers stripped, and Alpine chooses its listener as:
@@ -21,24 +32,35 @@
       el.tagName === 'select' || ['checkbox','radio'].includes(el.type)
           || modifiers.includes('lazy')  ?  'change'  :  'input'
 
-  So a plain text input is synced to the component state on `input` ONLY. A
+  So a plain text input is synced to the component state on `input` ONLY; a
   `change` event is never observed. On the next commit Magewire re-renders the
   section from its own (still empty) state and morphs the stale value back into
-  the DOM — the wipe.
+  the DOM — the wipe. Every field below is bound with a real Alpine `x-model`, so
+  that half is not simulated. The Magewire commit/morph is modelled by
+  `commitAndRerender()`: take whatever Alpine holds, round-trip it through a fake
+  server, write it back into the DOM. That is what morphdom does.
 
-  This page uses real Alpine `x-model` bindings, so the binding half is not
-  simulated at all. The only simulated part is the Magewire commit/morph, modelled
-  by `commitAndRerender()`: take whatever Alpine holds, round-trip it through a
-  fake server, write it back into the DOM. That is what morphdom does.
+  The shipped fix, for reference (it lives in the SDK, not here)
+  -------------------------------------------------------------
+  The fix is in the SDK's own event dispatcher, `pca.reactTriggerChange`
+  (`view/base/web/capture.js:3202-3228`). An `input[type=text]` now emits exactly
+  one bubbling `input` (lines 3218-3223) followed by exactly one bubbling `change`
+  (lines 3225-3228), in that order — native semantics: `input` while editing,
+  `change` on commit. `select`, `input[type=file]`, checkbox, radio, textarea and
+  every other `supportedInputTypes` key are unchanged.
+
+  Because it sits in the dispatcher rather than on the control's `populate` event,
+  it covers every path the SDK writes a field from: the populate loop
+  (`capture.js:7354`), the drill-down `filterSearch` write back to the search
+  field (`capture.js:7165`), the country list's `hide` restore of the stored
+  search (`capture.js:6549`) and `address.clear()` (`capture.js:7609`).
 
   Usage
   -----
-  Open this file in a browser (needs network access for the Alpine CDN script)
-  and press "Run both scenarios". Expected result after the fix in
-  view/base/web/capture.js: scenario A FAILs (that is the bug) and scenario B
-  PASSes on every text field.
-
-  See Test/manual/LOQ-17502-manual-qa.md for the in-Magento verification steps.
+  Open this file in a browser (needs network access for the Alpine CDN script) and
+  press "Run both scenarios". Scenario A (`change` only, the old dispatcher) loses
+  the populated values from the component state; scenario B (`input` then `change`,
+  the new dispatcher) keeps them.
 -->
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
 <style>
@@ -46,7 +68,7 @@
   body { font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 2rem; max-width: 60rem; }
   h1 { font-size: 1.25rem; margin: 0 0 .25rem; }
   h2 { font-size: 1rem; margin: 2rem 0 .5rem; }
-  p.lede { margin: 0 0 1.5rem; opacity: .75; }
+  p.lede { margin: 0 0 1rem; opacity: .75; }
   .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); gap: .75rem 1rem; }
   label { display: block; font-weight: 600; font-size: .8rem; margin-bottom: .2rem; }
   input, select { width: 100%; box-sizing: border-box; padding: .4rem .5rem; font: inherit; }
@@ -57,18 +79,31 @@
   .pass { color: #0a7d33; font-weight: 700; }
   .fail { color: #b3261e; font-weight: 700; }
   .note { opacity: .7; font-size: .85rem; }
+  .warn { border: 2px solid #b3261e; border-radius: 4px; padding: .75rem 1rem; margin: 0 0 1.5rem; }
+  .warn strong { color: #b3261e; }
   fieldset { border: 1px solid currentColor; border-radius: 4px; padding: 1rem; margin: 0 0 1rem; }
   legend { font-weight: 700; padding: 0 .4rem; }
 </style>
 </head>
 <body>
 
-<h1>LOQ-17502 — does the populate reach Alpine's <code>x-model</code>?</h1>
+<h1>LOQ-17502 &mdash; why a populate that fires only <code>change</code> is lost on Hyv&auml;</h1>
 <p class="lede">
   Every field below is bound with a real Alpine <code>x-model</code>, exactly as Magewire
   rewrites Hyv&auml; Checkout's <code>wire:model.defer</code>. "Component state" is what a
-  Magewire commit would send to the server — if a populated value is missing from it,
+  Magewire commit would send to the server &mdash; if a populated value is missing from it,
   that value is already lost.
+</p>
+
+<p class="warn">
+  <strong>This page does not verify the fix.</strong> It never loads
+  <code>view/base/web/capture.js</code>; the dispatch below is a model of it, written by hand.
+  It demonstrates <em>Alpine's binding behaviour</em> &mdash; that a text input synced by
+  <code>x-model</code> needs <code>input</code>, and that a value which never reached component
+  state is lost on the next commit and morph. What exercises the real script is the automated
+  suite: <code>npm test</code> over <code>Test/js/</code>, which loads the actual
+  <code>capture.js</code>. A manual pass on a real Hyv&auml; Checkout is still required; see
+  <code>Test/manual/LOQ-17502-manual-qa.md</code>.
 </p>
 
 <div x-data="harness()" x-init="init()">
@@ -81,11 +116,11 @@
         <input id="street0" name="street[0]" type="text" x-model="form.street0">
       </div>
       <div>
-        <label for="street1">street[1] &mdash; <span class="note">text</span></label>
+        <label for="street1">street[1] &mdash; <span class="note">text, blank in this retrieve</span></label>
         <input id="street1" name="street[1]" type="text" x-model="form.street1">
       </div>
       <div>
-        <label for="company">company &mdash; <span class="note">text, POPULATE|PRESERVE</span></label>
+        <label for="company">company &mdash; <span class="note">text, POPULATE|PRESERVE, blank</span></label>
         <input id="company" name="company" type="text" x-model="form.company">
       </div>
       <div>
@@ -116,9 +151,9 @@
   </fieldset>
 
   <div class="actions">
-    <button class="primary" @click="runBothScenarios()">Run both scenarios (automated)</button>
-    <button @click="reset(); populate('current')">Populate &mdash; current behaviour</button>
-    <button @click="reset(); populate('fixed')">Populate &mdash; proposed fix</button>
+    <button class="primary" @click="runBothScenarios()">Run both scenarios</button>
+    <button @click="reset(); populate('before')">Populate &mdash; before the fix (change only)</button>
+    <button @click="reset(); populate('after')">Populate &mdash; after the fix (input, then change)</button>
     <button @click="commitAndRerender('manual commit')">Commit + re-render</button>
     <button @click="reset()">Reset</button>
   </div>
@@ -134,7 +169,8 @@
 <script>
 /**
  * The address the Loqate retrieve service returns for "Fatimastraat 19", as the
- * capture script would map it onto the module's `default` field mapping.
+ * capture script would map it onto the module's `default` field mapping. Note
+ * that two of the fields come back blank, which is normal.
  */
 const RETRIEVED = {
   street0:   'Fatimastraat 19',
@@ -145,8 +181,11 @@ const RETRIEVED = {
   region_id: '121'
 };
 
-/** Text fields whose value the populate must survive a commit. */
+/** Text fields with a value, whose populate must survive a commit. */
 const TEXT_FIELDS = ['street0', 'city', 'postcode'];
+
+/** Text fields the retrieve returns blank. They are written and dispatched too. */
+const BLANK_FIELDS = ['street1', 'company'];
 
 function harness() {
   return {
@@ -165,43 +204,50 @@ function harness() {
     },
 
     /* ------------------------------------------------------------------ *
-     * The two populate strategies.
+     * The two dispatch policies, MODELLED. This is not the real code — see
+     * the warning at the top of the file — but it models what the real
+     * dispatcher does, and no more than that.
      *
-     * 'current' mirrors view/base/web/capture.js as shipped in v2.1.1:
-     *   - text inputs: pca.setValue() writes .value, then reactTriggerChange()
-     *     takes its `input[type=text]` branch and dispatches ONLY `change`
-     *     (capture.js:3190-3199).
-     *   - the region select: pca.setValue()'s SELECT branch returns early
-     *     (capture.js:3335-3344) so the SDK dispatches nothing, but the module's
-     *     own mapRegionSelectValueWithRetry() does dispatch `change` — which is
-     *     what Alpine listens for on a select, so this one already works.
+     * 'before' is what `pca.reactTriggerChange` did up to v2.1.1: a text input
+     *   was matched by the `select`/`input[type=file]` branch and therefore got
+     *   a `change` event, and nothing else.
      *
-     * 'fixed' adds what dispatchPopulateEvents() in capture.js adds, and only
-     *   that: a bubbling `input` on an input/textarea, dispatched from the
-     *   control's `populate` event — i.e. after the SDK's own `change`. Nothing
-     *   the SDK already dispatches is duplicated.
+     * 'after' is what it does now (`capture.js:3202-3228`): a text input emits
+     *   one bubbling `input` (lines 3218-3223) and then one bubbling `change`
+     *   (lines 3225-3228), in that order.
+     *
+     * The region `<select>` behaves the same in both scenarios, for an unrelated
+     *   reason: `pca.setValue` returns as soon as it has set `selectedIndex` on a
+     *   select (`capture.js:3364-3373`), so it never reaches the dispatcher and
+     *   the SDK sends no event at all. The module's own `populate` listener
+     *   resolves the option and dispatches the `change` a select needs
+     *   (`capture.js:8120-8144`) — and `change` is exactly what Alpine listens
+     *   for on a select, so the region always worked.
+     *
+     * There is deliberately NO filter on the value here: the real code writes
+     * and dispatches for empty values too (`street[1]` and `company` come back
+     * blank from this retrieve, and `address.clear()` blanks every field), so
+     * this models the same policy. Only a missing element is skipped.
      * ------------------------------------------------------------------ */
     populate(strategy) {
       Object.keys(RETRIEVED).forEach((key) => {
         const el = document.getElementById(key);
-        const value = RETRIEVED[key];
-        if (!el || value === '') return;
+        if (!el) return;
 
-        el.value = value;
+        el.value = RETRIEVED[key];
 
         if (el.tagName === 'SELECT') {
-          // Both strategies dispatch `change` here — see note above.
+          // Stands in for mapRegionSelectValueWithRetry(); see the note above.
           el.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
           return;
         }
 
-        // What the SDK does today, in both scenarios.
-        el.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
-
-        // What the fix adds, from the control's populate event.
-        if (strategy === 'fixed') {
+        // Text input. Order matters: `input` while editing, `change` on commit.
+        if (strategy === 'after') {
           el.dispatchEvent(new Event('input', { bubbles: true, cancelable: false }));
         }
+
+        el.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
       });
     },
 
@@ -220,13 +266,14 @@ function harness() {
       console.log('[LOQ-17502] commit + re-render (' + trigger + ')', { ...this.server });
     },
 
-    /** Automated before/after check over the text fields. */
+    /** Before/after demonstration over the populated fields. */
     runBothScenarios() {
       const lines = [];
       let brokeAsExpected = false;
       let fixedHolds = true;
+      let blanksHold = true;
 
-      ['current', 'fixed'].forEach((strategy) => {
+      ['before', 'after'].forEach((strategy) => {
         this.reset();
         this.populate(strategy);
         this.commitAndRerender('automated ' + strategy);
@@ -234,27 +281,36 @@ function harness() {
         const survived = TEXT_FIELDS.filter((k) => this.form[k] === RETRIEVED[k]);
         const lost     = TEXT_FIELDS.filter((k) => this.form[k] !== RETRIEVED[k]);
         const ok       = lost.length === 0;
+        const blanksOk = BLANK_FIELDS.every((k) => this.form[k] === '');
 
-        if (strategy === 'current') brokeAsExpected = !ok;
-        if (strategy === 'fixed')   fixedHolds = ok;
+        if (strategy === 'before') brokeAsExpected = !ok;
+        if (strategy === 'after')  fixedHolds = ok;
+        blanksHold = blanksHold && blanksOk;
 
         lines.push(
-          (strategy === 'current'
-            ? 'A. Current behaviour (change only)     '
-            : 'B. With the fix (SDK change + our input)') +
+          (strategy === 'before'
+            ? 'A. Before the fix (change only)       '
+            : 'B. After the fix (input, then change) ') +
           (ok ? '<span class="pass">values survived</span>'
               : '<span class="fail">values wiped: ' + lost.join(', ') + '</span>') +
           (survived.length ? '\n   survived: ' + survived.join(', ') : '') +
           '\n   region_id (select): ' +
           (this.form.region_id === RETRIEVED.region_id
-            ? '<span class="pass">survived</span>' : '<span class="fail">wiped</span>')
+            ? '<span class="pass">survived</span>' : '<span class="fail">wiped</span>') +
+          '\n   blank-valued fields (' + BLANK_FIELDS.join(', ') + '), written and ' +
+          'dispatched like any other: ' +
+          (blanksOk ? '<span class="pass">still blank</span>'
+                    : '<span class="fail">unexpected value</span>')
         );
       });
 
-      const verdict = (brokeAsExpected && fixedHolds)
-        ? '<span class="pass">HARNESS PASS</span> — the bug reproduces on A and the fix holds on B.'
-        : '<span class="fail">HARNESS INCONCLUSIVE</span> — expected A to wipe and B to survive. '
-          + 'Check that Alpine loaded (the CDN script needs network access).';
+      const verdict = (brokeAsExpected && fixedHolds && blanksHold)
+        ? '<span class="pass">BEHAVIOUR DEMONSTRATED</span> — A loses the populated values, '
+          + 'B keeps them.\nThis says nothing about the shipped capture.js: run `npm test` '
+          + 'for that, and the\nHyv&auml; pass in LOQ-17502-manual-qa.md for the real checkout.'
+        : '<span class="fail">BEHAVIOUR NOT DEMONSTRATED</span> — expected A to lose the values '
+          + 'and B to keep them,\nwith the blank fields left blank in both. Check that Alpine '
+          + 'loaded (the CDN script\nneeds network access).';
 
       this.reset();
       this.report = lines.join('\n\n') + '\n\n' + verdict;

--- a/Test/manual/LOQ-17502-manual-qa.md
+++ b/Test/manual/LOQ-17502-manual-qa.md
@@ -1,0 +1,127 @@
+# LOQ-17502 — verification steps
+
+The fix is a change to `view/base/web/capture.js` only. There is no JS test runner in
+this repository (`Test/Unit` is PHPUnit, and it covers PHP), so nothing here is
+executed by `composer test`. Verification is the harness in step 1 plus the manual
+passes in steps 3-6.
+
+## What the fix changes
+
+`dispatchPopulateEvents()` in the module's own wrapper now dispatches, from the
+control's `populate` event, the one event the bundled SDK never sends: a bubbling
+`input` on an input or textarea, `change` on anything else. Nothing the SDK already
+dispatches is duplicated. Fields the SDK is not allowed to write to are untouched,
+because the hook filters on the same `mode & pca.fieldMode.POPULATE` test the SDK's
+own populate loop uses.
+
+Two fields are deliberately **not** covered by that hook:
+
+- **country** — `pca.fieldMode.COUNTRY` does not carry the `POPULATE` bit, so the
+  country is filled in by the SDK's country list, which fires a native `change` of
+  its own (`capture.js`, `countrylist.populate()`).
+- **the region `<select>`** — still handled by `mapRegionSelectValueWithRetry()`,
+  which resolves the option to select and dispatches its own `change`.
+
+## 1. Standalone harness — no Magento needed
+
+Open `Test/manual/LOQ-17502-alpine-repro.html` in a browser and press
+**"Run both scenarios"**.
+
+Expected: `HARNESS PASS` — scenario A (what the SDK does on its own) wipes
+`street0`, `city` and `postcode`; scenario B (with the `input` event the fix adds)
+keeps them. The region `<select>` survives in both, which is why this ticket is
+about the text fields only.
+
+If the page reports `HARNESS INCONCLUSIVE`, Alpine did not load — the page pulls it
+from a CDN, and a corporate TLS proxy will block that. Save Alpine 3 next to the
+file and point the `<script src>` at it.
+
+## 2. Optional — drive the real widget headlessly
+
+Stronger than step 1, because it exercises the actual `capture.js` rather than a
+model of its event behaviour. Serve a page over `http://` that loads
+`view/base/web/capture.js`, Alpine, an address form whose fields are bound with
+`x-model` and named as the module's `default` mapping expects (`street[0]`, `city`,
+`postcode`, `region_id`, `country_id`), and a `#loqate-urls` div pointing at stub
+`find` / `retrieve` endpoints. The controllers return the Loqate response
+unwrapped — a bare JSON array, not `{Items: [...]}` — because the control is
+constructed with `endpoint.unwrapped = true`.
+
+Then, in a headless browser: type an address into `street[0]`, click the suggestion,
+read the Alpine component state, and finally overwrite every field from that state
+(what a Magewire commit + morph does). Before the fix the state is missing `city` and
+`postcode`; after it, both are present. Note that `street[0]` survives either way —
+the shopper typed it, so real `input` events already fired. That asymmetry is the
+signature of this bug.
+
+Worth asserting at the same time: each populated text field receives exactly one
+`input` and one `change`, and `pca.Address` is not constructed repeatedly (a
+`MutationObserver` re-init loop would show up as a climbing count).
+
+## 3. Deploy to the devcontainer
+
+The devcontainer installs Luma; it does **not** install Hyvä, which needs private
+Hyvä GitLab credentials. So steps 3-5 are what you can verify locally, and step 6
+needs a Hyvä environment.
+
+```
+.devcontainer/setup-magento.sh          # first time only
+.devcontainer/sync-extension.sh         # after every change to the module
+bin/magento setup:upgrade && bin/magento cache:flush
+```
+
+`sync-extension.sh` copies the module into `vendor/` — it is not a live symlink, so
+a change is not picked up until you re-run it. Also flush the browser cache or use a
+private window; `capture.js` is a static view file and is aggressively cached.
+
+## 4. Luma checkout — the regression that matters most
+
+`view/frontend/layout/checkout_index_index.xml`. Knockout binds on `change`, which
+the SDK already sent and the fix does not touch, so this must behave exactly as
+before.
+
+1. Add a product to the cart and go to checkout.
+2. Type a partial address into the street field and pick a suggestion.
+3. Confirm street, city, postcode, region and country all populate.
+4. Click into other fields and back. Nothing may revert.
+5. Confirm no validation error appears against a field the lookup left empty
+   (`street[1]`, `company`).
+6. Place the order and confirm the saved shipping address matches what was shown.
+
+## 5. Admin and the other frontend forms
+
+Same lookup-and-tab-away flow, checking nothing reverts and no premature validation
+error appears:
+
+- Admin order create — `view/adminhtml/layout/sales_order_create_customer_block.xml`
+  (uses the `billingFields` / `shippingFields` mappings, not `default`).
+- Admin customer edit — `view/adminhtml/layout/customer_index_edit.xml`.
+- Customer address book — `view/frontend/layout/customer_address_form.xml`.
+- Multishipping — `view/frontend/layout/multishipping_checkout.xml`.
+
+The admin uses Magento UI components rather than Knockout-bound plain inputs, so
+pay attention to whether a populated value is still there after the field loses
+focus, and whether the form saves the populated values.
+
+## 6. Hyvä Checkout — the reported defect (needs a Hyvä environment)
+
+`view/frontend/layout/hyva_checkout_index_index.xml`. Use the customer's build, a
+staging site with Hyvä Checkout, or a local install with a Hyvä licence.
+
+1. Reproduce first **without** the fix, so you know the environment shows the bug:
+   look up `Fatimastraat 19`, pick the suggestion, then move focus to another field.
+   Postcode and city should blank out.
+2. Apply the fix and repeat. The values must survive.
+3. Continue to the next checkout step and place the order. Confirm the address that
+   is saved is the one the lookup filled in — the DOM looking right is not enough,
+   the value has to have reached the component state.
+4. In DevTools, confirm:
+   - no repeated `find` / `retrieve` requests firing in a loop;
+   - the Magewire commit request carries the populated `city` / `postcode`;
+   - no console errors from `capture.js`.
+5. Check the country field specifically. If country still reverts, that is **not**
+   this bug — country is populated by a different code path that already dispatches
+   its own `change`. Likely causes are the Hyvä country control not being a plain
+   `<select>`, or the region reload re-rendering and wiping its siblings. Diagnose
+   in DevTools and raise a separate ticket rather than extending this fix by
+   analogy.

--- a/Test/manual/LOQ-17502-manual-qa.md
+++ b/Test/manual/LOQ-17502-manual-qa.md
@@ -1,67 +1,139 @@
 # LOQ-17502 — verification steps
 
-The fix is a change to `view/base/web/capture.js` only. There is no JS test runner in
-this repository (`Test/Unit` is PHPUnit, and it covers PHP), so nothing here is
-executed by `composer test`. Verification is the harness in step 1 plus the manual
-passes in steps 3-6.
+The fix is a change to `view/base/web/capture.js` only, but it is no longer unverified
+by machine. There is now a JavaScript suite in this repository — `npm test`, over
+`Test/js/`, run in CI as its own job — which loads the real `capture.js` and asserts
+its event contract. `composer test` still covers PHP only (`Test/Unit` is PHPUnit),
+so it says nothing about this fix.
+
+What the automated suite proves: that the script dispatches the events it is supposed
+to dispatch, and that an Alpine `x-model` component bound the way Magewire binds one
+ends up holding the populated values. What only a human on a real Hyvä install can
+prove: that Hyvä Checkout's own Magewire components, morphing and validation behave —
+nothing automated here runs against Hyvä Checkout. So step 1 is the desk check, steps
+2-4 are what a local Luma devcontainer can show, and step 5 is still required before
+release.
 
 ## What the fix changes
 
-`dispatchPopulateEvents()` in the module's own wrapper now dispatches, from the
-control's `populate` event, the one event the bundled SDK never sends: a bubbling
-`input` on an input or textarea, `change` on anything else. Nothing the SDK already
-dispatches is duplicated. Fields the SDK is not allowed to write to are untouched,
-because the hook filters on the same `mode & pca.fieldMode.POPULATE` test the SDK's
-own populate loop uses.
+The fix is in the bundled SDK's own event dispatcher, `pca.reactTriggerChange`
+(`view/base/web/capture.js:3202-3228`). An `input[type=text]` now emits **exactly one
+bubbling `input`, then exactly one bubbling `change`**, in that order — native
+semantics: `input` while editing, `change` on commit. `select`, `input[type=file]`,
+checkbox, radio, textarea and every other `supportedInputTypes` key keep their
+upstream behaviour, untouched.
 
-Two fields are deliberately **not** covered by that hook:
+`input` is what Alpine's `x-model` needs (Alpine syncs a text input on `input` only,
+and uses `change` only for select, checkbox and radio), and `x-model` is what Magewire
+generates from the `wire:model.defer` bindings Hyvä Checkout uses. `change` is what
+Luma's Knockout `value` binding, the customer address book, multishipping and the
+admin Magento UI components listen for. Both events are required; dropping either
+breaks one of the two front ends.
 
-- **country** — `pca.fieldMode.COUNTRY` does not carry the `POPULATE` bit, so the
-  country is filled in by the SDK's country list, which fires a native `change` of
-  its own (`capture.js`, `countrylist.populate()`).
-- **the region `<select>`** — still handled by `mapRegionSelectValueWithRetry()`,
-  which resolves the option to select and dispatches its own `change`.
+It sits in the dispatcher, rather than on the capture control's `populate` event, for
+two reasons:
 
-## 1. Standalone harness — no Magento needed
+- **It covers every path the SDK writes a field from.** Not only the populate loop
+  (`capture.js:7354`), but also the drill-down `filterSearch` write back to the search
+  field (`capture.js:7165`), the country list's `hide` restore of the stored search
+  (`capture.js:6549`) and `address.clear()` (`capture.js:7609`). A hook on the
+  `populate` event would cover the first of those four and leave the other three
+  writing values Hyvä never learns about.
+- **It does not depend on a local fork change elsewhere in the same file.** A hook that
+  only added `input` would have relied on the dispatcher's local `input[type=text]`
+  clause to keep supplying the `change`. A clean re-vendor of the SDK deletes that
+  clause, and Luma would have broken silently. Both events now live in one place, in
+  one branch, described in the local-changes block at the top of `capture.js`.
 
-Open `Test/manual/LOQ-17502-alpine-repro.html` in a browser and press
-**"Run both scenarios"**.
+Two fields get their event from somewhere else, and neither is affected by this
+change:
 
-Expected: `HARNESS PASS` — scenario A (what the SDK does on its own) wipes
-`street0`, `city` and `postcode`; scenario B (with the `input` event the fix adds)
-keeps them. The region `<select>` survives in both, which is why this ticket is
-about the text fields only.
+- **country** — `pca.fieldMode.COUNTRY` (8) carries no `POPULATE` bit (2), so the
+  populate loop skips the country field entirely (`capture.js:7323`). It is filled in
+  by the SDK's country list, which fires its own native `change`
+  (`countrylist.populate()`, `capture.js:5733`).
+- **the region `<select>`** — `pca.setValue` returns as soon as it has set
+  `selectedIndex` on a select (`capture.js:3364-3373`), so a select never reaches the
+  dispatcher and the SDK sends no event at all for it. The module's own `populate`
+  listener (`capture.js:8133-8151`) resolves the option — matching the region codes
+  Magento keeps in data attributes, which `pca.setValue` misses — and dispatches the
+  `change` a select needs. `mapRegionSelectValueWithRetry()` is the only thing
+  providing that event, and `change` is exactly what Alpine, Knockout and the admin UI
+  components listen for on a select. The region elements are now resolved by name on
+  every populate rather than snapshotted at init, so a `region_id` select that renders
+  later (Magewire re-rendering the address form, or Magento loading the region list
+  once a country is chosen) is still mapped. `region` (text input) and `region_id`
+  (select) both map to `ProvinceName`; only the select goes through the mapper, the
+  text input is populated by the ordinary loop like any other text field.
 
-If the page reports `HARNESS INCONCLUSIVE`, Alpine did not load — the page pulls it
-from a CDN, and a corporate TLS proxy will block that. Save Alpine 3 next to the
-file and point the `<script src>` at it.
+**Because the fix is in the shared dispatcher, the Luma and admin regression passes
+matter more than they would for a hook on `populate`:** every text input the SDK
+writes, anywhere, now receives an extra `input` event it did not receive before. That
+is the correct native order and no consumer of `change` loses anything, but a listener
+that reacts to both will now run twice. Steps 3 and 4 exist to look for that.
 
-## 2. Optional — drive the real widget headlessly
+## 1. Desk checks — no Magento install needed
 
-Stronger than step 1, because it exercises the actual `capture.js` rather than a
-model of its event behaviour. Serve a page over `http://` that loads
-`view/base/web/capture.js`, Alpine, an address form whose fields are bound with
-`x-model` and named as the module's `default` mapping expects (`street[0]`, `city`,
-`postcode`, `region_id`, `country_id`), and a `#loqate-urls` div pointing at stub
-`find` / `retrieve` endpoints. The controllers return the Loqate response
-unwrapped — a bare JSON array, not `{Items: [...]}` — because the control is
-constructed with `endpoint.unwrapped = true`.
+### `npm test` — the automated suite
 
-Then, in a headless browser: type an address into `street[0]`, click the suggestion,
-read the Alpine component state, and finally overwrite every field from that state
-(what a Magewire commit + morph does). Before the fix the state is missing `city` and
-`postcode`; after it, both are present. Note that `street[0]` survives either way —
-the shopper typed it, so real `input` events already fired. That asymmetry is the
-signature of this bug.
+```
+npm ci        # first time, and after the lockfile changes
+npm test
+```
 
-Worth asserting at the same time: each populated text field receives exactly one
-`input` and one `change`, and `pca.Address` is not constructed repeatedly (a
-`MutationObserver` re-init loop would show up as a climbing count).
+Node's built-in test runner (`node --test`; there is no vitest or jest here), over
+`Test/js/`, using jsdom and the real Alpine package from npm.
 
-## 3. Deploy to the devcontainer
+`jsdom@30` sets the floor, so the suite needs **Node `^22.22.2 || ^24.15.0 ||
+>=26.0.0`** — which is what `package.json` declares. Node 20 cannot run it at all;
+neither can a 22.x older than 22.22.2 or a 24.x older than 24.15.0. On any of those
+`npm ci` warns `EBADENGINE` and the run cannot be trusted. CI covers `22` and `24`,
+each resolved to its newest patch, so CI is always above the floor.
+
+The tests load the actual `view/base/web/capture.js` rather than a re-implementation of
+its behaviour, and assert:
+
+- one `input` followed by one `change`, in that order, for each populated text field;
+- that an Alpine `x-model` component ends up holding `city` and `postcode`, and that
+  both survive a simulated Magewire commit and morph;
+- that the drill-down path and the country-list-cancel path emit `input` as well;
+- that a synthetic `input` does not trigger a `find` or `retrieve` request, so the
+  extra event cannot start a lookup loop;
+- that `pca.Address` is constructed only once, not repeatedly by the `MutationObserver`
+  rescan.
+
+A failure here means the event contract has moved. Read the failing assertion before
+changing anything: losing `change` breaks Luma, the address book, multishipping and
+the admin; losing `input` re-opens this ticket. An extra event of either kind is also
+a failure — double-firing is what steps 3 and 4 hunt for by hand.
+
+This is the strongest automated evidence available, and it is still not Hyvä Checkout.
+
+### The Alpine harness — explains the bug, does not test the fix
+
+Open `Test/manual/LOQ-17502-alpine-repro.html` in a browser and press **"Run both
+scenarios"**.
+
+The page never loads `capture.js`; it models the dispatch in a dozen lines of its own.
+So it demonstrates *Alpine's binding behaviour* — that a text input bound with
+`x-model` is only synced on `input`, and that a value which never reached component
+state is overwritten by the next commit and morph — and nothing about the shipped
+code. Use it to understand *why* the defect happened, or to show someone; do not treat
+it as verification.
+
+Expected: `BEHAVIOUR DEMONSTRATED` — scenario A (`change` only) loses `street0`, `city`
+and `postcode` from the component state; scenario B (`input`, then `change`) keeps
+them. The region `<select>` survives in both, which is why this ticket is about the
+text fields only.
+
+If the page reports `BEHAVIOUR NOT DEMONSTRATED`, Alpine most likely did not load — the
+page pulls it from a CDN, and a corporate TLS proxy will block that. Save Alpine 3 next
+to the file and point the `<script src>` at it.
+
+## 2. Deploy to the devcontainer
 
 The devcontainer installs Luma; it does **not** install Hyvä, which needs private
-Hyvä GitLab credentials. So steps 3-5 are what you can verify locally, and step 6
+Hyvä GitLab credentials. So steps 2-4 are what you can verify locally, and step 5
 needs a Hyvä environment.
 
 ```
@@ -74,24 +146,29 @@ bin/magento setup:upgrade && bin/magento cache:flush
 a change is not picked up until you re-run it. Also flush the browser cache or use a
 private window; `capture.js` is a static view file and is aggressively cached.
 
-## 4. Luma checkout — the regression that matters most
+## 3. Luma checkout — the regression that matters most
 
-`view/frontend/layout/checkout_index_index.xml`. Knockout binds on `change`, which
-the SDK already sent and the fix does not touch, so this must behave exactly as
-before.
+`view/frontend/layout/checkout_index_index.xml`. Knockout binds on `change`, which the
+dispatcher still sends for every node type it sent it for before, so this must behave
+exactly as it did. What is new is the extra `input` on text inputs, so watch for
+anything that reacts twice.
 
 1. Add a product to the cart and go to checkout.
 2. Type a partial address into the street field and pick a suggestion.
 3. Confirm street, city, postcode, region and country all populate.
 4. Click into other fields and back. Nothing may revert.
 5. Confirm no validation error appears against a field the lookup left empty
-   (`street[1]`, `company`).
-6. Place the order and confirm the saved shipping address matches what was shown.
+   (`street[1]`, `company`) — a premature or duplicated validation run is the
+   signature of the extra `input` being handled where it should not be.
+6. Watch the browser console and the network tab while a suggestion is applied: no
+   repeated `find` / `retrieve` calls, and no jQuery validation running twice over the
+   same field (a `valid()` call per event rather than per commit).
+7. Place the order and confirm the saved shipping address matches what was shown.
 
-## 5. Admin and the other frontend forms
+## 4. Admin and the other frontend forms
 
-Same lookup-and-tab-away flow, checking nothing reverts and no premature validation
-error appears:
+Same lookup-and-tab-away flow, checking nothing reverts, no premature validation error
+appears, and nothing fires twice:
 
 - Admin order create — `view/adminhtml/layout/sales_order_create_customer_block.xml`
   (uses the `billingFields` / `shippingFields` mappings, not `default`).
@@ -99,11 +176,13 @@ error appears:
 - Customer address book — `view/frontend/layout/customer_address_form.xml`.
 - Multishipping — `view/frontend/layout/multishipping_checkout.xml`.
 
-The admin uses Magento UI components rather than Knockout-bound plain inputs, so
-pay attention to whether a populated value is still there after the field loses
-focus, and whether the form saves the populated values.
+The admin uses Magento UI components rather than Knockout-bound plain inputs, so pay
+attention to whether a populated value is still there after the field loses focus,
+whether the form saves the populated values, and whether the extra `input` causes
+visible component churn — a field re-rendering or re-validating twice, a spinner
+flashing, or an admin order-create block reloading more than once per suggestion.
 
-## 6. Hyvä Checkout — the reported defect (needs a Hyvä environment)
+## 5. Hyvä Checkout — the reported defect (needs a Hyvä environment)
 
 `view/frontend/layout/hyva_checkout_index_index.xml`. Use the customer's build, a
 staging site with Hyvä Checkout, or a local install with a Hyvä licence.
@@ -118,6 +197,8 @@ staging site with Hyvä Checkout, or a local install with a Hyvä licence.
 4. In DevTools, confirm:
    - no repeated `find` / `retrieve` requests firing in a loop;
    - the Magewire commit request carries the populated `city` / `postcode`;
+   - no burst of Magewire commits — `wire:model.defer` must not commit on the new
+     `input` events, so a suggestion should not produce one commit per field;
    - no console errors from `capture.js`.
 5. Check the country field specifically. If country still reverts, that is **not**
    this bug — country is populated by a different code path that already dispatches

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
     }
   ],
   "autoload": {
+    "exclude-from-classmap": [
+      "/node_modules/",
+      "/.claude/"
+    ],
     "files": [
       "registration.php"
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,586 @@
+{
+  "name": "loqate-magento-js-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "loqate-magento-js-tests",
+      "version": "0.0.0",
+      "license": "OSL-3.0",
+      "devDependencies": {
+        "alpinejs": "3.16.3",
+        "jsdom": "30.0.1"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.1.tgz",
+      "integrity": "sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+      "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/alpinejs": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.3.tgz",
+      "integrity": "sha512-kLIO2JOPs5ZY3mHPH+CHHPzp89Y6Gb2luLRy+RDIb1oG9y6N5Vfc75kkEoaSOPhJqvakuPiAsnd9paNPNSZyVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "~3.5.40"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "loqate-magento-js-tests",
+  "version": "0.0.0",
+  "private": true,
+  "description": "JavaScript test suite for the vendored Loqate capture SDK (view/base/web/capture.js).",
+  "license": "OSL-3.0",
+  "scripts": {
+    "test": "node --test --test-reporter=spec \"Test/js/**/*.test.mjs\""
+  },
+  "devDependencies": {
+    "alpinejs": "3.16.3",
+    "jsdom": "30.0.1"
+  },
+  "engines": {
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+  }
+}

--- a/view/base/web/capture.js
+++ b/view/base/web/capture.js
@@ -9,7 +9,19 @@
         - options.endpoint.retrieve - the retrieve endpoint to use
         - options.endpoint.unwrapped - whether to assume the response from the endpoints will be unwrapped (i.e not in the `Items` array)
     - Updated the `pca.fetch` method to pass through an options object, this is necessary for the unwrapped option to be toggleable
-    - Updated event logic to init the 'change' event for text inputs (see commit #6e3fa015c69f657572009a578ea15f1efbe09af3)
+    - Updated event logic in `pca.reactTriggerChange` so that a text input is matched by the
+      `select`/`input[type=file]` branch and therefore gets a 'change' event
+      (see commit #6e3fa015c69f657572009a578ea15f1efbe09af3)
+    - Extended that same branch so a text input deliberately emits BOTH 'input' and 'change',
+      in that order (LOQ-17502). Both events are required, for different front ends:
+        - 'change' is what Luma checkout (Knockout's `value` binding), the customer address
+          book, multishipping and the admin Magento UI components listen for.
+        - 'input' is what Alpine's `x-model` needs, which is what Magewire generates from the
+          `wire:model.defer` bindings Hyva Checkout uses for its address fields. Alpine syncs a
+          text input on 'input' only; it uses 'change' only for select/checkbox/radio.
+      DO NOT drop either event when re-vendoring the SDK: losing 'change' breaks Luma and the
+      admin, losing 'input' breaks Hyva Checkout (populated values are reverted by the next
+      Magewire re-render). Other node types are untouched by this change.
   */
 
   /*! Copyright © 2009-2025 Postcode Anywhere (Holdings) Ltd. (http://www.postcodeanywhere.co.uk)
@@ -3192,6 +3204,23 @@
           (nodeName === "input" && type === "file") ||
           (nodeName === "input" && type === "text")
         ) {
+          // LOCAL CHANGE (LOQ-17502): a text input must emit BOTH `input` and
+          // `change`, in that order (native semantics: `input` while editing,
+          // `change` on commit). Alpine's `x-model` - which Magewire generates
+          // from the `wire:model.defer` bindings Hyva Checkout uses - only syncs
+          // a text input to component state on `input`, while Knockout's `value`
+          // binding (Luma checkout) and the admin Magento UI components only
+          // listen for `change`. Dispatching just one of the two breaks one of
+          // the two front ends. Only text inputs are widened here: `select`,
+          // `input[type=file]` and every other supported type keep their
+          // upstream behaviour.
+          if (nodeName === "input" && type === "text") {
+            // Dispatch input.
+            event = document.createEvent("HTMLEvents");
+            event.initEvent("input", true, false);
+            node.dispatchEvent(event);
+          }
+
           // IE9-IE11, non-IE
           // Dispatch change.
           event = document.createEvent("HTMLEvents");
@@ -7893,41 +7922,6 @@
     }
   }
 
-  /**
-   * Dispatch the event a populated field needs but the bundled SDK never sends.
-   *
-   * For a text input the SDK dispatches `change` and nothing else — its
-   * `reactTriggerChange` matches the `input[type=text]` branch, so the branch that
-   * would dispatch `input` is unreachable. For a `<select>` it dispatches nothing
-   * at all, because `pca.setValue` returns as soon as it has set `selectedIndex`.
-   *
-   * `change` is enough for the Luma checkout, where Knockout's `value` binding
-   * listens for it. It is not enough for Hyvä Checkout: its fields are Magewire
-   * `wire:model.defer`, which Magewire rewrites into an Alpine `x-model`, and
-   * Alpine listens for `input` on a text input — `change` only on a select,
-   * checkbox or radio. Without the `input` event Hyvä's component state never
-   * learns the field was filled in, so the next render morphs the stale empty
-   * value back into the DOM and the address the shopper picked disappears
-   * (LOQ-17502).
-   *
-   * Only the missing event is sent, so nothing the SDK already dispatches is
-   * duplicated: `input` for an input or textarea, `change` for anything else.
-   */
-  function dispatchPopulateEvents(element) {
-    if (!element) {
-      return;
-    }
-
-    if (element.tagName === "INPUT" || element.tagName === "TEXTAREA") {
-      element.dispatchEvent(
-        new Event("input", { bubbles: true, cancelable: false })
-      );
-      return;
-    }
-
-    dispatchChange(element);
-  }
-
   function mapRegionSelectValue(selectElement, details) {
     if (!selectElement || selectElement.tagName !== "SELECT" || !details) {
       return false;
@@ -8111,30 +8105,51 @@
         },
       });
 
-      const isRegionSelect = (field) =>
-        field.field === "ProvinceName" &&
-        field.element &&
-        field.element.tagName === "SELECT";
+      /**
+       * The region can be mapped to more than one element (Magento renders both a
+       * `region` text input and a `region_id` select), so every ProvinceName
+       * entry is kept and only the ones that resolve to a `<select>` are mapped.
+       *
+       * The names are kept as strings rather than the elements resolved at init:
+       * a `region_id` select is frequently rendered after this point - Magewire
+       * re-renders the Hyva Checkout address form, and Magento loads the region
+       * list on demand once a country is chosen - so an element snapshotted now
+       * would be null forever. It is resolved from the DOM on every populate
+       * instead.
+       *
+       * No `mode & pca.fieldMode.POPULATE` filter is needed: every ProvinceName
+       * entry in all three mappings (`default`, `billingFields`,
+       * `shippingFields`) already carries POPULATE, and `country_id` - the only
+       * non-POPULATE entry in any of them - is excluded structurally because its
+       * `field` is `CountryIso2`, not `ProvinceName`. Add the mode check here if
+       * a future mapping ever gains a ProvinceName entry without POPULATE, so it
+       * is not silently acted on.
+       */
+      const regionFieldNames = fieldMapping
+        .filter((field) => field.field === "ProvinceName")
+        .map((field) => field.element);
 
-      // Every field the SDK is allowed to write to. The country field is not one
-      // of them: pca.fieldMode.COUNTRY does not carry the POPULATE bit, so the
-      // country is filled in by the SDK's own country list, which already fires a
-      // native change event of its own.
-      const populatedFields = addressFieldsWithElements.filter(
-        (field) => field.element && (field.mode & pca.fieldMode.POPULATE) !== 0
-      );
+      if (regionFieldNames.length) {
+        control.listen("populate", function (details) {
+          regionFieldNames.forEach((name) => {
+            const element = getElementByName(name, context);
 
-      control.listen("populate", function (details) {
-        populatedFields.forEach((field) => {
-          if (isRegionSelect(field)) {
-            // Resolves the option to select and dispatches its own change event.
-            mapRegionSelectValueWithRetry(field.element, details);
-            return;
-          }
+            if (!element || element.tagName !== "SELECT") {
+              return;
+            }
 
-          dispatchPopulateEvents(field.element);
+            // `pca.setValue` returns as soon as it has set `selectedIndex` on a
+            // select, so it skips `pca.reactTriggerChange` and the select is
+            // updated without a single event being dispatched. It also only
+            // matches an option on its exact value or label, which misses the
+            // region codes Magento carries in data attributes. This resolves the
+            // option itself and dispatches the change event a select needs - the
+            // event Knockout, the admin UI components and Alpine's `x-model` all
+            // listen for on a select.
+            mapRegionSelectValueWithRetry(element, details);
+          });
         });
-      });
+      }
 
       pcaInstances[instanceKey] = { anchorElement, control };
     }

--- a/view/base/web/capture.js
+++ b/view/base/web/capture.js
@@ -7893,6 +7893,41 @@
     }
   }
 
+  /**
+   * Dispatch the event a populated field needs but the bundled SDK never sends.
+   *
+   * For a text input the SDK dispatches `change` and nothing else — its
+   * `reactTriggerChange` matches the `input[type=text]` branch, so the branch that
+   * would dispatch `input` is unreachable. For a `<select>` it dispatches nothing
+   * at all, because `pca.setValue` returns as soon as it has set `selectedIndex`.
+   *
+   * `change` is enough for the Luma checkout, where Knockout's `value` binding
+   * listens for it. It is not enough for Hyvä Checkout: its fields are Magewire
+   * `wire:model.defer`, which Magewire rewrites into an Alpine `x-model`, and
+   * Alpine listens for `input` on a text input — `change` only on a select,
+   * checkbox or radio. Without the `input` event Hyvä's component state never
+   * learns the field was filled in, so the next render morphs the stale empty
+   * value back into the DOM and the address the shopper picked disappears
+   * (LOQ-17502).
+   *
+   * Only the missing event is sent, so nothing the SDK already dispatches is
+   * duplicated: `input` for an input or textarea, `change` for anything else.
+   */
+  function dispatchPopulateEvents(element) {
+    if (!element) {
+      return;
+    }
+
+    if (element.tagName === "INPUT" || element.tagName === "TEXTAREA") {
+      element.dispatchEvent(
+        new Event("input", { bubbles: true, cancelable: false })
+      );
+      return;
+    }
+
+    dispatchChange(element);
+  }
+
   function mapRegionSelectValue(selectElement, details) {
     if (!selectElement || selectElement.tagName !== "SELECT" || !details) {
       return false;
@@ -8076,20 +8111,30 @@
         },
       });
 
-      const regionSelectFields = addressFieldsWithElements.filter(
-        (field) =>
-          field.field === "ProvinceName" &&
-          field.element &&
-          field.element.tagName === "SELECT"
+      const isRegionSelect = (field) =>
+        field.field === "ProvinceName" &&
+        field.element &&
+        field.element.tagName === "SELECT";
+
+      // Every field the SDK is allowed to write to. The country field is not one
+      // of them: pca.fieldMode.COUNTRY does not carry the POPULATE bit, so the
+      // country is filled in by the SDK's own country list, which already fires a
+      // native change event of its own.
+      const populatedFields = addressFieldsWithElements.filter(
+        (field) => field.element && (field.mode & pca.fieldMode.POPULATE) !== 0
       );
 
-      if (regionSelectFields.length) {
-        control.listen("populate", function (details) {
-          regionSelectFields.forEach((regionField) => {
-            mapRegionSelectValueWithRetry(regionField.element, details);
-          });
+      control.listen("populate", function (details) {
+        populatedFields.forEach((field) => {
+          if (isRegionSelect(field)) {
+            // Resolves the option to select and dispatches its own change event.
+            mapRegionSelectValueWithRetry(field.element, details);
+            return;
+          }
+
+          dispatchPopulateEvents(field.element);
         });
-      }
+      });
 
       pcaInstances[instanceKey] = { anchorElement, control };
     }


### PR DESCRIPTION
## LOQ-17502 — an address picked from the lookup empties itself again on Hyvä Checkout

Reported on Magento 2.4.8-p5 / PHP 8.4 with module 2.0.16. The shopper searches, picks a suggestion, watches city, postcode and region fill in, then loses them the moment focus moves to another field. The customer reproduced it on their own theme and on Hyvä's default theme, and could not reproduce it once the checkout was switched to Luma.

Every release up to and including v2.1.1 is affected — `git diff v2.0.16 master -- view/base/web/capture.js view/frontend/layout/ view/frontend/templates/` is empty, so **upgrading alone does not fix this.**

## Why

Hyvä Checkout's fields are Magewire `wire:model.defer`. Magewire rewrites that into an Alpine `x-model` with the `defer`/`lazy` modifiers stripped, and Alpine picks its listener as:

```js
el.tagName === "select" || ["checkbox","radio"].includes(el.type) || modifiers.includes("lazy") ? "change" : "input"
```

So a text input is synced to the component state on **`input` only**.

The bundled capture SDK dispatches `change` and nothing else for a text input. A local change to the vendored SDK — recorded in the file's own header as *"Updated event logic to init the 'change' event for text inputs"* — added `input[type=text]` to the first branch of `reactTriggerChange`, which makes the branch below it, the one that dispatches `input`, unreachable for exactly the fields this bug affects.

The result: Hyvä's component state never learns the field was filled in, and its next render morphs the stale empty value back over what the shopper could see. Luma is unaffected because Knockout's `value` binding listens for `change` — precisely what was being sent.

The street field appears to survive on both front ends, but only because the shopper typed into it and real `input` events had already fired. That asymmetry is the signature of this bug.

## The change

`dispatchPopulateEvents()` in the module's own wrapper dispatches, from the capture control's `populate` event, the one event the SDK omits — `input` for an input or textarea, `change` for anything else — for every field the SDK is allowed to write to. The filter is the same `mode & pca.fieldMode.POPULATE` test the SDK's own populate loop uses, so the two cannot drift. That hook was previously registered only when the region field happened to be a `<select>`.

Deliberately left alone:

- **country** — `pca.fieldMode.COUNTRY` does not carry the `POPULATE` bit; the country is filled in by the SDK's country list, which already fires a native `change` of its own.
- **the region `<select>`** — still handled by `mapRegionSelectValueWithRetry()`, which dispatches its own `change`.

No SDK internals were touched. Everything is inside the module's own wrapper section, so a future re-vendor of the SDK cannot silently drop the fix. Turning off `simulateReactEvents` and having the wrapper own all dispatch was considered and rejected: that flag also gates `change` on three unrelated call sites, so the blast radius is wider than the bug.

## Verification

No JS test runner exists in this repository, so this is a harness plus a manual pass. Both are committed under `Test/manual/`.

**1. Standalone Alpine harness** (`LOQ-17502-alpine-repro.html`) — real `x-model` bindings, no Magento or Hyvä needed. Reproduces the wipe on the SDK's current behaviour and shows it fixed with the added `input` event.

**2. The real `capture.js`, driven in a headless browser** against stubbed `find`/`retrieve` endpoints, with actual typing and an actual click on the suggestion. A/B against the unmodified file from `master`:

| | component state after picking the address | after a re-render |
|---|---|---|
| `master` | `street0` only — `city` and `postcode` missing | **`city` and `postcode` wiped** |
| this branch | `street0`, `city`, `postcode`, `region_id` | all values survive |

**3. Regression instrumentation** on the same run — each populated text field receives exactly **one** `input` and **one** `change` (no double-firing), and `pca.Address` is not re-constructed, so the `MutationObserver` is not looping.

## What still needs a human

The devcontainer cannot install Hyvä (needs private Hyvä GitLab credentials), so the Hyvä pass has to happen on staging or the customer's build. `Test/manual/LOQ-17502-manual-qa.md` has the steps, including confirming the placed order actually saves the populated address rather than just looking right in the DOM.

The Luma / admin / multishipping / address-book passes in that document are the regression surface — the same `capture.js` serves all of them. The change is additive and duplicates no existing event, but it has not been run inside Magento itself.

PHPUnit was not run: this branch touches no PHP, and the local environment is missing the `dom`, `mbstring` and `xmlwriter` extensions the suite requires.

`composer.json` is untouched — the version bump is an automated release commit.
